### PR TITLE
fix #241 莫妮卡Url转换失败

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,11 +273,12 @@
         "name": "IYUU自动辅种",
         "description": "基于IYUU官方Api实现自动辅种。",
         "labels": "做种,IYUU",
-        "version": "1.9.2",
+        "version": "1.9.3",
         "icon": "IYUU.png",
         "author": "jxxghp",
         "level": 2,
         "history": {
+            "v1.9.3": "修复Monika因缺少rsskey，种子下载失败的问题",
             "v1.9.2": "适配馒头使用API下载种子",
             "v1.9.1": "支持自定义辅种的种子分类",
             "v1.9": "支持自定义辅种后标签，支持将站点名作为标签",

--- a/plugins/iyuuautoseed/__init__.py
+++ b/plugins/iyuuautoseed/__init__.py
@@ -1040,6 +1040,12 @@ class IYUUAutoSeed(_PluginBase):
             判断是否为mteam站点
             """
             return True if "m-team." in url else False
+        
+        def __is_monika(url: str):
+            """
+            判断是否为monika站点
+            """
+            return True if "monikadesign." in url else False
 
         def __get_mteam_enclosure(tid: str, apikey: str):
             """
@@ -1068,6 +1074,19 @@ class IYUUAutoSeed(_PluginBase):
                 logger.warn(f"m-team 获取种子下载链接失败：{tid}")
                 return None
             return res.json().get("data")
+        
+        def __get_monika_torrent(tid: str, rssurl: str):
+            """
+            Monika下载需要使用rsskey从站点配置中获取并拼接下载链接
+            """
+            if not rssurl:
+                logger.error("Monika站点的rss链接未配置")
+                return None
+           
+            rss_match = re.search(r'/rss/\d+\.(\w+)', rssurl)
+            rsskey = rss_match.group(1)
+            download_url = f"{site.get('url')}torrents/download/{tid}.{rsskey}"
+            return download_url
 
         def __is_special_site(url: str):
             """
@@ -1090,6 +1109,9 @@ class IYUUAutoSeed(_PluginBase):
             if __is_mteam(site.get('url')):
                 # 调用mteam接口获取下载链接
                 return __get_mteam_enclosure(tid=seed.get("torrent_id"), apikey=site.get("apikey"))
+            if __is_monika(site.get('url')):
+                # 返回种子id和站点配置中所Monika的rss链接
+                return __get_monika_torrent(tid=seed.get("torrent_id"), rssurl=site.get("rss"))
             elif __is_special_site(site.get('url')):
                 # 从详情页面获取下载链接
                 return self.__get_torrent_url_from_page(seed=seed, site=site)


### PR DESCRIPTION
#241
因缺少rsskey下载链接，无法转换。且原代码通用处理逻辑，无法正常适配莫妮卡的base_url。于是重写了一段方法用以适配。
经测试可用。暂未发现bug，或与其他站点冲突。
```
【INFO】2024-07-09 18:21:37,424 - iyuuautoseed - 成功添加辅种下载，站点：莫妮卡，种子链接：https://monikadesign.uk/torrents/download/205.xxxxxxxxx?https=1
【INFO】2024-07-09 18:21:37,409 - iyuuautoseed - 23bcb61xxxxxxxxxxxxxxx 跳过校验，请自行检查...
【INFO】2024-07-09 18:21:31,770 - iyuuautoseed - 添加下载任务：https://monikadesign.uk/torrents/download/205.xxxxxx?https=1 ...
【DEBUG】2024-07-09 18:21:31,749 - torrent.py - 解析种子：[MonikaDesign][76]Ef:.A.Fairy.Tale.of.the.Two.S02.1080p.BluRay.x265.FLAC.2.0-AI-Raws.torrent
```