### PR TITLE
fix(brushflow): 兼容 transmission-rpc v7.x 属性重命名

### DIFF
--- a/plugins.v2/brushflow/__init__.py
+++ b/plugins.v2/brushflow/__init__.py
@@ -3460,18 +3460,20 @@ class BrushFlow(_PluginBase):
             torrent_id = torrent.hashString
             # 标题
             torrent_title = torrent.name
-            # 做种时间
-            if (not torrent.date_done
-                    or torrent.date_done.timestamp() < 1):
+            # 做种时间 — 兼容 transmission-rpc v7(done_date) 与旧版(date_done)
+            done_date = getattr(torrent, "done_date", None) or getattr(torrent, "date_done", None)
+            if (not done_date
+                    or done_date.timestamp() < 1):
                 seeding_time = 0
             else:
-                seeding_time = date_now - int(torrent.date_done.timestamp())
-            # 下载耗时
-            if (not torrent.date_added
-                    or torrent.date_added.timestamp() < 1):
+                seeding_time = date_now - int(done_date.timestamp())
+            # 下载耗时 — 兼容 v7(added_date) 与旧版(date_added)
+            added_date = getattr(torrent, "added_date", None) or getattr(torrent, "date_added", None)
+            if (not added_date
+                    or added_date.timestamp() < 1):
                 dltime = 0
             else:
-                dltime = date_now - int(torrent.date_added.timestamp())
+                dltime = date_now - int(added_date.timestamp())
             # 下载量
             downloaded = int(torrent.total_size * torrent.progress / 100)
             # 分享率
@@ -3483,21 +3485,23 @@ class BrushFlow(_PluginBase):
                 avg_upspeed = int(uploaded / dltime)
             else:
                 avg_upspeed = uploaded
-            # 未活动时间
-            if (not torrent.date_active
-                    or torrent.date_active.timestamp() < 1):
+            # 未活动时间 — 兼容 v7(activity_date) 与旧版(date_active)
+            activity_date = getattr(torrent, "activity_date", None) or getattr(torrent, "date_active", None)
+            if (not activity_date
+                    or activity_date.timestamp() < 1):
                 iatime = 0
             else:
-                iatime = date_now - int(torrent.date_active.timestamp())
+                iatime = date_now - int(activity_date.timestamp())
             # 种子大小
             total_size = torrent.total_size
             # 添加时间
-            add_on = (torrent.date_added.timestamp() if torrent.date_added else 0)
+            add_on = (added_date.timestamp() if added_date else 0)
             add_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(add_on))
