### PR TITLE
fix：修复海胆签到失败问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
         "name": "站点自动签到",
         "description": "自动模拟登录、签到站点。",
         "labels": "站点",
-        "version": "2.4",
+        "version": "2.4.1",
         "icon": "signin.png",
         "author": "thsrite",
         "level": 2,
         "history": {
+            "v2.4.1": "修复海胆签到失败问题",
             "v2.4": "适配m-team Api地址变化",
             "v2.3.2": "修复YemaPT登录失败，支持YemaPT自动签到",
             "v2.3.1": "修复签到报错问题",

--- a/plugins/autosignin/__init__.py
+++ b/plugins/autosignin/__init__.py
@@ -38,7 +38,7 @@ class AutoSignIn(_PluginBase):
     # 插件图标
     plugin_icon = "signin.png"
     # 插件版本
-    plugin_version = "2.4"
+    plugin_version = "2.4.1"
     # 插件作者
     plugin_author = "thsrite"
     # 作者主页

--- a/plugins/autosignin/sites/haidan.py
+++ b/plugins/autosignin/sites/haidan.py
@@ -39,7 +39,15 @@ class HaiDan(_ISiteSigninHandler):
         render = site_info.get("render")
 
         # 签到
-        html_text = self.get_page_source(url='https://www.haidan.video/signin.php',
+        # 签到页会重定向到index.php，由于302重定向特性，导致index.php没有携带cookie
+        self.get_page_source(url='https://www.haidan.video/signin.php',
+                                         cookie=site_cookie,
+                                         ua=ua,
+                                         proxy=proxy,
+                                         render=render)
+
+        # 重新携带cookie获取index.php查看签到结果
+        html_text = self.get_page_source(url='https://www.haidan.video/index.php',
                                          cookie=site_cookie,
                                          ua=ua,
                                          proxy=proxy,


### PR DESCRIPTION
修复海胆签到页重定向丢失cookie，导致的检测签到失败，实际签到成功的问题