### PR TITLE
fix 只会统计憨憨种子信息第一页的bug

### DIFF
--- a/plugins/sitestatistic/siteuserinfo/nexus_php.py
+++ b/plugins/sitestatistic/siteuserinfo/nexus_php.py
@@ -217,7 +217,7 @@ class NexusPhpSiteUserInfo(ISiteUserInfo):
 
         # 是否存在下页数据
         next_page = None
-        next_page_text = html.xpath('//a[contains(.//text(), "下一页") or contains(.//text(), "下一頁")]/@href')
+        next_page_text = html.xpath('//a[contains(.//text(), "下一页") or contains(.//text(), "下一頁") or contains(.//text(), ">")]/@href')
         if next_page_text:
             next_page = next_page_text[-1].strip()
             # fix up page url


### PR DESCRIPTION
憨憨的下一页是 ">"  而不是 下一页。 所以目前只会统计第一页的做种体积和数量。
![image](https://github.com/jxxghp/MoviePilot-Plugins/assets/9531643/53a1993b-7f8d-4f3f-92bd-39aee686a04a)
