### PR TITLE
fix(MoviePilotUpdateNotify): 修复版本描述为空时的报错

### DIFF
--- a/plugins.v2/moviepilotupdatenotify/__init__.py
+++ b/plugins.v2/moviepilotupdatenotify/__init__.py
@@ -23,7 +23,7 @@ class MoviePilotUpdateNotify(_PluginBase):
     # 插件图标
     plugin_icon = "Moviepilot_A.png"
     # 插件版本
-    plugin_version = "2.2"
+    plugin_version = "2.3"
     # 插件作者
     plugin_author = "thsrite"
     # 作者主页
@@ -171,7 +171,7 @@ class MoviePilotUpdateNotify(_PluginBase):
         """
         result = self.__get_latest_version("https://api.github.com/repos/jxxghp/MoviePilot/releases")
         if result:
-            return result['tag_name'], result['body'], result['published_at']
+            return result['tag_name'], f"{result['body'] or ''}", result['published_at']
         return None, None, None
 
     def __get_front_latest(self):
@@ -180,7 +180,7 @@ class MoviePilotUpdateNotify(_PluginBase):
         """
         result = self.__get_latest_version("https://api.github.com/repos/jxxghp/MoviePilot-Frontend/releases")
         if result:
-            return result['tag_name'], result['body'], result['published_at']
+            return result['tag_name'], f"{result['body'] or ''}", result['published_at']
         return None, None, None
 
     def get_state(self) -> bool:

--- a/plugins/moviepilotupdatenotify/__init__.py
+++ b/plugins/moviepilotupdatenotify/__init__.py
@@ -22,7 +22,7 @@ class MoviePilotUpdateNotify(_PluginBase):
     # 插件图标
     plugin_icon = "Moviepilot_A.png"
     # 插件版本
-    plugin_version = "1.4"
+    plugin_version = "1.5"
     # 插件作者
     plugin_author = "thsrite"
     # 作者主页
@@ -151,7 +151,7 @@ class MoviePilotUpdateNotify(_PluginBase):
         if version_res:
             ver_json = version_res.json()
             version = f"{ver_json['tag_name']}"
-            description = f"{ver_json['body']}"
+            description = f"{ver_json['body'] or ''}"
             update_time = f"{ver_json['published_at']}"
             return version, description, update_time
         else:
@@ -167,7 +167,7 @@ class MoviePilotUpdateNotify(_PluginBase):
         if version_res:
             ver_json = version_res.json()
             version = f"{ver_json['tag_name']}"
-            description = f"{ver_json['body']}"
+            description = f"{ver_json['body'] or ''}"
             update_time = f"{ver_json['published_at']}"
             return version, description, update_time
         else:


### PR DESCRIPTION
现在 github release 的 api，在版本描述为空的时候，body 返回的是 null 不是空字符串，获取前端版本时 description 会是 none  ，会稳定的报错导致无法自动更新

```
AttributeError: 'NoneType' object has no attribute 'startswith'
           ^^^^^^^^^^^^^^^^^^^^^^
    if not description.startswith(release_version):
  File "/app/app/plugins/moviepilotupdatenotify/__init__.py", line 138, in __notify_update
    self.__notify_update(update_time=update_time,
  File "/app/app/plugins/moviepilotupdatenotify/__init__.py", line 118, in __check_front_update
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    front_update = self.__check_front_update() if self._update_types and "前端" in self._update_types else False
  File "/app/app/plugins/moviepilotupdatenotify/__init__.py", line 68, in __check_update
    job["func"](*args, **kwargs)
  File "/app/app/scheduler.py", line 503, in start
【ERROR】2026-01-05 09:00:01,903 - scheduler.py - 定时任务 MoviePilot更新检查服务 执行失败：'NoneType' object has no attribute 'startswith' - Traceback (most recent call last):
```