### PR TITLE
青蛙辅种: 取消远程种子导出，避免不兼容低版本qb

### DIFF
--- a/plugins/crossseed/__init__.py
+++ b/plugins/crossseed/__init__.py
@@ -788,8 +788,9 @@ class CrossSeed(_PluginBase):
                 torrent_path = Path(self._torrentpaths[idx]) / f"{hash_str}.torrent"
                 torrent_info = None
                 if not torrent_path.exists():
-                    if downloader == "qbittorrent":
-                        # FIXME qb从4.4.0开始，种子文件以标题+序号的方式保存，目前只能尝试导出后再解析
+                    if False and downloader == "qbittorrent":
+                        # qb开启SQLite功能后将不再以hash命名的方式保存torrent文件
+                        # TODO 导出功能需要qb4.5.0以上版本才支持
                         logger.warn(f"QB种子文件不存在：{torrent_path} 尝试远程导出种子")
                         try:
                             torrent_data = torrent.export()


### PR DESCRIPTION
之前为了解决因开启QB的SQLite而导致找不到torrent文件的特例，我增加了种子导出功能作为备选应对。
但在低版本QB（<4.5.0）上会产生兼容问题（有反馈会导致mp重启）

为了兼容可能会增加额外的判断和界面开关，
这个我没精力去验证、优化老版QB，以及让TR下载器的行为一致，所以暂时取消导出功能

@lingjiameng 