-            # 种子标签
-            tags = torrent.get("tags")
-            # tracker
-            tracker = torrent.get("tracker")
+            # 种子标签 — v7(labels) 与旧版(labels) 均为属性
+            tags = getattr(torrent, "labels", None) or ""
+            # tracker — 兼容 v7(tracker_list) 与旧版(tracker_list)
+            tracker_list = getattr(torrent, "tracker_list", None)
+            tracker = tracker_list[0] if tracker_list else ""
 
         return {
             "hash": torrent_id,
@@ -3985,11 +3989,21 @@ class BrushFlow(_PluginBase):
         """
         trackers = []
         try:
-            tracker_url = torrent.get("tracker")
+            # 兼容 QB(dict) 和 TR(object) 两种种子类型：先尝试 dict 访问，再尝试属性
+            tracker_url = None
+            try:
+                tracker_url = torrent.get("tracker")
+            except (AttributeError, TypeError):
+                tracker_list = getattr(torrent, "tracker_list", None)
+                tracker_url = tracker_list[0] if tracker_list else None
             if tracker_url:
                 trackers.append(tracker_url)
 
-            magnet_link = torrent.get("magnet_uri")
+            magnet_link = None
+            try:
+                magnet_link = torrent.get("magnet_uri")
+            except (AttributeError, TypeError):
+                magnet_link = getattr(torrent, "magnet_link", None)
             if magnet_link:
                 query_params: dict = parse_qs(urlparse(magnet_link).query)
                 encoded_tracker_urls = query_params.get('tr', [])

--- a/tests/v2/brushflow/test_torrent_info.py
+++ b/tests/v2/brushflow/test_torrent_info.py
@@ -1,0 +1,122 @@
+"""BrushFlow 插件兼容性测试：确保 __get_torrent_info 兼容 transmission-rpc v7.x。
+
+v7.x 将以下属性重命名：
+  date_done   → done_date
+  date_added  → added_date
+  date_active → activity_date
+  tags (dict)  → labels (property, list[str])
+  tracker (dict) → tracker_list (property, list[str])
+"""
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock, PropertyMock
+
+import pytest
+
+from brushflow import BrushFlow
+
+
+class FakeTorrentV7:
+    """模拟 transmission-rpc v7.x 的 Torrent 对象。
+
+    v7.x 中 date_done/date_added/date_active 已被移除，
+    只保留 done_date/added_date/activity_date。
+    """
+
+    def __init__(self):
+        self.hashString = "aabbccdd"
+        self.name = "Test.Torrent-SomeGroup"
+        self.done_date = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        self.added_date = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        self.activity_date = datetime(2024, 1, 1, 14, 0, 0, tzinfo=timezone.utc)
+        self.total_size = 1024 * 1024 * 100  # 100 MB
+        self.progress = 100.0
+        self.ratio = 1.5
+        self.labels = ["brush_tag", "movie"]
+        self.tracker_list = ["https://tracker.example.com/announce"]
+        self.magnet_link = "magnet:?xt=urn:btih:aabbccdd&tr=https://tracker.example.com/announce"
+
+    # v7.x Torrent 没有 .get() 方法，不定义该属性
+
+
+@pytest.fixture
+def brushflow_instance():
+    """创建 BrushFlow 实例。"""
+    return BrushFlow()
+
+
+def _make_downloader_helper_mock():
+    """创建 mock DownloaderHelper，模拟 Transmission 下载器（非 QB）。"""
+    mock_dh = MagicMock()
+    mock_dh.is_downloader.return_value = False
+    return mock_dh
+
+
+# ─── __get_torrent_info ────────────────────────────────────────────
+
+class TestGetTorrentInfoV7:
+    """测试 __get_torrent_info 能正确处理 v7.x Torrent 对象。"""
+
+    def test_extracts_basic_fields_from_v7_torrent(self, brushflow_instance):
+        """应从 v7.x Torrent 对象正确提取基本字段（hash, title, total_size, ratio）。"""
+        torrent = FakeTorrentV7()
+        mock_dh = _make_downloader_helper_mock()
+        with patch("brushflow.DownloaderHelper", return_value=mock_dh), \
+             patch.object(type(brushflow_instance), "service_info",
+                          new_callable=PropertyMock,
+                          return_value=MagicMock()):
+            result = getattr(brushflow_instance, "_BrushFlow__get_torrent_info")(torrent)
+
+        assert result["hash"] == "aabbccdd"
+        assert result["title"] == "Test.Torrent-SomeGroup"
+        assert result["total_size"] == 1024 * 1024 * 100
+        assert result["ratio"] == 1.5
+
+    def test_computes_seeding_time_from_done_date(self, brushflow_instance):
+        """应使用 done_date（v7.x）计算做种时间，结果为正数。"""
+        torrent = FakeTorrentV7()
+        mock_dh = _make_downloader_helper_mock()
+        with patch("brushflow.DownloaderHelper", return_value=mock_dh), \
+             patch.object(type(brushflow_instance), "service_info",
+                          new_callable=PropertyMock,
+                          return_value=MagicMock()):
+            result = getattr(brushflow_instance, "_BrushFlow__get_torrent_info")(torrent)
+
+        assert result["seeding_time"] > 0
+
+    def test_extracts_tags_from_labels(self, brushflow_instance):
+        """应从 labels 属性（v7.x）提取标签列表。"""
+        torrent = FakeTorrentV7()
+        mock_dh = _make_downloader_helper_mock()
+        with patch("brushflow.DownloaderHelper", return_value=mock_dh), \
+             patch.object(type(brushflow_instance), "service_info",
+                          new_callable=PropertyMock,
+                          return_value=MagicMock()):
+            result = getattr(brushflow_instance, "_BrushFlow__get_torrent_info")(torrent)
+
+        assert result["tags"] == ["brush_tag", "movie"]
+
+    def test_extracts_tracker_from_tracker_list(self, brushflow_instance):
+        """应从 tracker_list 属性（v7.x）提取第一个 tracker URL。"""
+        torrent = FakeTorrentV7()
+        mock_dh = _make_downloader_helper_mock()
+        with patch("brushflow.DownloaderHelper", return_value=mock_dh), \
+             patch.object(type(brushflow_instance), "service_info",
+                          new_callable=PropertyMock,
+                          return_value=MagicMock()):
+            result = getattr(brushflow_instance, "_BrushFlow__get_torrent_info")(torrent)
+
+        assert result["tracker"] == "https://tracker.example.com/announce"
+
+
+# ─── __get_site_by_torrent ─────────────────────────────────────────
+
+class TestGetSiteByTorrentV7:
+    """测试 __get_site_by_torrent 能从 v7.x Torrent 对象获取站点信息。"""
+
+    def test_extracts_tracker_from_v7_torrent(self):
+        """应从 v7.x Torrent 的 tracker_list 获取 tracker URL。"""
+        torrent = FakeTorrentV7()
+        site_id, domain = getattr(BrushFlow, "_BrushFlow__get_site_by_torrent")(torrent)
+
+        # 至少应解析出 tracker.example.com 的域名
+        assert "example.com" in domain or domain != "未知"


### PR DESCRIPTION
### **User description**
## 问题

BrushFlow 插件在 Transmission 下载器环境下运行时报错：

```
AttributeError: 'Torrent' object has no attribute 'date_done'
```

**根因**：`transmission-rpc` v7.x 移除了已废弃的属性别名：
- `date_done` → `done_date`
- `date_added` → `added_date`
- `date_active` → `activity_date`
- dict 访问 `tags`/`tracker`/`magnet_uri` → 属性访问 `labels`/`tracker_list`/`magnet_link`

MoviePilot 的 `requirements.in` 指定 `transmission-rpc~=7.0.11`，但 brushflow 插件仍使用旧版属性名。

## 修复

使用 `getattr` 兼容新旧属性名，确保在 v4.x 和 v7.x 下均能正常工作：

| 方法 | 修改 |
|---|---|
| `__get_torrent_info` | `date_done/date_added/date_active` → `getattr` 兼容新旧名 |
| `__get_torrent_info` | `tags/tracker` 从 dict.get() 改为属性访问 |
| `__get_site_by_torrent` | `tracker/magnet_uri` 先 dict 后属性 fallback |

## 测试

新增 `tests/v2/brushflow/test_torrent_info.py`，5 个测试全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 兼容 Transmission v7 属性重命名

- 修复 TR 种子信息提取

- 增加 v7 兼容性测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>兼容 Transmission v7 种子属性</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

plugins.v2/brushflow/__init__.py

<ul><li>在 <code>__get_torrent_info</code> 中兼容 <code>done_date</code>、<code>added_date</code>、<code>activity_date</code>。<br> <li> 改用 <code>labels</code> 和 <code>tracker_list</code> 提取 TR 标签与 tracker。<br> <li> 在 <code>__get_site_by_torrent</code> 中为 TR 对象添加属性访问 fallback。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot-Plugins/pull/1066/files#diff-cc5a234f5f64b9d3a653490514ef5c3a8371921c370ff24f855447229efceaf1">+33/-19</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_torrent_info.py</strong><dd><code>新增 BrushFlow v7 兼容测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/v2/brushflow/test_torrent_info.py

<ul><li>新增 <code>FakeTorrentV7</code> 模拟 transmission-rpc v7 种子对象。<br> <li> 覆盖基本字段、做种时间、标签与 tracker 提取。<br> <li> 验证 <code>__get_site_by_torrent</code> 可处理 v7 tracker 属性。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot-Plugins/pull/1066/files#diff-830bbf639d3c17a14d7c633a36dc1994b77ec90d9d36c5a8db86a5c80f5fdedc">+122/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

