### PR TITLE
Update openai library for chatgpt plugin

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -103,11 +103,12 @@
     "name": "ChatGPT",
     "description": "消息交互支持与ChatGPT对话。",
     "labels": "消息通知,识别",
-    "version": "2.1.7",
+    "version": "2.1.8",
     "icon": "Chatgpt_A.png",
     "author": "jxxghp",
     "level": 1,
     "history": {
+      "v2.1.8": "修复 OpenAI API >=1.0.0 兼容性问题",
       "v2.1.7":"独立安装OpenAi SDK依赖",
       "v2.1.6": "支持自定义辅助识别提示词",
       "v2.1.5": "兼容一些模型返回json数据信息用markdown语法包裹的情况",


### PR DESCRIPTION
Update ChatGPT plugins to be compatible with OpenAI API >=1.0.0.

This PR fixes the `openai.ChatCompletion` not supported error by migrating API calls to use the `openai.OpenAI()` client instance and `client.chat.completions.create()`, updating exception handling, and configuring proxies via `httpx.Client`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc0b99f0-c3aa-4e8a-84a9-8c6e583c3022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc0b99f0-c3aa-4e8a-84a9-8c6e583c3022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

