### PR TITLE
fix 6b0504d0

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,11 +301,12 @@
         "name": "IYUU自动辅种",
         "description": "基于IYUU官方Api实现自动辅种。",
         "labels": "做种,IYUU",
-        "version": "1.9.8",
+        "version": "1.9.9",
         "icon": "IYUU.png",
         "author": "jxxghp",
         "level": 2,
         "history": {
+            "v1.9.9": "修复qb辅种结束后自动开始暂停的种子",
             "v1.9.8": "辅种结束后，一起开始所有辅种后暂停的种子（排除了出错的种子）",
             "v1.9.7": "支持qbittorrent 5",
             "v1.9.6": "调整IYUU最新域名",

--- a/package.v2.json
+++ b/package.v2.json
@@ -204,11 +204,12 @@
         "name": "IYUU自动辅种",
         "description": "基于IYUU官方Api实现自动辅种。",
         "labels": "做种,IYUU",
-        "version": "2.4",
+        "version": "2.5",
         "icon": "IYUU.png",
         "author": "jxxghp",
         "level": 2,
         "history": {
+            "v2.5": "修复qb辅种结束后自动开始暂停的种子",
             "v2.4": "辅种结束后，一起开始所有辅种后暂停的种子（排除了出错的种子）",
             "v2.3": "支持qbittorrent 5",
             "v2.2": "修复种子校验服务未生效",

--- a/plugins.v2/iyuuautoseed/__init__.py
+++ b/plugins.v2/iyuuautoseed/__init__.py
@@ -33,7 +33,7 @@ class IYUUAutoSeed(_PluginBase):
     # 插件图标
     plugin_icon = "IYUU.png"
     # 插件版本
-    plugin_version = "2.4"
+    plugin_version = "2.5"
     # 插件作者
     plugin_author = "jxxghp"
     # 作者主页
@@ -649,7 +649,7 @@ class IYUUAutoSeed(_PluginBase):
             downloader_obj = service.instance
             # 只处理 qb
             if service.type == "qbittorrent":
-                paused_torrents, _ = downloader_obj.get_torrents(status=["paused"])
+                paused_torrents, _ = downloader_obj.get_torrents(status="paused")
                 # errored_torrents, _ = downloader_obj.get_torrents(status=["errored"])
                 pausedUP_torrent_hashs = []
                 for torrent in paused_torrents:

--- a/plugins/iyuuautoseed/__init__.py
+++ b/plugins/iyuuautoseed/__init__.py
@@ -34,7 +34,7 @@ class IYUUAutoSeed(_PluginBase):
     # 插件图标
     plugin_icon = "IYUU.png"
     # 插件版本
-    plugin_version = "1.9.8"
+    plugin_version = "1.9.9"
     # 插件作者
     plugin_author = "jxxghp"
     # 作者主页
@@ -638,7 +638,7 @@ class IYUUAutoSeed(_PluginBase):
             # 只处理 qb
             if downloader == "qbittorrent":
                 downloader_obj = self.__get_downloader(downloader)
-                paused_torrents, _ = downloader_obj.get_torrents(status=["paused"])
+                paused_torrents, _ = downloader_obj.get_torrents(status="paused")
                 # errored_torrents, _ = downloader_obj.get_torrents(status=["errored"])
                 pausedUP_torrent_hashs = []
                 for torrent in paused_torrents:


### PR DESCRIPTION
qbittorrent.py - 获取种子列表出错：unhashable type: 'list'
修改后
![image](https://github.com/user-attachments/assets/32901514-8517-49b2-837b-5373e0ea6c00)
