### PR TITLE
支持MP离线下载种子后推送到QB

### DIFF
--- a/plugins/brushflow/__init__.py
+++ b/plugins/brushflow/__init__.py
@@ -1,5 +1,4 @@
 import re
-import requests
 import threading
 import time
 from datetime import datetime, timedelta
@@ -19,6 +18,7 @@ from app.modules.qbittorrent import Qbittorrent
 from app.modules.transmission import Transmission
 from app.plugins import _PluginBase
 from app.schemas import Notification, NotificationType, TorrentInfo
+from app.utils.http import RequestUtils
 from app.utils.string import StringUtils
 
 lock = threading.Lock()
@@ -1663,10 +1663,10 @@ class BrushFlow(_PluginBase):
             tag = StringUtils.generate_random_str(10)
             content = torrent.enclosure
             if self._offline_mode:
-                torrent_resp = requests.get(content,
-                                            headers={'User-Agent': torrent.site_ua.strip(), 'cookie': torrent.site_cookie.strip()})
-                if torrent_resp.ok:
-                    content = torrent_resp.content
+                torrent_res = RequestUtils(cookies=torrent.site_cookie,
+                                           ua=torrent.site_ua).get_res(url=content)
+                if torrent_res.ok:
+                    content = torrent_res.content
                 else:
                     logger.error('下载种子文件失败，继续提交种子链接进行下载')
             state = self.qb.add_torrent(content=content,

--- a/plugins/brushflow/__init__.py
+++ b/plugins/brushflow/__init__.py
@@ -32,7 +32,7 @@ class BrushFlow(_PluginBase):
     # 插件图标
     plugin_icon = "brush.jpg"
     # 插件版本
-    plugin_version = "1.3"
+    plugin_version = "1.4"
     # 插件作者
     plugin_author = "jxxghp"
     # 作者主页
@@ -1316,7 +1316,7 @@ class BrushFlow(_PluginBase):
             "dl_speed": self._dl_speed,
             "save_path": self._save_path,
             "clear_task": self._clear_task,
-            "offline_mode": self._offline_mode,
+            "offline_mode": self._offline_mode
         })
 
     def brush(self):

--- a/plugins/brushflow/__init__.py
+++ b/plugins/brushflow/__init__.py
@@ -1315,7 +1315,8 @@ class BrushFlow(_PluginBase):
             "up_speed": self._up_speed,
             "dl_speed": self._dl_speed,
             "save_path": self._save_path,
-            "clear_task": self._clear_task
+            "clear_task": self._clear_task,
+            "offline_mode": self._offline_mode,
         })
 
     def brush(self):


### PR DESCRIPTION
经排查发现 #83 的问题在于我的 qb 没有做代理 ，qbittorrent 无法访问 https://u2.dmhy.org 这个域名，下载 torrent 的时候就失败了。

尝试过在 qb 中使用 proxy 来下载种子和 general 信息，但这种做法也有问题
1. 大部分梯子都屏蔽了 IPv6 ，因此部分 IPv6 only 的 tracker 会无法解析域名
2. 部分 tracker 屏蔽了机场的 ip 
3. 会有多个 IP 的问题（部分 PT 站比较严格，会需要额外报备）

出于以上考虑，我选择了在刷流插件中直接下载 torrent 的字节流并推送到 qb 这个方案。
可行性在于：
1. 在 mp 中并没有大量的流量会产生，且因为需要刮削，我选择给 mp 上代理，qb 保持直连，这种情况下 torrent 文件就可以下载下来，并且 qb（包括代码和依赖）中也预留了直接上传 torrent bytes 的 API
2. 一些 PT 会主动将 torrent 中的连接地址改为最新的没有被 GFW 墙的网址

在这个层面上，#83 表述的问题即可被解决。改进之后刷流插件添加一个 选项
开启后即可自动推送 bytes 到 qb 

<img width="973" alt="image" src="https://github.com/jxxghp/MoviePilot-Plugins/assets/8235790/d38b6870-a384-4760-bcfc-38d5acbb1d82">
