### PR TITLE
轮播图铺满全屏时，截取顶部部分

### DIFF
--- a/package.json
+++ b/package.json
@@ -724,7 +724,7 @@
         "name": "流行趋势轮播",
         "description": "在仪表板中显示流行趋势海报轮播图。",
         "labels": "仪表板",
-        "version": "1.0",
+        "version": "1.1",
         "icon": "TrendingShow.jpg",
         "author": "jxxghp",
         "level": 1

--- a/plugins/trendingshow/__init__.py
+++ b/plugins/trendingshow/__init__.py
@@ -12,7 +12,7 @@ class TrendingShow(_PluginBase):
     # 插件图标
     plugin_icon = "TrendingShow.jpg"
     # 插件版本
-    plugin_version = "1.0"
+    plugin_version = "1.1"
     # 插件作者
     plugin_author = "jxxghp"
     # 作者主页
@@ -191,7 +191,8 @@ class TrendingShow(_PluginBase):
                                     'component': 'VCarouselItem',
                                     'props': {
                                         'src': media.get_backdrop_image() if self._size == "mini" else media.backdrop_path,
-                                        'cover': True
+                                        'cover': True,
+                                        'position': 'top'
                                     },
                                     'content': [
                                         {


### PR DESCRIPTION
效果对比如下：
![image](https://github.com/jxxghp/MoviePilot-Plugins/assets/57806936/7fe96e63-37eb-4a0d-b1b0-d7d00e02b775)
![image](https://github.com/jxxghp/MoviePilot-Plugins/assets/57806936/bacb3a3c-f225-43df-a4f1-ef8dfb01b387)

老大，现有的组件大小一开始是为手机还是pc设计的？想把大尺寸和小尺寸屏幕的组件大小分开设置。