### PR TITLE
chore: add plugin release gates

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+python .github/scripts/check_plugin_versions.py package.json package.v2.json

--- a/.github/scripts/check_plugin_versions.py
+++ b/.github/scripts/check_plugin_versions.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""校验插件市场版本与插件源码版本一致。
+
+Release workflow 依赖 package.json/package.v2.json 生成 tag 和资产名；
+若插件目录内的 plugin_version 不同步，运行时会继续展示旧版本。这里在打包前失败退出，
+避免发布资产与插件自报版本不一致。
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore", category=SyntaxWarning)
+
+
+def _load_package(path: Path) -> dict:
+    """读取 package 文件；文件不存在时返回空字典，便于同一脚本兼容 v1/v2。"""
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as file_obj:
+        return json.load(file_obj)
+
+
+def _plugin_dir(package_file: Path, plugin_id: str) -> Path | None:
+    """按 package 文件定位对应插件目录，避免 v1/v2 同名插件互相串线。"""
+    plugin_id_lc = plugin_id.lower()
+    base_dir = Path("plugins.v2") if package_file.name == "package.v2.json" else Path("plugins")
+    candidate = base_dir / plugin_id_lc
+    return candidate if candidate.is_dir() else None
+
+
+def _plugin_version(init_file: Path) -> str | None:
+    """从 __init__.py 顶层类属性中提取 plugin_version 字面量。"""
+    tree = ast.parse(init_file.read_text(encoding="utf-8"), filename=str(init_file))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "plugin_version" for target in node.targets):
+            continue
+        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            return node.value.value
+    return None
+
+
+def check_package(path: Path) -> list[str]:
+    """校验单个 package 文件，返回所有错误文本。"""
+    errors: list[str] = []
+    package = _load_package(path)
+    for plugin_id, meta in package.items():
+        if not isinstance(meta, dict) or meta.get("release") is not True:
+            continue
+        package_version = str(meta.get("version") or "").strip()
+        plugin_dir = _plugin_dir(path, plugin_id)
+        if not plugin_dir:
+            continue
+        init_file = plugin_dir / "__init__.py"
+        if not init_file.exists():
+            errors.append(f"{path}: {plugin_id} 缺少 {init_file}")
+            continue
+        source_version = _plugin_version(init_file)
+        if not source_version:
+            errors.append(f"{path}: {plugin_id} 未在 {init_file} 中声明 plugin_version")
+            continue
+        if package_version != source_version:
+            errors.append(
+                f"{path}: {plugin_id} 版本不一致，package={package_version}, "
+                f"plugin_version={source_version} ({init_file})"
+            )
+    return errors
+
+
+def main() -> int:
+    """命令入口：所有 package 均通过时返回 0，否则打印错误并返回 1。"""
+    package_files = [Path(arg) for arg in sys.argv[1:]] or [Path("package.json"), Path("package.v2.json")]
+    errors: list[str] = []
+    for package_file in package_files:
+        errors.extend(check_package(package_file))
+    if errors:
+        print("插件版本门禁失败：")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("插件版本门禁通过")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/plugin-gate.yml
+++ b/.github/workflows/plugin-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-release-gate:
+    name: Plugin release gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check plugin versions
+        run: python .github/scripts/check_plugin_versions.py package.json package.v2.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq zip
 
+      - name: Check plugin versions
+        run: python .github/scripts/check_plugin_versions.py package.json package.v2.json
+
       - name: Build and release changed plugins
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -109,5 +112,4 @@ jobs:
 
           process_package "package.json"
           process_package "package.v2.json"
-
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ MoviePilot-Plugins/
 - 对 Python 插件代码，建议在宿主仓库环境中执行最小校验，例如：
   - `python3 -m py_compile <touched_files>`
   - `python3 -m compileall <touched_plugin_dirs>`
+  - `python3 .github/scripts/check_plugin_versions.py package.json package.v2.json`
   - `git diff --check`
 - 如果插件带有 Vue 远程组件，建议在对应前端工程中执行：
   - `yarn typecheck`
@@ -105,6 +106,8 @@ MoviePilot-Plugins/
 - `history` 用于展示插件更新日志，建议每次发布都补齐一条可读变更说明。
 - `system_version` 用于声明插件可安装的 MoviePilot 主系统版本范围，格式参考 pip 依赖版本约束；例如插件依赖 v2.12.0 新增能力时填写 `">=2.12.0"`。
 - 需要走 GitHub Release 压缩包分发的插件，请在对应索引条目中增加 `"release": true`，并确保仓库中的发布工作流能够定位到对应目录。
