### PR TITLE
更新 BarkMsg 插件版本至 1.3-1，修复批量推送时 device_keys 使用问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -491,12 +491,13 @@
         "name": "Bark消息推送",
         "description": "支持使用Bark发送消息通知。",
         "labels": "消息通知",
-        "version": "1.3",
+        "version": "1.3-1",
         "icon": "Bark_A.png",
         "author": "jxxghp",
         "level": 1,
         "v2": true,
         "history": {
+            "v1.3-1": "修使用post方式发送消息时无法使用device_keys用于批量推送",
             "v1.3": "将标题、推送内容放入请求体中，避免编码后 URI 过长导致无法推送",
             "v1.2": "支持多人消息发送"
         }

--- a/plugins/barkmsg/__init__.py
+++ b/plugins/barkmsg/__init__.py
@@ -16,7 +16,7 @@ class BarkMsg(_PluginBase):
     # 插件图标
     plugin_icon = "Bark_A.png"
     # 插件版本
-    plugin_version = "1.3"
+    plugin_version = "1.3-1"
     # 插件作者
     plugin_author = "jxxghp"
     # 作者主页
@@ -221,21 +221,25 @@ class BarkMsg(_PluginBase):
             req_body.update({
                 "title": title,
                 "body": text,
-                "device_keys": self._apikey.split(),
             })
-            res = RequestUtils().post_res(f"{self._server}/push", json=req_body)
-            if res and res.status_code == 200:
-                ret_json = res.json()
-                code = ret_json['code']
-                message = ret_json['message']
-                if code == 200:
-                    logger.info(f"Bark消息发送成功")
+            for apikey in self._apikey.split():
+                req_body.update({
+                    "device_key": apikey,
+                })
+                self._send(req_body)
+                res = RequestUtils().post_res(f"{self._server}/push", json=req_body)
+                if res and res.status_code == 200:
+                    ret_json = res.json()
+                    code = ret_json['code']
+                    message = ret_json['message']
+                    if code == 200:
+                        logger.info(f"{apikey} Bark消息发送成功")
+                    else:
+                        logger.warn(f"{apikey} Bark消息发送失败：{message}")
+                elif res is not None:
+                    logger.warn(f"{apikey} Bark消息发送失败，错误码：{res.status_code}，错误原因：{res.reason}")
                 else:
-                    logger.warn(f"Bark消息发送失败：{message}")
-            elif res is not None:
-                logger.warn(f"Bark消息发送失败，错误码：{res.status_code}，错误原因：{res.reason}")
-            else:
-                logger.warn(f"Bark消息发送失败：未获取到返回信息")
+                    logger.warn(f"{apikey} Bark消息发送失败：未获取到返回信息")
         except Exception as msg_e:
             logger.error(f"Bark消息发送失败：{str(msg_e)}")
 


### PR DESCRIPTION
[Bark文档](https://bark.day.app/#/tutorial?id=%e8%af%b7%e6%b1%82%e5%8f%82%e6%95%b0)有说明使用device_keys进行批量推送，但实测官方服务器的api接口不支持，暂且先单独进行推送