### PR TITLE
feat: 支持刷新后触发插件事件

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
         "name": "站点数据统计",
         "description": "自动统计和展示站点数据。",
         "labels": "站点,仪表板",
-        "version": "3.5",
+        "version": "3.6",
         "icon": "statistic.png",
         "author": "lightolly",
         "level": 2,
         "history": {
+            "v3.6": "支持站点数据统计刷新后触发插件事件",
             "v3.5": "站点数据统计支持YemaPT",
             "v3.4": "修复馒头站点数据统计",
             "v3.3": "支持选择仪表板组件规格",

--- a/plugins/brushflow/__init__.py
+++ b/plugins/brushflow/__init__.py
@@ -320,11 +320,12 @@ class BrushFlow(_PluginBase):
         brush_config = self._brush_config
 
         # 这里先过滤掉已删除的站点并保存，特别注意的是，这里保留了界面选择站点时的顺序，以便后续站点随机刷流或顺序刷流
-        site_id_to_public_status = {site.get("id"): site.get("public") for site in self.siteshelper.get_indexers()}
-        brush_config.brushsites = [
-            site_id for site_id in brush_config.brushsites
-            if site_id in site_id_to_public_status and not site_id_to_public_status[site_id]
-        ]
+        if brush_config.brushsites:
+            site_id_to_public_status = {site.get("id"): site.get("public") for site in self.siteshelper.get_indexers()}
+            brush_config.brushsites = [
+                site_id for site_id in brush_config.brushsites
+                if site_id in site_id_to_public_status and not site_id_to_public_status[site_id]
+            ]
 
         self.__update_config()
 

--- a/plugins/sitestatistic/__init__.py
+++ b/plugins/sitestatistic/__init__.py
@@ -43,7 +43,7 @@ class SiteStatistic(_PluginBase):
     # 插件图标
     plugin_icon = "statistic.png"
     # 插件版本
-    plugin_version = "3.5"
+    plugin_version = "3.6"
     # 插件作者
     plugin_author = "lightolly"
     # 作者主页
@@ -1440,6 +1440,11 @@ class SiteStatistic(_PluginBase):
 
             # 更新时间
             self.save_data("last_update_time", today_date)
+
+            self.eventmanager.send_event(etype=EventType.PluginAction, data={
+                "action": "sitestatistic_refresh_complete"
+            })
+
             logger.info("站点数据刷新完成")
 
     def __custom_sites(self) -> List[Any]:


### PR DESCRIPTION
- 站点刷流兼容选择站点为空的场景
- 站点数据统计支持刷新后触发插件事件，用于联动其他插件同步数据