### PR TITLE
fix: relax lark-oapi constraint to avoid MoviePilot environment conflicts

### DIFF
--- a/plugins.v2/agentresourceofficer/feishu_channel.py
+++ b/plugins.v2/agentresourceofficer/feishu_channel.py
@@ -33,7 +33,7 @@ except Exception:
 
 _LARK_IMPORT_LOCK = threading.Lock()
 _LARK_AUTO_INSTALL_ATTEMPTED = False
-_LARK_PACKAGE_SPEC = "lark-oapi==1.5.3"
+_LARK_PACKAGE_SPEC = "lark-oapi>=1.4.0"
 
 try:
     from app.chain.download import DownloadChain

--- a/plugins.v2/agentresourceofficer/requirements.txt
+++ b/plugins.v2/agentresourceofficer/requirements.txt
@@ -1,4 +1,4 @@
 requests
 cloudscraper
-lark-oapi==1.5.3
+lark-oapi>=1.4.0
 p115client==0.0.8.4.8

--- a/plugins.v2/feishucommandbridgelong/README.md
+++ b/plugins.v2/feishucommandbridgelong/README.md
@@ -105,5 +105,5 @@ POST /api/v1/plugin/FeishuCommandBridgeLong/assistant/pick
 ## 依赖
 
 ```txt
-lark-oapi==1.5.3
+lark-oapi>=1.4.0
 ```

--- a/plugins.v2/feishucommandbridgelong/requirements.txt
+++ b/plugins.v2/feishucommandbridgelong/requirements.txt
@@ -1,1 +1,1 @@
-lark-oapi==1.5.3
+lark-oapi>=1.4.0

--- a/plugins/agentresourceofficer/feishu_channel.py
+++ b/plugins/agentresourceofficer/feishu_channel.py
@@ -33,7 +33,7 @@ except Exception:
 
 _LARK_IMPORT_LOCK = threading.Lock()
 _LARK_AUTO_INSTALL_ATTEMPTED = False
-_LARK_PACKAGE_SPEC = "lark-oapi==1.5.3"
+_LARK_PACKAGE_SPEC = "lark-oapi>=1.4.0"
 
 try:
     from app.chain.download import DownloadChain

--- a/plugins/agentresourceofficer/requirements.txt
+++ b/plugins/agentresourceofficer/requirements.txt
@@ -1,4 +1,4 @@
 requests
 cloudscraper
-lark-oapi==1.5.3
+lark-oapi>=1.4.0
 p115client==0.0.8.4.8

--- a/plugins/feishucommandbridgelong/README.md
+++ b/plugins/feishucommandbridgelong/README.md
@@ -105,5 +105,5 @@ POST /api/v1/plugin/FeishuCommandBridgeLong/assistant/pick
 ## 依赖
 
 ```txt
-lark-oapi==1.5.3
+lark-oapi>=1.4.0
 ```

--- a/plugins/feishucommandbridgelong/requirements.txt
+++ b/plugins/feishucommandbridgelong/requirements.txt
@@ -1,1 +1,1 @@
-lark-oapi==1.5.3
+lark-oapi>=1.4.0


### PR DESCRIPTION
## 背景

- MoviePilot 主程序环境已有 `lark-oapi 1.4.24`
- 插件写死 `lark-oapi==1.5.3`
- 安装器为避免污染共享环境而拒绝安装

## 本次改动

- `AgentResourceOfficer` / `FeishuCommandBridgeLong` 的 requirements.txt 从 `==1.5.3` 放宽到 `>=1.4.0`
- `AgentResourceOfficer/feishu_channel.py` 的 `_LARK_PACKAGE_SPEC` 同步放宽
- `plugins/` 和 `plugins.v2/` 两个布局下的 README 依赖说明同步对齐

## 兼容性说明

插件实际只使用 `lark-oapi` 的以下能力：

- `ws.client`
- `EventDispatcherHandler`
- `LogLevel`

这些在 `1.4.x` 已存在，因此 `>=1.4.0` 足够覆盖 MoviePilot 当前环境。