### PR TITLE
Update cleaninvalidseed to v1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -702,11 +702,12 @@
         "name": "清理QB无效做种",
         "description": "清理已经被站点删除的种子及对应源文件，仅支持QB",
         "labels": "Qbittorrent",
-        "version": "1.5",
+        "version": "1.6",
         "icon": "clean_a.png",
         "author": "DzAvril",
         "level": 1,
         "history": {
+            "v1.6": "修复当种子有多个标签时，通过标签过滤不删除种子会失效的问题",
             "v1.5": "1. 增加通过分类、标签过滤不删除种子功能；2. 全量通知提供更多信息",
             "v1.4": "修复插件功能失效的问题",
             "v1.3": "1. 增加远程命令 2. 根据tracker error_message字段进行过滤,避免误删",

--- a/plugins/cleaninvalidseed/__init__.py
+++ b/plugins/cleaninvalidseed/__init__.py
@@ -28,7 +28,7 @@ class CleanInvalidSeed(_PluginBase):
     # 插件图标
     plugin_icon = "clean_a.png"
     # 插件版本
-    plugin_version = "1.5"
+    plugin_version = "1.6"
     # 插件作者
     plugin_author = "DzAvril"
     # 作者主页
@@ -307,7 +307,7 @@ class CleanInvalidSeed(_PluginBase):
                         if torrent.category in exclude_categories:
                             is_excluded = True
                             invalid_torrents_exclude_categories.append(torrent)
-                        torrent_labels = torrent.tags.split(",")
+                        torrent_labels = [tag.strip() for tag in torrent.tags.split(",")]
                         for label in torrent_labels:
                             if label in exclude_labels:
                                 is_excluded = True


### PR DESCRIPTION
修复当种子有多个标签时，通过标签过滤不删除种子会失效的问题