### PR TITLE
fix(BrushFlow): trigger plugin event with downloader

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -15,7 +15,7 @@
         "name": "站点刷流",
         "description": "自动托管刷流，将会提高对应站点的访问频率。",
         "labels": "刷流,仪表板",
-        "version": "3.9.1",
+        "version": "3.9.2",
         "icon": "brush.jpg",
         "author": "jxxghp,InfinityPacer",
         "level": 2,

--- a/plugins.v2/brushflow/__init__.py
+++ b/plugins.v2/brushflow/__init__.py
@@ -2034,10 +2034,12 @@ class BrushFlow(_PluginBase):
                 "time": time.time()
             }
 
-            self.eventmanager.send_event(etype=EventType.PluginAction, data={
-                "action": "brushflow_download_added",
+            self.eventmanager.send_event(etype=EventType.PluginTriggered, data={
+                "plugin_id": self.__class__.__name__,
+                "event_name": "brushflow_download_added",
                 "hash": hash_string,
-                "data": torrent_task
+                "data": torrent_task,
+                "downloader": self.service_info.name
             })
             torrent_tasks[hash_string] = torrent_task
 

--- a/plugins.v2/brushflow/__init__.py
+++ b/plugins.v2/brushflow/__init__.py
@@ -246,7 +246,7 @@ class BrushFlow(_PluginBase):
     # 插件图标
     plugin_icon = "brush.jpg"
     # 插件版本
-    plugin_version = "3.9.1"
+    plugin_version = "3.9.2"
     # 插件作者
     plugin_author = "jxxghp,InfinityPacer"
     # 作者主页


### PR DESCRIPTION
- 下载种子事件调整为 `PluginTriggered`，并支持事件信息中携带 `downloader`