### PR TITLE
fix: harden plugin release version gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-python .github/scripts/check_plugin_versions.py package.json package.v2.json
+python3 .github/scripts/check_plugin_versions.py package.json package.v2.json

--- a/.github/scripts/check_plugin_versions.py
+++ b/.github/scripts/check_plugin_versions.py
@@ -29,20 +29,28 @@ def _plugin_dir(package_file: Path, plugin_id: str) -> Path | None:
     """按 package 文件定位对应插件目录，避免 v1/v2 同名插件互相串线。"""
     plugin_id_lc = plugin_id.lower()
     base_dir = Path("plugins.v2") if package_file.name == "package.v2.json" else Path("plugins")
-    candidate = base_dir / plugin_id_lc
+    candidate = package_file.parent / base_dir / plugin_id_lc
     return candidate if candidate.is_dir() else None
 
 
+def _expected_plugin_dir(package_file: Path, plugin_id: str) -> Path:
+    """返回 package 条目对应的插件目录，用于缺失目录时输出可定位错误。"""
+    plugin_id_lc = plugin_id.lower()
+    base_dir = Path("plugins.v2") if package_file.name == "package.v2.json" else Path("plugins")
+    return package_file.parent / base_dir / plugin_id_lc
+
+
 def _plugin_version(init_file: Path) -> str | None:
-    """从 __init__.py 顶层类属性中提取 plugin_version 字面量。"""
+    """从 __init__.py 类级属性中提取 plugin_version 字面量。"""
     tree = ast.parse(init_file.read_text(encoding="utf-8"), filename=str(init_file))
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign):
-            continue
-        if not any(isinstance(target, ast.Name) and target.id == "plugin_version" for target in node.targets):
-            continue
-        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
-            return node.value.value
+    for class_node in (node for node in tree.body if isinstance(node, ast.ClassDef)):
+        for node in class_node.body:
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(isinstance(target, ast.Name) and target.id == "plugin_version" for target in node.targets):
+                continue
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                return node.value.value
     return None
 
 
@@ -56,6 +64,7 @@ def check_package(path: Path) -> list[str]:
         package_version = str(meta.get("version") or "").strip()
         plugin_dir = _plugin_dir(path, plugin_id)
         if not plugin_dir:
+            errors.append(f"{path}: {plugin_id} 缺少插件目录 {_expected_plugin_dir(path, plugin_id)}")
             continue
         init_file = plugin_dir / "__init__.py"
         if not init_file.exists():
@@ -63,7 +72,7 @@ def check_package(path: Path) -> list[str]:
             continue
         source_version = _plugin_version(init_file)
         if not source_version:
-            errors.append(f"{path}: {plugin_id} 未在 {init_file} 中声明 plugin_version")
+            errors.append(f"{path}: {plugin_id} 未在 {init_file} 中声明类级 plugin_version")
             continue
         if package_version != source_version:
             errors.append(

--- a/tests/v2/releasegate/test_check_plugin_versions.py
+++ b/tests/v2/releasegate/test_check_plugin_versions.py
@@ -1,0 +1,109 @@
+"""插件发布版本门禁脚本单测。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[3] / ".github" / "scripts" / "check_plugin_versions.py"
+
+
+def _load_module():
+    """按文件路径加载脚本，避免要求 .github/scripts 成为 Python 包。"""
+    spec = importlib.util.spec_from_file_location("check_plugin_versions", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_package(path: Path, plugin_id: str, version: str = "1.2.3") -> None:
+    """写入最小 release=true package 条目。"""
+    path.write_text(
+        json.dumps({plugin_id: {"version": version, "release": True}}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def test_check_package_resolves_plugin_dir_relative_to_package_file(tmp_path):
+    """从其他工作目录调用时，插件目录应相对 package 文件定位。"""
+    module = _load_module()
+    repo = tmp_path / "repo"
+    plugin_dir = repo / "plugins.v2" / "demo"
+    plugin_dir.mkdir(parents=True)
+    package_file = repo / "package.v2.json"
+    _write_package(package_file, "Demo")
+    (plugin_dir / "__init__.py").write_text(
+        "class Demo:\n"
+        "    plugin_version = '1.2.3'\n",
+        encoding="utf-8",
+    )
+
+    assert module.check_package(package_file) == []
+
+
+def test_cli_resolves_package_paths_from_repo_root_when_run_elsewhere(tmp_path):
+    """命令入口从其他工作目录运行时仍应读取仓库根的 package 文件。"""
+    repo = tmp_path / "repo"
+    plugin_dir = repo / "plugins.v2" / "demo"
+    plugin_dir.mkdir(parents=True)
+    _write_package(repo / "package.v2.json", "Demo")
+    (repo / "package.json").write_text("{}", encoding="utf-8")
+    (plugin_dir / "__init__.py").write_text(
+        "class Demo:\n"
+        "    plugin_version = '1.2.3'\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            str(repo / "package.json"),
+            str(repo / "package.v2.json"),
+        ],
+        cwd=tmp_path,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_check_package_reports_missing_release_plugin_dir(tmp_path):
+    """release=true 的插件缺少源码目录时应失败，避免发布项被静默跳过。"""
+    module = _load_module()
+    package_file = tmp_path / "package.v2.json"
+    _write_package(package_file, "MissingPlugin")
+
+    errors = module.check_package(package_file)
+
+    assert errors == [
+        f"{package_file}: MissingPlugin 缺少插件目录 {tmp_path / 'plugins.v2' / 'missingplugin'}"
+    ]
+
+
+def test_check_package_reads_class_level_plugin_version_only(tmp_path):
+    """只接受类级 plugin_version，避免函数内局部变量被误识别为插件版本。"""
+    module = _load_module()
+    plugin_dir = tmp_path / "plugins.v2" / "nestedonly"
+    plugin_dir.mkdir(parents=True)
+    package_file = tmp_path / "package.v2.json"
+    _write_package(package_file, "NestedOnly")
+    (plugin_dir / "__init__.py").write_text(
+        "def helper():\n"
+        "    plugin_version = '1.2.3'\n"
+        "    return plugin_version\n",
+        encoding="utf-8",
+    )
+
+    errors = module.check_package(package_file)
+
+    assert errors == [
+        f"{package_file}: NestedOnly 未在 {plugin_dir / '__init__.py'} 中声明类级 plugin_version"
+    ]


### PR DESCRIPTION
## 变更说明

- 调整版本门禁脚本的插件目录解析，按 package 文件所在目录定位 `plugins/` 与 `plugins.v2/`，避免依赖当前工作目录。
- 对 `release: true` 但源码目录缺失的插件返回明确错误，避免发布项被静默跳过。
- 只识别插件类上的 `plugin_version`，避免函数内局部变量或其他嵌套赋值被误认为插件版本。
- 将本地 pre-push hook 的解释器改为 `python3`。
- 增加针对版本门禁脚本的 pytest 覆盖，包含路径解析、缺失目录、类级版本识别等场景。

## 关联

Follow-up for #1056 reviewer feedback.

## 验证

- `MOVIEPILOT_BACKEND_PATH=<MoviePilot backend> <workspace>/.venv-test/bin/python -m pytest tests/v2/releasegate/test_check_plugin_versions.py -q`
- `python3 .github/scripts/check_plugin_versions.py package.json package.v2.json`
- `.githooks/pre-push`
- `python -m py_compile .github/scripts/check_plugin_versions.py`
- `python -m json.tool package.json >/dev/null && python -m json.tool package.v2.json >/dev/null && git diff --check`
- 临时副本中故意制造 `package.v2.json` 与 `plugin_version` 版本不一致，确认脚本失败并输出具体插件与文件路径。

本 PR 为 Codex 协作提交
