### PR TITLE
简化输出日志，使用设置里的CC配置

### DIFF
--- a/package.json
+++ b/package.json
@@ -855,9 +855,12 @@
     "name": "修改企业微信可信IP",
     "description": "优先使用cookie，当填写两个第三方token时手机微信可以更新cookie。验证码以？结尾发给企业微信应用。如：110301？",
     "labels": "消息通知",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "icon": "Wecom_A.png",
     "author": "RamenRa",
-    "level": 2
+    "level": 2,
+    "history": {
+        "v1.1.3": "关闭cookie输入框，延长cookie任务成功时不输出日志，使用设定中的CookieCloud设置"
+        }
     }
 }

--- a/plugins/dynamicwechat/update_help.py
+++ b/plugins/dynamicwechat/update_help.py
@@ -1,62 +1,9 @@
-import base64
 import hashlib
 from typing import Dict, Any
 import json
 import requests
-from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.backends import default_backend
-from os import urandom
+from app.utils.common import encrypt
 
-BLOCK_SIZE = 16
-
-def pad(data: bytes) -> bytes:
-    padder = padding.PKCS7(algorithms.AES.block_size).padder()
-    padded_data = padder.update(data) + padder.finalize()
-    return padded_data
-
-def unpad(data: bytes) -> bytes:
-    unpadder = padding.PKCS7(algorithms.AES.block_size).unpadder()
-    unpadded_data = unpadder.update(data) + unpadder.finalize()
-    return unpadded_data
-
-def bytes_to_key(data: bytes, salt: bytes, output: int = 48) -> bytes:
-    assert len(salt) == 8, len(salt)
-    data += salt
-    key = hashlib.md5(data).digest()
-    final_key = key
-    while len(final_key) < output:
-        key = hashlib.md5(key + data).digest()
-        final_key += key
-    return final_key[:output]
-
-def encrypt(message: bytes, passphrase: bytes) -> bytes:
-    salt = urandom(8)
-    key_iv = bytes_to_key(passphrase, salt, 32 + 16)
-    key = key_iv[:32]
-    iv = key_iv[32:]
-
-    # Create AES cipher object
-    cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
-    encryptor = cipher.encryptor()
-
-    encrypted_message = encryptor.update(pad(message)) + encryptor.finalize()
-    return base64.b64encode(b"Salted__" + salt + encrypted_message)
-
-def decrypt(encrypted: bytes, passphrase: bytes) -> bytes:
-    encrypted = base64.b64decode(encrypted)
-    assert encrypted[0:8] == b"Salted__"
-    salt = encrypted[8:16]
-    key_iv = bytes_to_key(passphrase, salt, 32 + 16)
-    key = key_iv[:32]
-    iv = key_iv[32:]
-
-    # Create AES cipher object
-    cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
-    decryptor = cipher.decryptor()
-
-    decrypted_message = decryptor.update(encrypted[16:]) + decryptor.finalize()
-    return unpad(decrypted_message)
 
 class PyCookieCloud:
     def __init__(self, url: str, uuid: str, password: str):


### PR DESCRIPTION
1. 尝试使用‘设定’里的CookieCloud设置，可以使用自定义的CC
2. 无法使用的远程命令，但还是在函数结束时退出浏览器，防止日志报错

3. 关闭cookie输入框和修改插件配置界面文本
4. 使用内置的加密函数
5. 延长cookie任务成功时不输出日志
6. 调整验证码筛选条件