### PR TITLE
豆瓣想看-补全年份和类型信息，修复识别错误 https://github.com/jxxghp/MoviePilot/issues/1264

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "DoubanSync": {
         "name": "豆瓣想看",
         "description": "同步豆瓣想看数据，自动添加订阅。",
-        "version": "1.1",
+        "version": "1.2",
         "icon": "douban.png",
         "author": "jxxghp",
         "level": 2

--- a/plugins/doubansync/__init__.py
+++ b/plugins/doubansync/__init__.py
@@ -6,6 +6,7 @@ from typing import Optional, Any, List, Dict, Tuple
 import pytz
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
+from app.schemas.types import MediaType
 
 from app.chain.download import DownloadChain
 from app.chain.search import SearchChain
@@ -30,7 +31,7 @@ class DoubanSync(_PluginBase):
     # 插件图标
     plugin_icon = "douban.png"
     # 插件版本
-    plugin_version = "1.1"
+    plugin_version = "1.2"
     # 插件作者
     plugin_author = "jxxghp"
     # 作者主页
@@ -475,6 +476,9 @@ class DoubanSync(_PluginBase):
                         continue
                     # 识别媒体信息
                     meta = MetaInfo(title=title)
+                    douban_info = self.chain.douban_info(doubanid=douban_id)
+                    meta.year = douban_info.get("year")
+                    meta.type = MediaType.MOVIE if douban_info.get("type") == "movie" else MediaType.TV
                     mediainfo = self.chain.recognize_media(meta=meta, doubanid=douban_id)
                     if not mediainfo:
                         logger.warn(f'未识别到媒体信息，标题：{title}，豆瓣ID：{douban_id}')


### PR DESCRIPTION
测试结果

```
moviepilot  | INFO:    doubansync - 开始同步用户 xxx 的豆瓣想看数据 ...
moviepilot  | DEBUG:   connectionpool.py - Starting new HTTPS connection (1): www.douban.com:443
moviepilot  | DEBUG:   connectionpool.py - https://www.douban.com:443 "GET /feed/people/xxx/interests HTTP/1.1" 200 None
moviepilot  | INFO:    doubansync - 获取到用户 xxx 豆瓣RSS数据：10
moviepilot  | DEBUG:   chain - 请求模块执行：douban_info ...
moviepilot  | INFO:    douban - 开始获取豆瓣信息：25780594 ...
moviepilot  | DEBUG:   connectionpool.py - Starting new HTTPS connection (1): frodo.douban.com:443
moviepilot  | DEBUG:   connectionpool.py - https://frodo.douban.com:443 "GET /api/v2/movie/25780594?apiKey=0dad551ec0f84ed02907ff5c42e8ec70&os_rom=android&_ts=20231219&_sig=mZCKZXyOfaU%2BTP9XjAH4y4D8GZE%3D HTTP/1.1" 301 192
moviepilot  | DEBUG:   connectionpool.py - https://frodo.douban.com:443 "GET /api/v2/tv/25780594?apiKey=0dad551ec0f84ed02907ff5c42e8ec70&os_rom=android&_ts=20231219&_sig=mZCKZXyOfaU%2BTP9XjAH4y4D8GZE%3D HTTP/1.1" 400 129
moviepilot  | DEBUG:   connectionpool.py - https://frodo.douban.com:443 "GET /api/v2/tv/25780594?apiKey=0dad551ec0f84ed02907ff5c42e8ec70&os_rom=android&_ts=20231219&_sig=Q%2BfGgTHFZOulK3IyX6fZnW%2FWnlM%3D HTTP/1.1" 200 None
moviepilot  | DEBUG:   connectionpool.py - https://frodo.douban.com:443 "GET /api/v2/tv/25780594/celebrities?apiKey=0dad551ec0f84ed02907ff5c42e8ec70&os_rom=android&_ts=20231219&_sig=98Y%2F58dMSkyl%2F%2BZWl20VD2xCSd4%3D HTTP/1.1" 200 None
moviepilot  | DEBUG:   chain - 请求模块执行：recognize_media ...
moviepilot  | INFO:    themoviedb - 正在识别 渗透 ...
moviepilot  | DEBUG:   tmdbapi.py - 正在识别电视剧：渗透, 年份=2013 ...
moviepilot  | DEBUG:   connectionpool.py - Starting new HTTPS connection (1): api.themoviedb.org:443
moviepilot  | DEBUG:   connectionpool.py - https://api.themoviedb.org:443 "GET /3/search/tv?api_key=xxx&query=%E6%B8%97%E9%80%8F&page=1&first_air_date_year=2013&language=zh HTTP/1.1" 200 None
moviepilot  | DEBUG:   tmdbapi.py - API返回：1
moviepilot  | INFO:    tmdbapi.py - 正在查询TMDB电视剧：92307 ...
moviepilot  | DEBUG:   connectionpool.py - Starting new HTTPS connection (1): api.themoviedb.org:443
moviepilot  | DEBUG:   connectionpool.py - https://api.themoviedb.org:443 "GET /3/tv/92307?api_key=xxx&append_to_response=images,credits,alternative_titles,translations,external_ids&language=zh HTTP/1.1" 200 None
moviepilot  | INFO:    tmdbapi.py - 92307 查询结果：渗透
moviepilot  | INFO:    themoviedb - 渗透 TMDB识别结果：电视剧 渗透 (2013) 92307
moviepilot  | DEBUG:   connectionpool.py - https://api.themoviedb.org:443 "GET /3/tv/92307/episode_groups?api_key=xxx&&language=zh HTTP/1.1" 200 None
moviepilot  | DEBUG:   chain - 请求模块执行：media_exists ...
moviepilot  | INFO:    emby - 渗透 (2013) 在媒体库中不存在
moviepilot  | INFO:    doubansync - 渗透 (2013) 媒体库中不存在，开始搜索 ...
moviepilot  | INFO:    search.py - 开始搜索资源，关键词：渗透 ...
moviepilot  | WARNING: search.py - 未开启任何有效站点，无法搜索资源
moviepilot  | WARNING: search.py - 渗透 未搜索到资源
moviepilot  | WARNING: doubansync - 渗透 (2013) 未搜索到资源
moviepilot  | INFO:    subscribe.py - 开始添加订阅，标题：渗透 ...
moviepilot  | DEBUG:   chain - 请求模块执行：recognize_media ...
moviepilot  | INFO:    themoviedb - 渗透 使用TMDB识别缓存：渗透
moviepilot  | INFO:    tmdbapi.py - 正在查询TMDB电视剧：92307 ...
moviepilot  | INFO:    tmdbapi.py - 92307 查询结果：渗透
moviepilot  | INFO:    themoviedb - 渗透 TMDB识别结果：电视剧 渗透 (2013) 92307
moviepilot  | DEBUG:   chain - 请求模块执行：obtain_images ...
moviepilot  | INFO:    fanart - 渗透 (2013) 没有tvdbid，无法获取fanart图片
moviepilot  | INFO:    tmdbapi.py - 正在获取电视剧图片：92307...
moviepilot  | DEBUG:   connectionpool.py - https://api.themoviedb.org:443 "GET /3/tv/92307/images?api_key=xxx&&language=zh HTTP/1.1" 200 None
moviepilot  | INFO:    subscribe.py - 渗透 (2013) S01 添加订阅成功
```