### PR TITLE
修复标题或内容为空时，消息推送失败的问题。

### DIFF
--- a/package.json
+++ b/package.json
@@ -810,14 +810,15 @@
     "name": "ntfy消息推送",
     "description": "支持使用ntfy发送消息通知。",
     "labels": "消息通知",
-    "version": "1.2",
+    "version": "1.3",
     "icon": "Ntfy_A.png",
     "author": "lethargicScribe",
     "level": 1,
     "v2": true,
     "history": {
       "v1.1": "添加Token认证和用户动作",
-      "v1.2": "修复 ntfy 通知图标链接失效的问题"
+      "v1.2": "修复 ntfy 通知图标链接失效的问题",
+      "v1.3": "修复标题或文本为空时，通知发送失败的问题"
     }
   },
   "GotifyMsg": {

--- a/plugins/ntfymsg/__init__.py
+++ b/plugins/ntfymsg/__init__.py
@@ -62,7 +62,7 @@ class NtfyMsg(_PluginBase):
     # 插件图标
     plugin_icon = "Ntfy_A.png"
     # 插件版本
-    plugin_version = "1.2"
+    plugin_version = "1.3"
     # 插件作者
     plugin_author = "lethargicScribe"
     # 作者主页


### PR DESCRIPTION
当标题或内容都为空时，使用空字符 “\u200b”填充。以避免报错和 ntfy 自动生成 “triggered” 文本。