### PR TITLE
【豆瓣榜单订阅】对于MediaType.UNKNOWN的处理；豆瓣id识别兼容最后斜杠缺失

### DIFF
--- a/plugins.v2/doubanrank/__init__.py
+++ b/plugins.v2/doubanrank/__init__.py
@@ -30,7 +30,7 @@ class DoubanRank(_PluginBase):
     # 插件图标
     plugin_icon = "movie.jpg"
     # 插件版本
-    plugin_version = "2.0.0"
+    plugin_version = "2.0.1"
     # 插件作者
     plugin_author = "jxxghp"
     # 作者主页
@@ -564,6 +564,8 @@ class DoubanRank(_PluginBase):
                     meta.year = year
                     if mtype:
                         meta.type = mtype
+                    if meta.type not in (MediaType.MOVIE, MediaType.TV):
+                        meta.type = None
                     # 识别媒体信息
                     if douban_id:
                         # 识别豆瓣信息
@@ -573,6 +575,7 @@ class DoubanRank(_PluginBase):
                                 logger.warn(
                                     f'未能通过豆瓣ID {douban_id} 获取到TMDB信息，标题：{title}，豆瓣ID：{douban_id}')
                                 continue
+                            meta.type = tmdbinfo.get('media_type')
                             mediainfo = self.chain.recognize_media(meta=meta, tmdbid=tmdbinfo.get("id"))
                             if not mediainfo:
                                 logger.warn(f'TMDBID {tmdbinfo.get("id")} 未识别到媒体信息')
@@ -665,7 +668,7 @@ class DoubanRank(_PluginBase):
                     rss_info['title'] = title
                     rss_info['link'] = link
 
-                    doubanid = re.findall(r"/(\d+)/", link)
+                    doubanid = re.findall(r"/(\d+)(?=/|$)", link)
                     if doubanid:
                         doubanid = doubanid[0]
                     if doubanid and not str(doubanid).isdigit():


### PR DESCRIPTION
豆瓣榜单订阅目前的体验有些问题。
- MediaType.UNKNOWN被作为mtype参数一路透传，并在https://github.com/jxxghp/MoviePilot/blob/682f4fe608f362f4d9919a11816d04178c6f4fd5/app/chain/media.py#L238
处作为mtype获取tmdb信息，从而对于剧集失败。预期应该是None，从而在这一行不会使用参数传入的mtype，转而使用meta.type。测试用例rss：https://rsshub.email-once.com/douban/list/tv_chinese_best_weekly
![image](https://github.com/user-attachments/assets/e78ef873-2f95-4236-8b4b-97f58b7f5d62)
- 同时与上一点相关的，在按照doubanid匹配到tmdb后，由于meta传参中meta.type是Media.UNKNONW，在recognize_media中会分别查询电影/剧集两个类型，会有较多错误信息出现：”tmdbapi.py - The resource you requested could not be found."。因此使用tmdbinfo中的media_type代替。测试用例rss：https://rsshub.email-once.com/douban/list/movie_weekly_best
![image](https://github.com/user-attachments/assets/d71a259c-c5b9-47bf-b52f-3324d5ea27ef)
- 对于豆瓣id，目前匹配要求在两个'/'之间，但存在情况豆瓣id处于末尾，这种case会无法匹配到豆瓣id，降低识别准确度。测试用例rss：https://rsshub.email-once.com/douban/list/tv_real_time_hotest
![image](https://github.com/user-attachments/assets/11004af3-4490-4f4a-8f6d-46ab0baa627b)
