### PR TITLE
fix 兼容问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -394,7 +394,7 @@
     "DiagParamAdjust": {
         "name": "诊断参数调整",
         "description": "Emby专用插件|暂时性解决emby字幕偏移问题，需要emby安装Diagnostics插件。",
-        "version": "1.2",
+        "version": "1.3",
         "icon": "Themeengine_A.png",
         "author": "jeblove",
         "level": 1


### PR DESCRIPTION
解决播放1080p视频时字幕依然被修改，将2160p与1080p视频分开识别。
插件执行改为由接收webhooks为主导，cron为辅。
取消原来的用户登录方式消息执行，主要利用播放消息识别文件名中的分辨率，随而是否执行”替换“操作。

![image](https://github.com/jxxghp/MoviePilot-Plugins/assets/17330034/27c55c84-59e2-49cb-92c0-4c5ced29d704)

![image](https://github.com/jxxghp/MoviePilot-Plugins/assets/17330034/68ceb0ae-f25a-4093-939e-4d17d604d768)

![image](https://github.com/jxxghp/MoviePilot-Plugins/assets/17330034/e867381a-b2fd-462a-a7e7-386cd8339654)
