### PR TITLE
fix brushflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "BrushFlow": {
         "name": "站点刷流",
         "description": "自动托管刷流，将会提高对应站点的访问频率。",
-        "version": "2.5",
+        "version": "2.6",
         "icon": "brush.jpg",
         "author": "jxxghp,InfinityPacer",
         "level": 2

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "BrushFlow": {
         "name": "站点刷流",
         "description": "自动托管刷流，将会提高对应站点的访问频率。",
-        "version": "2.4",
+        "version": "2.5",
         "icon": "brush.jpg",
         "author": "jxxghp,InfinityPacer",
         "level": 2


### PR DESCRIPTION
- 进一步优化订阅排除匹配逻辑，从媒体库缓存中读取订阅别名作为标题，提高排除命中率
- 鉴于部分用户对刷流操作和对应的风险没有充分认知，插件配置中相关的提示置顶显示
- 增加H&R做种时间配置项，当配置了H&R做种时间/分享率时，则H&R种子只有达到预期行为时，才会进行删除，如果没有配置H&R做种时间/分享率，则普通种子的删除规则也适用于H&R种子
- 刷流前置条件调整，原有逻辑为保种体积 > 实际做种体积，则允许继续刷流，调整为保种体积 > (实际做种体积 + 种子大小下限) 时，才允许继续刷流，进一步降低刷流频率，如果没有配置种子大小，则与原有逻辑保持一致
- 鉴于部分用户无法理解代理下载种子的逻辑，默认关闭代理下载种子，如日志中出现下载种子失败的情况，可检查下载器网络能否正常访问站点或对代理下载种子有充分认知后开启选项