### PR TITLE
fix(dirmonitor): use global scrape setting as fallback

### DIFF
--- a/plugins/dirmonitor/__init__.py
+++ b/plugins/dirmonitor/__init__.py
@@ -120,7 +120,7 @@ class DirMonitor(_PluginBase):
             self._interval = config.get("interval") or 10
             self._cron = config.get("cron")
             self._size = config.get("size") or 0
-            self._scrape = config.get("scrape") or False
+            self._scrape = config.get("scrape", settings.SCRAP_METADATA)
 
         # 停止现有任务
         self.stop_service()


### PR DESCRIPTION
Do not break the experience for existing users https://github.com/jxxghp/MoviePilot/issues/2214

我的测试环境被我不小心删了，这个没有测试， plz test it before merge