+- 本仓库提供可选的本地 pre-push hook，用于在推送前检查索引版本与插件 `plugin_version` 是否一致。Git 不会自动启用仓库内 hook；需要本地执行一次 `git config core.hooksPath .githooks`。
+- 本地 hook 只作为提前发现问题的辅助，不能替代 GitHub Actions。PR 门禁和 Release 打包前门禁会继续执行同一版本一致性检查。
 
 
 ## 常见问题
@@ -152,6 +155,8 @@ MoviePilot-Plugins/
 - 新增加的插件建议追加在索引文件末尾，便于在插件市场中作为较新的条目出现。
 - 如果插件目录文件较多，或你希望用户直接下载压缩包安装，可以在对应索引条目中增加 `"release": true`。
 - 当前仓库的 GitHub Actions 发布工作流只会在 `package.json` 或 `package.v2.json` 发生变更时触发，并且只处理声明了 `"release": true` 的插件。
+- PR 会运行 `Plugin release gate`，用于提前发现 `package.json` / `package.v2.json` 中的 `version` 与插件 `__init__.py` 中 `plugin_version` 不一致的问题。
+- Release 工作流会在打包前再次运行版本门禁；即使变更通过直接推送进入目标分支，版本不一致也会在打包前失败，不会继续生成错误版本的压缩包。
 - 发布工作流会按下面的规则打包与创建 Release：
   - 插件目录优先在 `plugins/<plugin_id_lower>` 和 `plugins.v2/<plugin_id_lower>` 中查找
   - Tag 格式为 `插件ID_v插件版本号`

--- a/docs/V2_Plugin_Development.md
+++ b/docs/V2_Plugin_Development.md
@@ -610,8 +610,21 @@ def run_with_downloader(self, name: str):
 ```bash
 python3 -m py_compile plugins.v2/myplugin/__init__.py
 python3 -m compileall plugins.v2/myplugin
+python3 .github/scripts/check_plugin_versions.py package.json package.v2.json
 git diff --check
 ```
+
+版本门禁只检查索引中 `"release": true` 的插件，并按索引文件定位对应目录：
+`package.json` 对应 `plugins/`，`package.v2.json` 对应 `plugins.v2/`。索引里的
+`version` 必须与插件 `__init__.py` 中的 `plugin_version` 一致。
+
+如果希望在本地推送前提前发现版本不一致，可以启用仓库提供的 pre-push hook：
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Git 不会自动启用仓库内 hook；本地 hook 只是开发辅助，PR 门禁和 Release 打包前门禁仍会在 GitHub Actions 中执行。
 
 ### 9.2 API 层
 
@@ -639,8 +652,9 @@ git diff --check
 4. 索引里的 `version` 与代码里的 `plugin_version` 一致
 5. `history` 已补齐本次变更说明
 6. 若使用 Release 分发，条目已声明 `"release": true`
-7. Python 代码完成最小语法校验
-8. 若有 Vue 远程组件，构建产物已更新
+7. `python3 .github/scripts/check_plugin_versions.py package.json package.v2.json` 已通过
+8. Python 代码完成最小语法校验
+9. 若有 Vue 远程组件，构建产物已更新
 
 ## 11. 什么时候还要回去看宿主源码
 


### PR DESCRIPTION
## 变更说明

- 新增 `Plugin release gate` PR 检查，在 PR 阶段校验发布插件的索引版本与插件 `plugin_version` 是否一致。
- 在 `Plugin Release` 工作流打包前复用同一版本门禁，避免直接推送后继续生成错误版本的 Release 资产。
- 新增 `.githooks/pre-push`，开发者可通过 `git config core.hooksPath .githooks` 在本地推送前提前发现版本不一致问题。
- 更新 `README.md` 与 `docs/V2_Plugin_Development.md`，说明门禁命令、hook 启用方式和发布前检查要求。

## 影响路径

- `.github/scripts/check_plugin_versions.py`
- `.github/workflows/plugin-gate.yml`
- `.github/workflows/release.yml`
- `.githooks/pre-push`
- `README.md`
- `docs/V2_Plugin_Development.md`

## 验证

- `python .github/scripts/check_plugin_versions.py package.json package.v2.json`
- `.githooks/pre-push`
- `python -m py_compile .github/scripts/check_plugin_versions.py`
- `python -m json.tool package.json >/dev/null && python -m json.tool package.v2.json >/dev/null && git diff --check`
- 临时副本中故意制造 `package.v2.json` 与 `plugin_version` 版本不一致，确认脚本会在打包前失败并输出具体插件与文件路径。

本 PR 为 Codex 协作提交
