### PR TITLE
放弃self.post_message()的消息推送，还原成send_pushplus_message(),更新到1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -855,11 +855,12 @@
         "name": "修改企业微信可信IP",
         "description": "优先使用cookie，当填写两个第三方token时手机微信可以更新cookie。验证码以？结尾发给企业微信应用。如：110301？",
         "labels": "消息通知",
-        "version": "1.1.3",
+        "version": "1.1.4",
         "icon": "Wecom_A.png",
         "author": "RamenRa",
         "level": 2,
         "history": {
+            "v1.1.4": "放弃self.post_message()的消息推送，还原成send_pushplus_message()",
             "v1.1.3": "关闭cookie输入框，延长cookie任务成功时不输出日志，使用设定中的CookieCloud设置"
         }
     },


### PR DESCRIPTION
当公网IP变动时，触发推送二维码。此时企业微信已经无法发送二维码图片，因此不再使用插件通知的方式发送二维码