### PR TITLE
fix:未配置主辅分离时辅种未自动开始的问题

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -213,11 +213,12 @@
         "name": "IYUU自动辅种",
         "description": "基于IYUU官方Api实现自动辅种。",
         "labels": "做种,IYUU",
-        "version": "2.7",
+        "version": "2.8",
         "icon": "IYUU.png",
         "author": "jxxghp,ckun",
         "level": 2,
         "history": {
+            "v2.8": "为配置主辅分离时，不走辅种下载器检查",
             "v2.7": "增加主辅分离配置，单独指定辅种下载器",
             "v2.6": "优化执行周期输入，需要MoviePilot v2.2.1+",
             "v2.5": "修复qb辅种结束后自动开始暂停的种子",

--- a/plugins.v2/iyuuautoseed/__init__.py
+++ b/plugins.v2/iyuuautoseed/__init__.py
@@ -33,7 +33,7 @@ class IYUUAutoSeed(_PluginBase):
     # 插件图标
     plugin_icon = "IYUU.png"
     # 插件版本
-    plugin_version = "2.7"
+    plugin_version = "2.8"
     # 插件作者
     plugin_author = "jxxghp,ckun"
     # 作者主页
@@ -191,7 +191,7 @@ class IYUUAutoSeed(_PluginBase):
         服务信息
         """
         if not self._auto_downloader:
-            logger.warning("尚未配置主辅分离下载器，请检查配置")
+            logger.info("尚未配置主辅分离下载器，辅种不分离")
             return None
 
         service = self.downloader_helper.get_service(name=self._auto_downloader)
@@ -688,7 +688,7 @@ class IYUUAutoSeed(_PluginBase):
             else:
                 logger.info(f"没有需要辅种的种子")
         # 指定主辅分离时只检查辅种下载器
-        if not self.auto_service_info:
+        if self.auto_service_info:
             self.start_service_torrents(self.auto_service_info)
         else:
             # qb 中，辅种结束后，一起开始所有辅种后暂停的种子（排除了出错的种子），及时人工确认也是手动开始这部分种子
@@ -739,7 +739,7 @@ class IYUUAutoSeed(_PluginBase):
         if self._is_recheck_running:
             return
         self._is_recheck_running = True
-        if not self.auto_service_info:
+        if self.auto_service_info:
             # 检查指定下载器
             self.check_recheck_service(self.auto_service_info)
             self._is_recheck_running = False


### PR DESCRIPTION
不想使用主从分离，查询后报错：
【WARNING】2025-01-14 00:23:53,717 - iyuuautoseed - 尚未配置主辅分离下载器，请检查配置
【WARNING】2025-01-14 00:23:53,716 - iyuuautoseed - 尚未配置主辅分离下载器，请检查配置

添加的辅种任务不会自动开始，一直处于暂停状态