### PR TITLE
钉钉机器人换行优化

### DIFF
--- a/package.json
+++ b/package.json
@@ -943,11 +943,14 @@
     "name": "钉钉机器人",
     "description": "支持使用钉钉机器人发送消息通知。",
     "labels": "消息通知,钉钉机器人",
-    "version": "1.12",
+    "version": "1.13",
     "icon": "Dingding_A.png",
     "author": "nnlegenda",
     "level": 1,
-    "v2": true
+    "v2": true,
+    "history": {
+      "v1.13": "优化钉钉消息换行"
+    }
   },
   "DynamicWeChat": {
     "name": "动态企微可信IP",

--- a/plugins/dingdingmsg/__init__.py
+++ b/plugins/dingdingmsg/__init__.py
@@ -209,6 +209,8 @@ class DingdingMsg(_PluginBase):
             if text:
                 # 对text进行Markdown特殊字符转义
                 text = re.sub(r"([_`])", r"\\\1", text)
+                # 钉钉中需要在换行前有两个空格，才能够正常换行
+                text = re.sub(r"\n", r"  \n", text)
             else:
                 text = ""
 

--- a/plugins/dingdingmsg/__init__.py
+++ b/plugins/dingdingmsg/__init__.py
@@ -21,7 +21,7 @@ class DingdingMsg(_PluginBase):
     # 插件图标
     plugin_icon = "Dingding_A.png"
     # 插件版本
-    plugin_version = "1.12"
+    plugin_version = "1.13"
     # 插件作者
     plugin_author = "nnlegenda"
     # 作者主页


### PR DESCRIPTION
钉钉机器人消息中，需要在换行符前添加两个空格才能换行，对此替换原消息换行符进行优化。即使该优化没有作用，在换行前添加空格也不会影响消息展示。