### PR TITLE
Fix 自动删种任务错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "TorrentRemover": {
         "name": "自动删种",
         "description": "自动删除下载器中的下载任务。",
-        "version": "1.2",
+        "version": "1.2.1",
         "icon": "delete.jpg",
         "author": "jxxghp",
         "level": 2

--- a/plugins/torrentremover/__init__.py
+++ b/plugins/torrentremover/__init__.py
@@ -27,7 +27,7 @@ class TorrentRemover(_PluginBase):
     # 插件图标
     plugin_icon = "delete.jpg"
     # 插件版本
-    plugin_version = "1.2"
+    plugin_version = "1.2.1"
     # 插件作者
     plugin_author = "jxxghp"
     # 作者主页
@@ -767,7 +767,7 @@ class TorrentRemover(_PluginBase):
         else:
             tags = []
         if self._mponly:
-            tags.extend(settings.TORRENT_TAG)
+            tags.append(settings.TORRENT_TAG)
         # 查询种子
         torrents, error_flag = downloader_obj.get_torrents(tags=tags or None)
         if error_flag:


### PR DESCRIPTION
使用extend添加MP标签导致string被拆分为单个字母添加到tags中，导致无法正常使用。改为append。