### PR TITLE
fix workwechatmsg content-type

### DIFF
--- a/plugins/workwechatmsg/__init__.py
+++ b/plugins/workwechatmsg/__init__.py
@@ -196,7 +196,7 @@ class WorkWechatMsg(_PluginBase):
                     }
                 }
 
-            res = RequestUtils().post_res(url=self._webhookurl, json=payload)
+            res = RequestUtils(content_type="application/json").post_res(url=self._webhookurl, json=payload)
             if res and res.status_code == 200:
                 ret_json = res.json()
                 errno = ret_json.get('errcode')


### PR DESCRIPTION
已有版本发送消息时，日志输出：

【WARNING】2025-06-12 08:10:00,330 - log.py - 企业微信机器人消息发送失败，错误码：415，错误原因：

目前是调用 from app.utils.http import RequestUtils
默认值为：
```
if not content_type:
    content_type = "application/x-www-form-urlencoded; charset=UTF-8"
```

根据官方文档，指定content-type为application/json