### PR TITLE
fix issue #191

### DIFF
--- a/package.json
+++ b/package.json
@@ -385,11 +385,12 @@
     "RemoveLink": {
         "name": "清理硬链接",
         "description": "监控目录内文件被删除时，同步删除监控目录内所有和它硬链接的文件",
-        "version": "1.6",
+        "version": "1.7",
         "icon": "Ombi_A.png",
         "author": "DzAvril",
         "level": 1,
         "history": {
+            "v1.7": "修复因未监测重命名事件导致的清理硬链接失败的问题",
             "v1.6": "提升插件性能"
         }
     },

--- a/plugins/removelink/__init__.py
+++ b/plugins/removelink/__init__.py
@@ -40,6 +40,22 @@ class FileMonitorHandler(FileSystemEventHandler):
         # 新增文件记录
         with state_lock:
             self.sync.state_set[str(file_path)] = file_path.stat().st_ino
+    
+    def on_moved(self, event):
+        if event.is_directory:
+            return
+        file_path = Path(event.dest_path)
+        if file_path.suffix in [".!qB", ".part", ".mp"]:
+            return
+        logger.info(f"监测到新增文件：{file_path}")
+        if self.sync.exclude_keywords:
+            for keyword in self.sync.exclude_keywords.split("\n"):
+                if keyword and keyword in str(file_path):
+                    logger.info(f"{file_path} 命中过滤关键字 {keyword}，不处理")
+                    return
+        # 新增文件记录
+        with state_lock:
+            self.sync.state_set[str(file_path)] = file_path.stat().st_ino
 
     def on_deleted(self, event):
         if event.is_directory:
@@ -90,7 +106,7 @@ class RemoveLink(_PluginBase):
     # 插件图标
     plugin_icon = "Ombi_A.png"
     # 插件版本
-    plugin_version = "1.6"
+    plugin_version = "1.7"
     # 插件作者
     plugin_author = "DzAvril"
     # 作者主页


### PR DESCRIPTION
修复问题 #191 
原因是插件过滤QB临时文件.!qB，而下载完成后执行的动作是重命名，插件未监测重命名事件导致没有将新增文件添加到监控列表中，从而删除硬链接失败。