### PR TITLE
fix：修复时区问题导致的上次同步后8h内的种子不同步的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -357,10 +357,13 @@
         "name": "下载器文件同步",
         "description": "同步下载器的文件信息到数据库，删除文件时联动删除下载任务。",
         "labels": "下载管理",
-        "version": "1.1",
+        "version": "1.1.1",
         "icon": "Youtube-dl_A.png",
         "author": "thsrite",
-        "level": 1
+        "level": 1,
+        "history": {
+            "v1.1.1": "修复时区问题导致的上次同步后8h内的种子不同步的问题"
+        }
     },
     "BrushFlow": {
         "name": "站点刷流",

--- a/plugins/syncdownloadfiles/__init__.py
+++ b/plugins/syncdownloadfiles/__init__.py
@@ -22,7 +22,7 @@ class SyncDownloadFiles(_PluginBase):
     # 插件图标
     plugin_icon = "Youtube-dl_A.png"
     # 插件版本
-    plugin_version = "1.1"
+    plugin_version = "1.1.1"
     # 插件作者
     plugin_author = "thsrite"
     # 作者主页
@@ -265,7 +265,7 @@ class SyncDownloadFiles(_PluginBase):
         if last_sync_time:
             # 获取种子时间
             if dl_tpe == "qbittorrent":
-                torrent_date = time.gmtime(torrent.get("added_on"))  # 将时间戳转换为时间元组
+                torrent_date = time.localtime(torrent.get("added_on"))  # 将时间戳转换为时间元组
                 torrent_date = time.strftime("%Y-%m-%d %H:%M:%S", torrent_date)  # 格式化时间
             else:
                 torrent_date = torrent.added_date


### PR DESCRIPTION
`time.gmtime(timestamp)`获取的是UTC时间，转为字符串后为时区0的时间
后面代码中与DB中的last_sync_time字符串（带有时区）比较`if last_sync_time > str(torrent_date):`
导致上次同步后8h内，下载器新增的种子都无法满足条件
改为`time.localtime(timestamp)`获取当地时间进行比较