### PR TITLE
Revert 辅种结束后，一起开始所有辅种后暂停的种子（排除了出错的种子）

### DIFF
--- a/package.json
+++ b/package.json
@@ -299,11 +299,12 @@
         "name": "IYUU自动辅种",
         "description": "基于IYUU官方Api实现自动辅种。",
         "labels": "做种,IYUU",
-        "version": "1.9.9",
+        "version": "1.9.10",
         "icon": "IYUU.png",
         "author": "jxxghp",
         "level": 2,
         "history": {
+            "v1.9.10": "Revert 辅种结束后，一起开始所有辅种后暂停的种子（排除了出错的种子）",
             "v1.9.9": "修复qb辅种结束后自动开始暂停的种子",
             "v1.9.8": "辅种结束后，一起开始所有辅种后暂停的种子（排除了出错的种子）",
             "v1.9.7": "支持qbittorrent 5",

--- a/package.v2.json
+++ b/package.v2.json
@@ -217,7 +217,7 @@
         "name": "IYUU自动辅种",
         "description": "基于IYUU官方Api实现自动辅种。",
         "labels": "做种,IYUU",
-        "version": "2.9",
+        "version": "2.10",
         "icon": "IYUU.png",
         "author": "jxxghp,ckun",
         "level": 2,

--- a/plugins.v2/iyuuautoseed/__init__.py
+++ b/plugins.v2/iyuuautoseed/__init__.py
@@ -33,7 +33,7 @@ class IYUUAutoSeed(_PluginBase):
     # 插件图标
     plugin_icon = "IYUU.png"
     # 插件版本
-    plugin_version = "2.9"
+    plugin_version = "2.10"
     # 插件作者
     plugin_author = "jxxghp,ckun"
     # 作者主页
@@ -687,13 +687,7 @@ class IYUUAutoSeed(_PluginBase):
                 self.check_recheck()
             else:
                 logger.info(f"没有需要辅种的种子")
-        # 指定主辅分离时只检查辅种下载器
-        if self.auto_service_info:
-            self.start_service_torrents(self.auto_service_info)
-        else:
-            # qb 中，辅种结束后，一起开始所有辅种后暂停的种子（排除了出错的种子），及时人工确认也是手动开始这部分种子
-            for service in self.service_infos.values():
-                self.start_service_torrents(service)
+
         # 保存缓存
         self.__update_config()
         # 发送消息
@@ -710,25 +704,6 @@ class IYUUAutoSeed(_PluginBase):
                          f"{self.cached} 条失败记录已加入缓存"
                 )
         logger.info("辅种任务执行完成")
-
-    def start_service_torrents(self, service: ServiceInfo):
-        """
-        指定下载器开始种子
-        """
-        downloader = service.name
-        downloader_obj = service.instance
-        # 只处理 qb
-        if service.type == "qbittorrent":
-            paused_torrents, _ = downloader_obj.get_torrents(status="paused")
-            # errored_torrents, _ = downloader_obj.get_torrents(status=["errored"])
-            pausedUP_torrent_hashs = []
-            for torrent in paused_torrents:
-                if torrent.state in ['pausedUP', 'stoppedUP']:
-                    pausedUP_torrent_hashs.append(torrent.hash)
-                    logger.info(f"下载器 {downloader} 自动开始种子 {torrent.name}")
-                else:
-                    logger.info(f"下载器 {downloader} 不自动开始种子 {torrent.name}, state={torrent.state}")
-            downloader_obj.start_torrents(ids=pausedUP_torrent_hashs)
 
     def check_recheck(self):
         """

--- a/plugins/iyuuautoseed/__init__.py
+++ b/plugins/iyuuautoseed/__init__.py
@@ -34,7 +34,7 @@ class IYUUAutoSeed(_PluginBase):
     # 插件图标
     plugin_icon = "IYUU.png"
     # 插件版本
-    plugin_version = "1.9.9"
+    plugin_version = "1.9.10"
     # 插件作者
     plugin_author = "jxxghp"
     # 作者主页
@@ -633,21 +633,7 @@ class IYUUAutoSeed(_PluginBase):
                 self.check_recheck()
             else:
                 logger.info(f"没有需要辅种的种子")
-        # qb 中，辅种结束后，一起开始所有辅种后暂停的种子（排除了出错的种子），及时人工确认也是手动开始这部分种子
-        for downloader in self._downloaders:
-            # 只处理 qb
-            if downloader == "qbittorrent":
-                downloader_obj = self.__get_downloader(downloader)
-                paused_torrents, _ = downloader_obj.get_torrents(status="paused")
-                # errored_torrents, _ = downloader_obj.get_torrents(status=["errored"])
-                pausedUP_torrent_hashs = []
-                for torrent in paused_torrents:
-                    if torrent.state in ['pausedUP', 'stoppedUP']:
-                        pausedUP_torrent_hashs.append(torrent.hash)
-                        logger.info(f"下载器 {downloader} 自动开始种子 {torrent.name}")
-                    else:
-                        logger.info(f"下载器 {downloader} 不自动开始种子 {torrent.name}, state={torrent.state}")
-                downloader_obj.start_torrents(ids=pausedUP_torrent_hashs)
+
         # 保存缓存
         self.__update_config()
         # 发送消息


### PR DESCRIPTION
fix #513 #630

1. 没考虑到会直接把所有已暂停种子重新开始，即使不是辅出来的种子
2. 没考虑到会把 qB 跳检的种子自动开始，即使不直接报错，也需要人工确认