### PR TITLE
将文件后缀名检查改为不区分大小写

### DIFF
--- a/plugins/dirmonitor/__init__.py
+++ b/plugins/dirmonitor/__init__.py
@@ -330,7 +330,7 @@ class DirMonitor(_PluginBase):
                             return
 
                 # 不是媒体文件不处理
-                if file_path.suffix not in settings.RMT_MEDIAEXT:
+                if file_path.suffix.casefold() not in map(str.casefold, settings.RMT_MEDIAEXT):
                     logger.debug(f"{event_path} 不是媒体文件")
                     return
 


### PR DESCRIPTION
修复有些大写后缀被排除的情况：
```
【DEBUG】2024-08-30 17:00:00,542 - dirmonitor - /mnt/MyPassport/downloads/电视剧/国外动漫/Mobile.Suit.Gundam.SEED.Destiny.01-50Fin.2004.BluRay.iPad.720p.AAC.x264/Mobile.Suit.Gundam.SEED.Destiny.2004.S01E42.BluRay.iPad.720p.AAC.x264.MP4 不是媒体文件
```