### PR TITLE
ci(pr-agent): align inline review workflow

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -159,8 +159,10 @@ jobs:
           set -euo pipefail
           current_body="$(mktemp)"
           latest_body="$(mktemp)"
+          latest_response="$(mktemp)"
           next_body="$(mktemp)"
           payload="$(mktemp)"
+          etag_file="$(mktemp)"
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
           placeholder_body="${RUNNER_TEMP}/pr-agent-body-with-placeholder.md"
 
@@ -204,7 +206,27 @@ jobs:
           body_changed=false
           can_describe=true
           if ! cmp -s "${current_body}" "${next_body}"; then
-            gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${latest_body}"
+            gh api -i "repos/${REPO}/pulls/${PR_NUMBER}" > "${latest_response}"
+            python3 - "${latest_response}" "${latest_body}" "${etag_file}" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          raw = Path(sys.argv[1]).read_text()
+          parts = re.split(r"\r?\n\r?\n", raw)
+          headers = parts[-2] if len(parts) > 1 else ""
+          body = parts[-1]
+          etag = ""
+          for line in headers.splitlines():
+              if line.lower().startswith("etag:"):
+                  etag = line.split(":", 1)[1].strip()
+                  break
+          Path(sys.argv[2]).write_text(json.loads(body).get("body") or "")
+          if etag.lower().startswith("w/"):
+              etag = ""
+          Path(sys.argv[3]).write_text(etag)
+          PY
             if ! cmp -s "${current_body}" "${latest_body}"; then
               echo "PR body changed while preparing PR-Agent markers; skip placeholder update."
               can_describe=false
@@ -217,7 +239,12 @@ jobs:
           body = Path(sys.argv[1]).read_text()
           Path(sys.argv[2]).write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY
-              gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+              etag="$(cat "${etag_file}")"
+              if [ -n "${etag}" ]; then
+                gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" -H "If-Match: ${etag}" --input "${payload}" >/dev/null
+              else
+                gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+              fi
               body_changed=true
             fi
           fi
@@ -427,8 +454,7 @@ jobs:
           pr_code_suggestions.extra_instructions: |
             Match the configured response language.
             Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
-            Start every suggestion body with this hidden ownership marker on its own first line: <!-- pr-agent-inline-comment:${{ github.run_id }} -->
-            Then start the visible suggestion text with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
+            Start every suggestion with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
           pr_code_suggestions.num_code_suggestions_per_chunk: "2"
@@ -439,6 +465,94 @@ jobs:
           # 可选成本和噪音控制：
           # github_action_config.auto_improve: "true"
           # config.verbosity_level: "1"
+
+      - name: Mark PR-Agent inline comments
+        if: >-
+          always() &&
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true' &&
+          steps.pragent_head.outputs.is_stale != 'true' &&
+          steps.inline_state_before.outputs.inline_ids_b64 != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
+          BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
+          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
+        run: |
+          set -euo pipefail
+          before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
+          before_review_ids="$(printf '%s' "${BEFORE_REVIEW_IDS_B64:-W10=}" | base64 -d)"
+          comments="$(mktemp)"
+          reviews="$(mktemp)"
+          patches="$(mktemp)"
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | @json' > "${comments}"
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
+          python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${patches}" <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          before_ids = set(json.loads(sys.argv[1] or "[]"))
+          before_review_ids = set(json.loads(sys.argv[2] or "[]"))
+          comments_path = Path(sys.argv[3])
+          reviews_path = Path(sys.argv[4])
+          patches_path = Path(sys.argv[5])
+          marker = os.environ["PR_AGENT_INLINE_MARKER"]
+          marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
+
+          new_review_ids = set()
+          for line in reviews_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("id") not in before_review_ids
+              ):
+                  new_review_ids.add(item["id"])
+
+          patches = []
+          for line in comments_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              body = item.get("body") or ""
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("id") not in before_ids
+                  and item.get("pull_request_review_id") in new_review_ids
+                  and body.lstrip().startswith("**Suggestion:**")
+                  and not marker_re.search(body)
+              ):
+                  patches.append({"id": item["id"], "body": f"{marker}\n{body}"})
+
+          patches_path.write_text("\n".join(json.dumps(item, ensure_ascii=False) for item in patches))
+          PY
+
+          if [ ! -s "${patches}" ]; then
+            echo "No PR-Agent inline comments to mark."
+            exit 0
+          fi
+          patch_failed=false
+          while IFS= read -r patch || [ -n "${patch}" ]; do
+            [ -z "${patch}" ] && continue
+            comment_id="$(printf '%s' "${patch}" | jq -r '.id')"
+            payload="$(mktemp)"
+            err="$(mktemp)"
+            printf '%s' "${patch}" | jq '{body:.body}' > "${payload}"
+            if ! gh api --method PATCH "repos/${REPO}/pulls/comments/${comment_id}" --input "${payload}" >/dev/null 2>"${err}"; then
+              cat "${err}" >&2
+              echo "PR-Agent inline comment ${comment_id} could not be marked."
+              patch_failed=true
+            fi
+          done < "${patches}"
+          if [ "${patch_failed}" = "true" ]; then
+            exit 1
+          fi
 
       - name: Clean stale PR-Agent inline comments
         id: post_pragent_state
@@ -500,7 +614,6 @@ jobs:
               if (
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_review_ids
-                  and item.get("commit_id") == head_sha
               ):
                   new_review_ids.add(item["id"])
 
@@ -512,7 +625,6 @@ jobs:
               if (
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_ids
-                  and item.get("commit_id") == head_sha
                   and item.get("pull_request_review_id") in new_review_ids
                   and is_pr_agent_suggestion(item)
               ):
@@ -852,7 +964,9 @@ jobs:
           placeholder_body="${RUNNER_TEMP}/pr-agent-body-with-placeholder.md"
           current_body="$(mktemp)"
           latest_body="$(mktemp)"
+          latest_response="$(mktemp)"
           payload="$(mktemp)"
+          etag_file="$(mktemp)"
 
           if [ ! -s "${body_backup}" ] || [ ! -s "${placeholder_body}" ]; then
             echo "No PR body backup found."
@@ -931,10 +1045,35 @@ jobs:
           payload_path.write_text(json.dumps({"body": next_body}, ensure_ascii=False))
           PY
           if [ -s "${payload}" ]; then
-            gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${latest_body}"
+            gh api -i "repos/${REPO}/pulls/${PR_NUMBER}" > "${latest_response}"
+            python3 - "${latest_response}" "${latest_body}" "${etag_file}" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          raw = Path(sys.argv[1]).read_text()
+          parts = re.split(r"\r?\n\r?\n", raw)
+          headers = parts[-2] if len(parts) > 1 else ""
+          body = parts[-1]
+          etag = ""
+          for line in headers.splitlines():
+              if line.lower().startswith("etag:"):
+                  etag = line.split(":", 1)[1].strip()
+                  break
+          Path(sys.argv[2]).write_text(json.loads(body).get("body") or "")
+          if etag.lower().startswith("w/"):
+              etag = ""
+          Path(sys.argv[3]).write_text(etag)
+          PY
             if ! cmp -s "${current_body}" "${latest_body}"; then
               echo "PR body changed while preparing restore payload; skip restore."
               exit 0
             fi
-            gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+            etag="$(cat "${etag_file}")"
+            if [ -n "${etag}" ]; then
+              gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" -H "If-Match: ${etag}" --input "${payload}" >/dev/null
+            else
+              gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+            fi
           fi

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -158,6 +158,7 @@ jobs:
         run: |
           set -euo pipefail
           current_body="$(mktemp)"
+          latest_body="$(mktemp)"
           next_body="$(mktemp)"
           payload="$(mktemp)"
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
@@ -202,7 +203,11 @@ jobs:
 
           body_changed=false
           if ! cmp -s "${current_body}" "${next_body}"; then
-            python3 - "${next_body}" "${payload}" <<'PY'
+            gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${latest_body}"
+            if ! cmp -s "${current_body}" "${latest_body}"; then
+              echo "PR body changed while preparing PR-Agent markers; skip placeholder update."
+            else
+              python3 - "${next_body}" "${payload}" <<'PY'
           import json
           import sys
           from pathlib import Path
@@ -210,8 +215,9 @@ jobs:
           body = Path(sys.argv[1]).read_text()
           Path(sys.argv[2]).write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY
-            gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
-            body_changed=true
+              gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+              body_changed=true
+            fi
           fi
           echo "body_changed=${body_changed}" >> "${GITHUB_OUTPUT}"
 
@@ -361,6 +367,7 @@ jobs:
           pr_code_suggestions.extra_instructions: |
             Match the configured response language.
             Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
+            Start every suggestion body with this exact hidden marker on the first line: <!-- pr-agent-inline-comment -->.
             Start every suggestion body with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
@@ -419,14 +426,14 @@ jobs:
           reviews_path = Path(sys.argv[4])
           delete_path = Path(sys.argv[5])
           head_sha = sys.argv[6]
-          risk_prefix_re = re.compile(
-              r"^\s*(?:<!-- pr-agent-inline-comment -->\s*)?"
+          pr_agent_marker_re = re.compile(
+              r"^\s*<!-- pr-agent-inline-comment -->\s*"
               r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
               re.IGNORECASE,
           )
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              return bool(risk_prefix_re.search(item.get("body") or ""))
+              return bool(pr_agent_marker_re.search(item.get("body") or ""))
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -535,8 +542,13 @@ jobs:
           pr_url = sys.argv[7]
           commit_url = sys.argv[8]
           short_sha = sys.argv[9]
+          pr_agent_marker_re = re.compile(
+              r"^\s*<!-- pr-agent-inline-comment -->\s*"
+              r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
           risk_prefix_re = re.compile(
-              r"^\s*(?:<!-- pr-agent-inline-comment -->\s*)?"
+              r"^\s*"
               r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
               re.IGNORECASE,
           )
@@ -545,7 +557,8 @@ jobs:
               return re.sub(r"^\s*<!-- pr-agent-inline-comment -->\s*", "", body or "").strip()
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              return bool(risk_prefix_re.search(item.get("body") or ""))
+              body = item.get("body") or ""
+              return bool(pr_agent_marker_re.search(body) or risk_prefix_re.search(body))
 
           comments = []
           for line in comments_path.read_text().splitlines():

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -461,7 +461,7 @@ jobs:
             echo "No stale PR-Agent inline comments to clean."
             exit 0
           fi
-          while IFS= read -r comment_id; do
+          while IFS= read -r comment_id || [ -n "${comment_id}" ]; do
             [ -z "${comment_id}" ] && continue
             gh api --method DELETE "repos/${REPO}/pulls/comments/${comment_id}" >/dev/null
           done < "${delete_ids}"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -17,11 +17,6 @@ on:
       - created
       - edited
 
-concurrency:
-  # 同一 PR 上只保留最新一次 PR-Agent 运行，避免旧 commit 的 review 后完成并覆盖新结果。
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   # 读取仓库内容和 PR diff。
   contents: read
@@ -52,6 +47,9 @@ jobs:
           )
         )
       )
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -74,6 +72,8 @@ jobs:
           pr = json.loads(Path(sys.argv[1]).read_text())
           title = pr.get("title") or ""
           body = pr.get("body") or ""
+          labels = {item.get("name", "") for item in pr.get("labels") or []}
+          skip_pr_agent = "true" if "skip pr-agent" in labels or re.search(r"^(?:\[Auto\]|Auto)", title) else "false"
 
           body = re.sub(
               r"\n*##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*"
@@ -110,16 +110,21 @@ jobs:
           print(f"response_language={response_language}")
           print(f"summary_heading={summary_heading}")
           print(f"summary_language={summary_language}")
+          print(f"skip_pr_agent={skip_pr_agent}")
           PY
 
       - name: Prepare PR-Agent description markers
+        id: prepare_description
         if: >-
-          github.event_name == 'pull_request_target' ||
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
           (
-            github.event_name == 'issue_comment' &&
+            github.event_name == 'pull_request_target' ||
             (
-              github.event.comment.body == '/describe' ||
-              startsWith(github.event.comment.body, '/describe ')
+              github.event_name == 'issue_comment' &&
+              (
+                github.event.comment.body == '/describe' ||
+                startsWith(github.event.comment.body, '/describe ')
+              )
             )
           )
         env:
@@ -132,8 +137,10 @@ jobs:
           current_body="$(mktemp)"
           next_body="$(mktemp)"
           payload="$(mktemp)"
+          body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
 
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
+          cp "${current_body}" "${body_backup}"
           python3 - "${current_body}" "${next_body}" <<'PY'
           import os
           import re
@@ -166,6 +173,7 @@ jobs:
           next_path.write_text(next_body)
           PY
 
+          body_changed=false
           if ! cmp -s "${current_body}" "${next_body}"; then
             python3 - "${next_body}" "${payload}" <<'PY'
           import json
@@ -176,17 +184,22 @@ jobs:
           Path(sys.argv[2]).write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY
             gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+            body_changed=true
           fi
+          echo "body_changed=${body_changed}" >> "${GITHUB_OUTPUT}"
 
       - name: Snapshot PR-Agent inline comments
         id: inline_state_before
         if: >-
-          github.event_name == 'pull_request_target' ||
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
           (
-            github.event_name == 'issue_comment' &&
+            github.event_name == 'pull_request_target' ||
             (
-              github.event.comment.body == '/improve' ||
-              startsWith(github.event.comment.body, '/improve ')
+              github.event_name == 'issue_comment' &&
+              (
+                github.event.comment.body == '/improve' ||
+                startsWith(github.event.comment.body, '/improve ')
+              )
             )
           )
         env:
@@ -201,12 +214,15 @@ jobs:
 
       - name: Clean previous PR-Agent code review summary
         if: >-
-          github.event_name == 'pull_request_target' ||
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
           (
-            github.event_name == 'issue_comment' &&
+            github.event_name == 'pull_request_target' ||
             (
-              github.event.comment.body == '/improve' ||
-              startsWith(github.event.comment.body, '/improve ')
+              github.event_name == 'issue_comment' &&
+              (
+                github.event.comment.body == '/improve' ||
+                startsWith(github.event.comment.body, '/improve ')
+              )
             )
           )
         env:
@@ -229,6 +245,7 @@ jobs:
 
       - name: Run PR-Agent
         id: pragent
+        if: steps.pr_language.outputs.skip_pr_agent != 'true'
         # 使用版本号加 digest 固定容器构建，避免 tag 被重推后改变运行内容。
         uses: docker://pragent/pr-agent:0.39.0-github_action@sha256:b253845caa8c7ff5ce8be78f32996647982bdd4890826a962b78eff2e385a825
         env:
@@ -303,12 +320,15 @@ jobs:
 
       - name: Publish PR-Agent code review summary
         if: >-
-          github.event_name == 'pull_request_target' ||
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
           (
-            github.event_name == 'issue_comment' &&
+            github.event_name == 'pull_request_target' ||
             (
-              github.event.comment.body == '/improve' ||
-              startsWith(github.event.comment.body, '/improve ')
+              github.event_name == 'issue_comment' &&
+              (
+                github.event.comment.body == '/improve' ||
+                startsWith(github.event.comment.body, '/improve ')
+              )
             )
           )
         env:
@@ -501,3 +521,39 @@ jobs:
           PY
 
           gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" >/dev/null
+
+      - name: Restore PR-Agent description markers on failure
+        if: >-
+          failure() &&
+          steps.prepare_description.outputs.body_changed == 'true' &&
+          steps.pr_language.outputs.skip_pr_agent != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
+          current_body="$(mktemp)"
+          payload="$(mktemp)"
+
+          if [ ! -s "${body_backup}" ]; then
+            echo "No PR body backup found."
+            exit 0
+          fi
+
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
+          if ! grep -q 'pr_agent:summary' "${current_body}"; then
+            echo "No visible PR-Agent summary placeholder to restore."
+            exit 0
+          fi
+
+          python3 - "${body_backup}" "${payload}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          body = Path(sys.argv[1]).read_text()
+          Path(sys.argv[2]).write_text(json.dumps({"body": body}, ensure_ascii=False))
+          PY
+          gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -416,6 +416,7 @@ jobs:
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
           import json
+          import re
           import sys
           from pathlib import Path
 
@@ -425,9 +426,13 @@ jobs:
           reviews_path = Path(sys.argv[4])
           delete_path = Path(sys.argv[5])
           head_sha = sys.argv[6]
+          risk_prefix_re = re.compile(
+              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              return bool((item.get("body") or "").strip())
+              return bool(risk_prefix_re.search((item.get("body") or "").lstrip()))
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -543,12 +548,17 @@ jobs:
               r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*",
               re.IGNORECASE,
           )
+          risk_prefix_re = re.compile(
+              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
 
           def normalize_suggestion_body(body: str) -> str:
               return marker_re.sub("", body or "", count=1).strip()
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              return bool((item.get("body") or "").strip())
+              body = normalize_suggestion_body(item.get("body") or "")
+              return bool(risk_prefix_re.search(body))
 
           comments = []
           for line in comments_path.read_text().splitlines():

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -368,7 +368,7 @@ jobs:
           pr_code_suggestions.extra_instructions: |
             Match the configured response language.
             Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
-            Start every suggestion body with this exact hidden marker on the first line: <!-- pr-agent-inline-comment -->.
+            Start every suggestion body with this exact hidden marker on the first line: <!-- pr-agent-inline-comment:${{ github.run_id }} -->.
             Start every suggestion body with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
@@ -396,6 +396,7 @@ jobs:
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
           BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
           BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
+          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
         run: |
           set -euo pipefail
           current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
@@ -417,6 +418,7 @@ jobs:
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
           import json
+          import os
           import re
           import sys
           from pathlib import Path
@@ -427,14 +429,17 @@ jobs:
           reviews_path = Path(sys.argv[4])
           delete_path = Path(sys.argv[5])
           head_sha = sys.argv[6]
-          pr_agent_marker_re = re.compile(
-              r"^\s*<!-- pr-agent-inline-comment -->\s*"
-              r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+          pr_agent_inline_marker = os.environ.get("PR_AGENT_INLINE_MARKER") or "<!-- pr-agent-inline-comment -->"
+          risk_prefix_re = re.compile(
+              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
               re.IGNORECASE,
           )
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              return bool(pr_agent_marker_re.search(item.get("body") or ""))
+              body = (item.get("body") or "").lstrip()
+              if not body.startswith(pr_agent_inline_marker):
+                  return False
+              return bool(risk_prefix_re.search(body[len(pr_agent_inline_marker):].lstrip()))
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -444,6 +449,7 @@ jobs:
               if (
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_review_ids
+                  and item.get("commit_id") == head_sha
               ):
                   new_review_ids.add(item["id"])
 
@@ -455,6 +461,7 @@ jobs:
               if (
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_ids
+                  and item.get("commit_id") == head_sha
                   and item.get("pull_request_review_id") in new_review_ids
                   and is_pr_agent_suggestion(item)
               ):
@@ -502,6 +509,7 @@ jobs:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
           SUMMARY_MODEL: gpt-5.5
+          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
         run: |
           set -euo pipefail
           before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
@@ -528,6 +536,7 @@ jobs:
 
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${review_data}" "${HEAD_SHA}" "${pr_url}" "${commit_url}" "${short_sha}" <<'PY'
           import json
+          import os
           import re
           import sys
           from pathlib import Path
@@ -541,18 +550,23 @@ jobs:
           pr_url = sys.argv[7]
           commit_url = sys.argv[8]
           short_sha = sys.argv[9]
-          pr_agent_marker_re = re.compile(
-              r"^\s*<!-- pr-agent-inline-comment -->\s*"
-              r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+          pr_agent_inline_marker = os.environ.get("PR_AGENT_INLINE_MARKER") or "<!-- pr-agent-inline-comment -->"
+          risk_prefix_re = re.compile(
+              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
               re.IGNORECASE,
           )
 
           def normalize_suggestion_body(body: str) -> str:
-              return re.sub(r"^\s*<!-- pr-agent-inline-comment -->\s*", "", body or "").strip()
+              stripped = (body or "").lstrip()
+              if stripped.startswith(pr_agent_inline_marker):
+                  return stripped[len(pr_agent_inline_marker):].lstrip()
+              return stripped.strip()
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              body = item.get("body") or ""
-              return bool(pr_agent_marker_re.search(body))
+              body = (item.get("body") or "").lstrip()
+              if not body.startswith(pr_agent_inline_marker):
+                  return False
+              return bool(risk_prefix_re.search(body[len(pr_agent_inline_marker):].lstrip()))
 
           comments = []
           for line in comments_path.read_text().splitlines():
@@ -719,8 +733,11 @@ jobs:
             exit 0
           fi
 
-          new_comment_id="$(gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" --jq '.id')"
-          comment_ids="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.id != ${new_comment_id} and .user.login == \"github-actions[bot]\" and ((.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) or (.body | startswith(\"<!-- pr-agent-update-notification -->\")))) | .id")"
+          new_comment="$(mktemp)"
+          gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" > "${new_comment}"
+          new_comment_id="$(jq -r '.id' "${new_comment}")"
+          new_comment_created_at="$(jq -r '.created_at' "${new_comment}")"
+          comment_ids="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.id != ${new_comment_id} and .user.login == \"github-actions[bot]\" and ((.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) or (.body | startswith(\"<!-- pr-agent-update-notification -->\"))) and (.created_at < \"${new_comment_created_at}\" or (.created_at == \"${new_comment_created_at}\" and .id < ${new_comment_id}))) | .id")"
 
           if [ -z "${comment_ids}" ]; then
             echo "No previous PR-Agent code review summary to clean."

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -476,7 +476,9 @@ jobs:
           fi
           while IFS= read -r comment_id || [ -n "${comment_id}" ]; do
             [ -z "${comment_id}" ] && continue
-            gh api --method DELETE "repos/${REPO}/pulls/comments/${comment_id}" >/dev/null
+            if ! gh api --method DELETE "repos/${REPO}/pulls/comments/${comment_id}" >/dev/null 2>&1; then
+              echo "PR-Agent inline comment ${comment_id} was already removed; continue."
+            fi
           done < "${delete_ids}"
 
       - name: Publish PR-Agent code review summary
@@ -746,7 +748,9 @@ jobs:
 
           while IFS= read -r comment_id; do
             [ -z "${comment_id}" ] && continue
-            gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null
+            if ! gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null 2>&1; then
+              echo "PR-Agent summary comment ${comment_id} was already removed; continue."
+            fi
           done <<< "${comment_ids}"
 
       - name: Restore PR-Agent description markers on failure

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -48,7 +48,7 @@ jobs:
         )
       )
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name == 'issue_comment' && (github.event.comment.body == '/ask' || startsWith(github.event.comment.body, '/ask ')) && github.event.comment.id || 'write' }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name == 'issue_comment' && github.event.comment.id || 'auto' }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -202,10 +202,12 @@ jobs:
           cp "${next_body}" "${placeholder_body}"
 
           body_changed=false
+          can_describe=true
           if ! cmp -s "${current_body}" "${next_body}"; then
             gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${latest_body}"
             if ! cmp -s "${current_body}" "${latest_body}"; then
               echo "PR body changed while preparing PR-Agent markers; skip placeholder update."
+              can_describe=false
             else
               python3 - "${next_body}" "${payload}" <<'PY'
           import json
@@ -220,6 +222,7 @@ jobs:
             fi
           fi
           echo "body_changed=${body_changed}" >> "${GITHUB_OUTPUT}"
+          echo "can_describe=${can_describe}" >> "${GITHUB_OUTPUT}"
 
       - name: Check PR head before PR-Agent
         id: pragent_head
@@ -253,15 +256,55 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
           EVENT_NAME: ${{ github.event_name }}
+          CAN_DESCRIBE: ${{ steps.prepare_description.outputs.can_describe }}
         run: |
           set -euo pipefail
+          can_describe="${CAN_DESCRIBE:-true}"
           should_improve=true
           push_commands='["/describe", "/improve"]'
+          if [ "${can_describe}" = "false" ]; then
+            push_commands='["/improve"]'
+          fi
           if [ "${EVENT_NAME}" = "pull_request_target" ]; then
             existing_summary_id="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) and (.body | contains(\"/commit/${RUN_HEAD_SHA}\"))) | .id" | tail -n 1)"
-            if [ -n "${existing_summary_id}" ]; then
+            existing_inline_id=""
+            if [ -z "${existing_summary_id}" ]; then
+              comments="$(mktemp)"
+              gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | @json' > "${comments}"
+              existing_inline_id="$(python3 - "${comments}" "${RUN_HEAD_SHA}" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          comments_path = Path(sys.argv[1])
+          head_sha = sys.argv[2]
+          marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
+
+          def is_pr_agent_suggestion(body: str) -> bool:
+              return bool(marker_re.search(body or ""))
+
+          for line in comments_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("commit_id") == head_sha
+                  and is_pr_agent_suggestion(item.get("body") or "")
+              ):
+                  print(item.get("id") or "")
+                  break
+          PY
+              )"
+            fi
+            if [ -n "${existing_summary_id}" ] || [ -n "${existing_inline_id}" ]; then
               should_improve=false
-              push_commands='["/describe"]'
+              if [ "${can_describe}" = "false" ]; then
+                push_commands='[]'
+              else
+                push_commands='["/describe"]'
+              fi
               echo "PR-Agent code review summary already exists for ${RUN_HEAD_SHA}; skip duplicate inline review."
             fi
           fi
@@ -306,7 +349,15 @@ jobs:
         if: >-
           steps.pr_language.outputs.skip_pr_agent != 'true' &&
           steps.run_state.outputs.is_stale != 'true' &&
-          steps.pragent_head.outputs.is_stale != 'true'
+          steps.pragent_head.outputs.is_stale != 'true' &&
+          !(
+            steps.prepare_description.outputs.can_describe == 'false' &&
+            github.event_name == 'issue_comment' &&
+            (
+              github.event.comment.body == '/describe' ||
+              startsWith(github.event.comment.body, '/describe ')
+            )
+          )
         timeout-minutes: 40
         # 使用版本号加 digest 固定容器构建，避免 tag 被重推后改变运行内容。
         uses: docker://pragent/pr-agent:0.39.0-github_action@sha256:b253845caa8c7ff5ce8be78f32996647982bdd4890826a962b78eff2e385a825
@@ -333,7 +384,7 @@ jobs:
 
           # PR 初次进入评审或后续 push 时，更新 PR 摘要并发布 GitHub Review 行内建议。
           github_action_config.auto_review: "false"
-          github_action_config.auto_describe: "true"
+          github_action_config.auto_describe: ${{ steps.prepare_description.outputs.can_describe != 'false' }}
           github_action_config.auto_improve: ${{ steps.review_history.outputs.should_improve }}
 
           # synchronize 由 push_commands 单独处理；每次 push 更新摘要和行内 Review，旧行评由 GitHub 标记 outdated。
@@ -380,6 +431,96 @@ jobs:
           # github_action_config.auto_improve: "true"
           # config.verbosity_level: "1"
 
+      - name: Mark PR-Agent inline comments
+        if: >-
+          always() &&
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true' &&
+          steps.pragent_head.outputs.is_stale != 'true' &&
+          steps.inline_state_before.outputs.inline_ids_b64 != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
+          BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
+          BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
+          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
+        run: |
+          set -euo pipefail
+          before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
+          before_review_ids="$(printf '%s' "${BEFORE_REVIEW_IDS_B64:-W10=}" | base64 -d)"
+          comments="$(mktemp)"
+          reviews="$(mktemp)"
+          patches="$(mktemp)"
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | @json' > "${comments}"
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
+          python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${patches}" "${RUN_HEAD_SHA}" <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          before_ids = set(json.loads(sys.argv[1] or "[]"))
+          before_review_ids = set(json.loads(sys.argv[2] or "[]"))
+          comments_path = Path(sys.argv[3])
+          reviews_path = Path(sys.argv[4])
+          patches_path = Path(sys.argv[5])
+          head_sha = sys.argv[6]
+          marker = os.environ["PR_AGENT_INLINE_MARKER"]
+          marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
+
+          new_review_ids = set()
+          for line in reviews_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("id") not in before_review_ids
+                  and item.get("commit_id") == head_sha
+              ):
+                  new_review_ids.add(item["id"])
+
+          patches = []
+          for line in comments_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              body = item.get("body") or ""
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("id") not in before_ids
+                  and item.get("commit_id") == head_sha
+                  and item.get("pull_request_review_id") in new_review_ids
+                  and body.strip()
+                  and not marker_re.search(body)
+              ):
+                  patches.append({"id": item["id"], "body": f"{marker}\n{body}"})
+
+          patches_path.write_text("\n".join(json.dumps(item, ensure_ascii=False) for item in patches))
+          PY
+
+          if [ ! -s "${patches}" ]; then
+            echo "No PR-Agent inline comments to mark."
+            exit 0
+          fi
+          patch_failed=false
+          while IFS= read -r patch || [ -n "${patch}" ]; do
+            [ -z "${patch}" ] && continue
+            comment_id="$(printf '%s' "${patch}" | jq -r '.id')"
+            payload="$(mktemp)"
+            printf '%s' "${patch}" | jq '{body:.body}' > "${payload}"
+            if ! gh api --method PATCH "repos/${REPO}/pulls/comments/${comment_id}" --input "${payload}" >/dev/null 2>&1; then
+              echo "PR-Agent inline comment ${comment_id} could not be marked."
+              patch_failed=true
+            fi
+          done < "${patches}"
+          if [ "${patch_failed}" = "true" ]; then
+            exit 1
+          fi
+
       - name: Clean stale PR-Agent inline comments
         id: post_pragent_state
         if: >-
@@ -395,6 +536,7 @@ jobs:
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
           BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
           BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
+          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
         run: |
           set -euo pipefail
           current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
@@ -416,7 +558,7 @@ jobs:
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
           import json
-          import re
+          import os
           import sys
           from pathlib import Path
 
@@ -426,20 +568,10 @@ jobs:
           reviews_path = Path(sys.argv[4])
           delete_path = Path(sys.argv[5])
           head_sha = sys.argv[6]
-          risk_prefix_re = re.compile(
-              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
-              re.IGNORECASE,
-          )
-          marker_re = re.compile(
-              r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*",
-              re.IGNORECASE,
-          )
-
-          def normalize_suggestion_body(body: str) -> str:
-              return marker_re.sub("", body or "", count=1).strip()
+          marker = os.environ["PR_AGENT_INLINE_MARKER"]
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              return bool(risk_prefix_re.search(normalize_suggestion_body(item.get("body") or "")))
+              return (item.get("body") or "").lstrip().startswith(marker)
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -511,6 +643,7 @@ jobs:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
           SUMMARY_MODEL: gpt-5.5
+          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
         run: |
           set -euo pipefail
           before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
@@ -551,12 +684,9 @@ jobs:
           pr_url = sys.argv[7]
           commit_url = sys.argv[8]
           short_sha = sys.argv[9]
+          marker = os.environ["PR_AGENT_INLINE_MARKER"]
           marker_re = re.compile(
               r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*",
-              re.IGNORECASE,
-          )
-          risk_prefix_re = re.compile(
-              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
               re.IGNORECASE,
           )
 
@@ -564,8 +694,7 @@ jobs:
               return marker_re.sub("", body or "", count=1).strip()
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              body = normalize_suggestion_body(item.get("body") or "")
-              return bool(risk_prefix_re.search(body))
+              return (item.get("body") or "").lstrip().startswith(marker)
 
           comments = []
           for line in comments_path.read_text().splitlines():

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -216,37 +216,6 @@ jobs:
           inline_ids_b64="$(printf '%s' "${inline_ids}" | base64 -w0)"
           echo "inline_ids_b64=${inline_ids_b64}" >> "${GITHUB_OUTPUT}"
 
-      - name: Clean previous PR-Agent code review summary
-        if: >-
-          steps.pr_language.outputs.skip_pr_agent != 'true' &&
-          (
-            github.event_name == 'pull_request_target' ||
-            (
-              github.event_name == 'issue_comment' &&
-              (
-                github.event.comment.body == '/improve' ||
-                startsWith(github.event.comment.body, '/improve ')
-              )
-            )
-          )
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-        run: |
-          set -euo pipefail
-          comment_ids="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq '.[] | select(.user.login == "github-actions[bot]" and ((.body | startswith("<!-- pr-agent-code-review-summary -->")) or (.body | startswith("<!-- pr-agent-update-notification -->")))) | .id')"
-
-          if [ -z "${comment_ids}" ]; then
-            echo "No previous PR-Agent code review summary to clean."
-            exit 0
-          fi
-
-          while IFS= read -r comment_id; do
-            [ -z "${comment_id}" ] && continue
-            gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null
-          done <<< "${comment_ids}"
-
       - name: Run PR-Agent
         id: pragent
         if: steps.pr_language.outputs.skip_pr_agent != 'true'
@@ -524,7 +493,18 @@ jobs:
           payload_path.write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY
 
-          gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" >/dev/null
+          new_comment_id="$(gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" --jq '.id')"
+          comment_ids="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.id != ${new_comment_id} and .user.login == \"github-actions[bot]\" and ((.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) or (.body | startswith(\"<!-- pr-agent-update-notification -->\")))) | .id")"
+
+          if [ -z "${comment_ids}" ]; then
+            echo "No previous PR-Agent code review summary to clean."
+            exit 0
+          fi
+
+          while IFS= read -r comment_id; do
+            [ -z "${comment_id}" ] && continue
+            gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null
+          done <<< "${comment_ids}"
 
       - name: Restore PR-Agent description markers on failure
         if: >-

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -323,7 +323,7 @@ jobs:
           pr_code_suggestions.extra_instructions: |
             Match the configured response language.
             Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
-            For prioritized issues, start the suggestion body with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
+            Start every suggestion body with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
           pr_code_suggestions.num_code_suggestions_per_chunk: "2"
@@ -374,16 +374,19 @@ jobs:
           comments_path = Path(sys.argv[2])
           delete_path = Path(sys.argv[3])
           head_sha = sys.argv[4]
+          risk_prefixes = ("🔴 **High Risk**:", "🟡 **Medium Risk**:", "🔵 **Low Risk**:")
 
           delete_ids = []
           for line in comments_path.read_text().splitlines():
               if not line.strip():
                   continue
               item = json.loads(line)
+              body = (item.get("body") or "").lstrip()
               if (
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_ids
                   and item.get("commit_id") == head_sha
+                  and body.startswith(risk_prefixes)
               ):
                   delete_ids.append(str(item["id"]))
 
@@ -458,6 +461,7 @@ jobs:
           pr_url = sys.argv[5]
           commit_url = sys.argv[6]
           short_sha = sys.argv[7]
+          risk_prefixes = ("🔴 **High Risk**:", "🟡 **Medium Risk**:", "🔵 **Low Risk**:")
 
           comments = []
           for line in comments_path.read_text().splitlines():
@@ -469,6 +473,7 @@ jobs:
               if item.get("user", {}).get("login") == "github-actions[bot]"
               and item.get("id") not in before_ids
               and item.get("commit_id") == head_sha
+              and (item.get("body") or "").lstrip().startswith(risk_prefixes)
           ]
           suggestions = []
           for item in new_comments:
@@ -632,7 +637,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
         run: |
           set -euo pipefail
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
@@ -646,13 +650,8 @@ jobs:
           fi
 
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
-          current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
-          is_stale=false
-          if [ -n "${RUN_HEAD_SHA}" ] && [ "${current_head_sha}" != "${RUN_HEAD_SHA}" ]; then
-            is_stale=true
-          fi
 
-          python3 - "${body_backup}" "${placeholder_body}" "${current_body}" "${payload}" "${is_stale}" <<'PY'
+          python3 - "${body_backup}" "${placeholder_body}" "${current_body}" "${payload}" <<'PY'
           import json
           import re
           import sys
@@ -662,7 +661,6 @@ jobs:
           placeholder_body = Path(sys.argv[2]).read_text()
           current_body = Path(sys.argv[3]).read_text()
           payload_path = Path(sys.argv[4])
-          is_stale = sys.argv[5] == "true"
 
           start = "<!-- pr-agent-summary:start -->"
           end = "<!-- pr-agent-summary:end -->"
@@ -692,10 +690,10 @@ jobs:
 
           current_section = current_body[current_block[0]:current_block[1]]
           placeholder_section = placeholder_body[placeholder_block[0]:placeholder_block[1]]
-          if "pr_agent:summary" not in current_section and not is_stale:
+          if "pr_agent:summary" not in current_section:
               print("No visible PR-Agent summary placeholder to restore.")
               raise SystemExit(0)
-          if current_section != placeholder_section and not is_stale:
+          if current_section != placeholder_section:
               print("Current PR-Agent summary block changed; skip restore.")
               raise SystemExit(0)
 

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -51,7 +51,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - name: Detect PR review language
         id: pr_language
@@ -59,12 +59,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           pr_info="$(mktemp)"
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "${pr_info}"
           python3 - "${pr_info}" >> "${GITHUB_OUTPUT}" <<'PY'
           import json
+          import os
           import re
           import sys
           from pathlib import Path
@@ -74,7 +76,7 @@ jobs:
           body = pr.get("body") or ""
           labels = {item.get("name", "") for item in pr.get("labels") or []}
           skip_pr_agent = "true" if "skip pr-agent" in labels or re.search(r"^(?:\[Auto\]|Auto)", title) else "false"
-          head_sha = pr.get("head", {}).get("sha") or ""
+          head_sha = os.environ.get("EVENT_HEAD_SHA") or pr.get("head", {}).get("sha") or ""
 
           body = re.sub(
               r"\n*##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -155,6 +155,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           SUMMARY_HEADING: ${{ steps.pr_language.outputs.summary_heading }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
         run: |
           set -euo pipefail
           current_body="$(mktemp)"
@@ -179,7 +180,9 @@ jobs:
           end = "<!-- pr-agent-summary:end -->"
           placeholder = "pr_agent:summary"
           summary_heading = os.environ.get("SUMMARY_HEADING") or "PR-Agent 摘要"
-          agent_block = f"## {summary_heading}\n\n{start}\n{placeholder}\n{end}\n"
+          run_head_sha = os.environ.get("RUN_HEAD_SHA") or ""
+          run_marker = f"<!-- pr-agent-run-head:{run_head_sha} -->\n" if run_head_sha else ""
+          agent_block = f"## {summary_heading}\n\n{start}\n{run_marker}{placeholder}\n{end}\n"
           body = re.sub(
               r"(?im)^##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*(?=<!-- pr-agent-summary:start -->)",
               f"## {summary_heading}\n\n",
@@ -189,7 +192,7 @@ jobs:
           start_index = body.find(start)
           end_index = body.find(end)
           if start_index >= 0 and end_index > start_index:
-              next_body = body[: start_index + len(start)] + f"\n{placeholder}\n" + body[end_index:]
+              next_body = body[: start_index + len(start)] + f"\n{run_marker}{placeholder}\n" + body[end_index:]
           else:
               separator = "\n\n" if body.strip() else ""
               next_body = body.rstrip() + separator + agent_block
@@ -253,6 +256,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
         run: |
           set -euo pipefail
           inline_ids="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | select(.user.login == "github-actions[bot]") | .id' | jq -sc '.')"
@@ -688,8 +692,13 @@ jobs:
           fi
 
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
+          current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          is_stale=false
+          if [ -n "${RUN_HEAD_SHA}" ] && [ "${current_head_sha}" != "${RUN_HEAD_SHA}" ]; then
+            is_stale=true
+          fi
 
-          python3 - "${body_backup}" "${placeholder_body}" "${current_body}" "${payload}" <<'PY'
+          python3 - "${body_backup}" "${placeholder_body}" "${current_body}" "${payload}" "${RUN_HEAD_SHA}" "${is_stale}" <<'PY'
           import json
           import re
           import sys
@@ -699,9 +708,12 @@ jobs:
           placeholder_body = Path(sys.argv[2]).read_text()
           current_body = Path(sys.argv[3]).read_text()
           payload_path = Path(sys.argv[4])
+          run_head_sha = sys.argv[5]
+          is_stale = sys.argv[6] == "true"
 
           start = "<!-- pr-agent-summary:start -->"
           end = "<!-- pr-agent-summary:end -->"
+          run_marker = f"<!-- pr-agent-run-head:{run_head_sha} -->" if run_head_sha else ""
           heading_re = re.compile(r"(?im)^##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*")
 
           def find_block(body: str) -> tuple[int, int] | None:
@@ -728,11 +740,20 @@ jobs:
 
           current_section = current_body[current_block[0]:current_block[1]]
           placeholder_section = placeholder_body[placeholder_block[0]:placeholder_block[1]]
-          if "pr_agent:summary" not in current_section:
+          current_has_marker = bool(run_marker and run_marker in current_section)
+          current_has_placeholder = "pr_agent:summary" in current_section
+          if not current_has_placeholder and not current_has_marker:
               print("No visible PR-Agent summary placeholder to restore.")
               raise SystemExit(0)
-          if current_section != placeholder_section:
+          if current_has_placeholder and current_section != placeholder_section:
               print("Current PR-Agent summary block changed; skip restore.")
+              raise SystemExit(0)
+
+          if current_has_marker and not current_has_placeholder and not is_stale:
+              next_section = current_section.replace(f"{run_marker}\n", "").replace(run_marker, "")
+              next_body = current_body[:current_block[0]] + next_section + current_body[current_block[1]:]
+              next_body = re.sub(r"\n{4,}", "\n\n\n", next_body).rstrip() + "\n"
+              payload_path.write_text(json.dumps({"body": next_body}, ensure_ascii=False))
               raise SystemExit(0)
 
           restored_section = backup_body[backup_block[0]:backup_block[1]] if backup_block else ""

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -427,7 +427,8 @@ jobs:
           pr_code_suggestions.extra_instructions: |
             Match the configured response language.
             Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
-            Start every suggestion body with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
+            Start every suggestion body with this hidden ownership marker on its own first line: <!-- pr-agent-inline-comment:${{ github.run_id }} -->
+            Then start the visible suggestion text with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
           pr_code_suggestions.num_code_suggestions_per_chunk: "2"
@@ -478,6 +479,14 @@ jobs:
           head_sha = sys.argv[6]
           marker = os.environ["PR_AGENT_INLINE_MARKER"]
           marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
+          risk_prefix_re = re.compile(
+              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
+
+          def looks_like_pr_agent_suggestion(body: str) -> bool:
+              body = marker_re.sub("", body or "", count=1).lstrip()
+              return bool(risk_prefix_re.search(body))
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -504,6 +513,7 @@ jobs:
                   and item.get("pull_request_review_id") in new_review_ids
                   and body.strip()
                   and not marker_re.search(body)
+                  and looks_like_pr_agent_suggestion(body)
               ):
                   patches.append({"id": item["id"], "body": f"{marker}\n{body}"})
 
@@ -630,7 +640,10 @@ jobs:
           (
             (
               github.event_name == 'pull_request_target' &&
-              steps.review_history.outputs.should_improve == 'true'
+              (
+                steps.review_history.outputs.should_improve == 'true' ||
+                steps.review_history.outputs.should_publish_existing_summary == 'true'
+              )
             ) ||
             (
               github.event_name == 'issue_comment' &&

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -93,9 +93,8 @@ jobs:
           )
           body = re.sub(r"```.*?```", " ", body, flags=re.DOTALL)
 
-          text = f"{title}\n{body}"
-          cjk_count = len(re.findall(r"[\u4e00-\u9fff]", text))
-          latin_words = len(re.findall(r"\b[A-Za-z][A-Za-z]{2,}\b", text))
+          cjk_count = len(re.findall(r"[\u4e00-\u9fff]", body))
+          latin_words = len(re.findall(r"\b[A-Za-z][A-Za-z]{2,}\b", body))
 
           if cjk_count >= 4:
               response_language = "zh-CN"
@@ -236,6 +235,33 @@ jobs:
           fi
           echo "is_stale=${is_stale}" >> "${GITHUB_OUTPUT}"
 
+      - name: Check existing PR-Agent review summary
+        id: review_history
+        if: >-
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true' &&
+          steps.pragent_head.outputs.is_stale != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          should_improve=true
+          push_commands='["/describe", "/improve"]'
+          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+            existing_summary_id="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) and (.body | contains(\"/commit/${RUN_HEAD_SHA}\"))) | .id" | tail -n 1)"
+            if [ -n "${existing_summary_id}" ]; then
+              should_improve=false
+              push_commands='["/describe"]'
+              echo "PR-Agent code review summary already exists for ${RUN_HEAD_SHA}; skip duplicate inline review."
+            fi
+          fi
+          echo "should_improve=${should_improve}" >> "${GITHUB_OUTPUT}"
+          echo "push_commands=${push_commands}" >> "${GITHUB_OUTPUT}"
+
       - name: Snapshot PR-Agent review state
         id: inline_state_before
         if: >-
@@ -243,7 +269,10 @@ jobs:
           steps.run_state.outputs.is_stale != 'true' &&
           steps.pragent_head.outputs.is_stale != 'true' &&
           (
-            github.event_name == 'pull_request_target' ||
+            (
+              github.event_name == 'pull_request_target' &&
+              steps.review_history.outputs.should_improve == 'true'
+            ) ||
             (
               github.event_name == 'issue_comment' &&
               (
@@ -298,12 +327,12 @@ jobs:
           # PR 初次进入评审或后续 push 时，更新 PR 摘要并发布 GitHub Review 行内建议。
           github_action_config.auto_review: "false"
           github_action_config.auto_describe: "true"
-          github_action_config.auto_improve: "true"
+          github_action_config.auto_improve: ${{ steps.review_history.outputs.should_improve }}
 
           # synchronize 由 push_commands 单独处理；每次 push 更新摘要和行内 Review，旧行评由 GitHub 标记 outdated。
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'
           github_action_config.handle_push_trigger: "true"
-          github_action_config.push_commands: '["/describe", "/improve"]'
+          github_action_config.push_commands: ${{ steps.review_history.outputs.push_commands }}
 
           # 保留 action outputs，便于后续 workflow 编排或排查。
           github_action_config.enable_output: "true"
@@ -380,6 +409,7 @@ jobs:
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
           import json
+          import re
           import sys
           from pathlib import Path
 
@@ -389,6 +419,14 @@ jobs:
           reviews_path = Path(sys.argv[4])
           delete_path = Path(sys.argv[5])
           head_sha = sys.argv[6]
+          risk_prefix_re = re.compile(
+              r"^\s*(?:<!-- pr-agent-inline-comment -->\s*)?"
+              r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
+
+          def is_pr_agent_suggestion(item: dict) -> bool:
+              return bool(risk_prefix_re.search(item.get("body") or ""))
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -412,6 +450,7 @@ jobs:
                   and item.get("id") not in before_ids
                   and item.get("commit_id") == head_sha
                   and item.get("pull_request_review_id") in new_review_ids
+                  and is_pr_agent_suggestion(item)
               ):
                   delete_ids.append(str(item["id"]))
 
@@ -434,7 +473,10 @@ jobs:
           steps.pragent_head.outputs.is_stale != 'true' &&
           steps.post_pragent_state.outputs.is_stale != 'true' &&
           (
-            github.event_name == 'pull_request_target' ||
+            (
+              github.event_name == 'pull_request_target' &&
+              steps.review_history.outputs.should_improve == 'true'
+            ) ||
             (
               github.event_name == 'issue_comment' &&
               (
@@ -480,6 +522,7 @@ jobs:
 
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${review_data}" "${HEAD_SHA}" "${pr_url}" "${commit_url}" "${short_sha}" <<'PY'
           import json
+          import re
           import sys
           from pathlib import Path
 
@@ -492,6 +535,17 @@ jobs:
           pr_url = sys.argv[7]
           commit_url = sys.argv[8]
           short_sha = sys.argv[9]
+          risk_prefix_re = re.compile(
+              r"^\s*(?:<!-- pr-agent-inline-comment -->\s*)?"
+              r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
+
+          def normalize_suggestion_body(body: str) -> str:
+              return re.sub(r"^\s*<!-- pr-agent-inline-comment -->\s*", "", body or "").strip()
+
+          def is_pr_agent_suggestion(item: dict) -> bool:
+              return bool(risk_prefix_re.search(item.get("body") or ""))
 
           comments = []
           for line in comments_path.read_text().splitlines():
@@ -516,10 +570,11 @@ jobs:
               and item.get("id") not in before_ids
               and item.get("commit_id") == head_sha
               and item.get("pull_request_review_id") in new_review_ids
+              and is_pr_agent_suggestion(item)
           ]
           suggestions = []
           for item in new_comments:
-              body = (item.get("body") or "").strip()
+              body = normalize_suggestion_body(item.get("body") or "")
               first_line = next((line.strip() for line in body.splitlines() if line.strip()), "")
               suggestions.append({
                   "path": item.get("path"),
@@ -634,7 +689,7 @@ jobs:
                       data = json.loads(response.read().decode("utf-8"))
                   content = data["choices"][0]["message"]["content"].strip()
                   return content or None
-              except (KeyError, TimeoutError, urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError):
+              except (KeyError, IndexError, TypeError, TimeoutError, urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError):
                   return None
 
           summary = llm_summary() or fallback_summary()

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -430,9 +430,16 @@ jobs:
               r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
               re.IGNORECASE,
           )
+          marker_re = re.compile(
+              r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*",
+              re.IGNORECASE,
+          )
+
+          def normalize_suggestion_body(body: str) -> str:
+              return marker_re.sub("", body or "", count=1).strip()
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              return bool(risk_prefix_re.search((item.get("body") or "").lstrip()))
+              return bool(risk_prefix_re.search(normalize_suggestion_body(item.get("body") or "")))
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -503,6 +503,11 @@ jobs:
           patches_path = Path(sys.argv[5])
           marker = os.environ["PR_AGENT_INLINE_MARKER"]
           marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
+          risk_prefixes = ("🔴 **High Risk**:", "🟡 **Medium Risk**:", "🔵 **Low Risk**:")
+
+          def is_pr_agent_inline_body(body: str) -> bool:
+              visible = (body or "").lstrip()
+              return visible.startswith("**Suggestion:**") or visible.startswith(risk_prefixes)
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -525,7 +530,7 @@ jobs:
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_ids
                   and item.get("pull_request_review_id") in new_review_ids
-                  and body.lstrip().startswith("**Suggestion:**")
+                  and is_pr_agent_inline_body(body)
                   and not marker_re.search(body)
               ):
                   patches.append({"id": item["id"], "body": f"{marker}\n{body}"})
@@ -951,7 +956,6 @@ jobs:
       - name: Restore PR-Agent description markers on failure
         if: >-
           always() &&
-          steps.prepare_description.outputs.body_changed == 'true' &&
           steps.pr_language.outputs.skip_pr_agent != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -968,7 +972,7 @@ jobs:
           payload="$(mktemp)"
           etag_file="$(mktemp)"
 
-          if [ ! -s "${body_backup}" ] || [ ! -s "${placeholder_body}" ]; then
+          if [ ! -e "${body_backup}" ] || [ ! -s "${placeholder_body}" ]; then
             echo "No PR body backup found."
             exit 0
           fi
@@ -1039,7 +1043,11 @@ jobs:
               payload_path.write_text(json.dumps({"body": next_body}, ensure_ascii=False))
               raise SystemExit(0)
 
-          restored_section = backup_body[backup_block[0]:backup_block[1]] if backup_block else ""
+          restored_section = ""
+          if backup_block:
+              backup_section = backup_body[backup_block[0]:backup_block[1]]
+              if "pr_agent:summary" not in backup_section:
+                  restored_section = backup_section
           next_body = current_body[:current_block[0]] + restored_section + current_body[current_block[1]:]
           next_body = re.sub(r"\n{4,}", "\n\n\n", next_body).rstrip() + "\n"
           payload_path.write_text(json.dumps({"body": next_body}, ensure_ascii=False))

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -233,7 +233,7 @@ jobs:
           fi
           echo "is_stale=${is_stale}" >> "${GITHUB_OUTPUT}"
 
-      - name: Snapshot PR-Agent inline comments
+      - name: Snapshot PR-Agent review state
         id: inline_state_before
         if: >-
           steps.pr_language.outputs.skip_pr_agent != 'true' &&
@@ -257,7 +257,10 @@ jobs:
           set -euo pipefail
           inline_ids="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | select(.user.login == "github-actions[bot]") | .id' | jq -sc '.')"
           inline_ids_b64="$(printf '%s' "${inline_ids}" | base64 -w0)"
+          review_ids="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | select(.user.login == "github-actions[bot]") | .id' | jq -sc '.')"
+          review_ids_b64="$(printf '%s' "${review_ids}" | base64 -w0)"
           echo "inline_ids_b64=${inline_ids_b64}" >> "${GITHUB_OUTPUT}"
+          echo "review_ids_b64=${review_ids_b64}" >> "${GITHUB_OUTPUT}"
 
       - name: Run PR-Agent
         id: pragent
@@ -351,6 +354,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
           BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
+          BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
         run: |
           set -euo pipefail
           current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
@@ -364,31 +368,46 @@ jobs:
           fi
 
           before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
+          before_review_ids="$(printf '%s' "${BEFORE_REVIEW_IDS_B64:-W10=}" | base64 -d)"
           comments="$(mktemp)"
+          reviews="$(mktemp)"
           delete_ids="$(mktemp)"
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | @json' > "${comments}"
-          python3 - "${before_ids}" "${comments}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
+          python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
           import json
           import sys
           from pathlib import Path
 
           before_ids = set(json.loads(sys.argv[1] or "[]"))
-          comments_path = Path(sys.argv[2])
-          delete_path = Path(sys.argv[3])
-          head_sha = sys.argv[4]
-          risk_prefixes = ("🔴 **High Risk**:", "🟡 **Medium Risk**:", "🔵 **Low Risk**:")
+          before_review_ids = set(json.loads(sys.argv[2] or "[]"))
+          comments_path = Path(sys.argv[3])
+          reviews_path = Path(sys.argv[4])
+          delete_path = Path(sys.argv[5])
+          head_sha = sys.argv[6]
+
+          new_review_ids = set()
+          for line in reviews_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("id") not in before_review_ids
+                  and item.get("commit_id") == head_sha
+              ):
+                  new_review_ids.add(item["id"])
 
           delete_ids = []
           for line in comments_path.read_text().splitlines():
               if not line.strip():
                   continue
               item = json.loads(line)
-              body = (item.get("body") or "").lstrip()
               if (
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_ids
                   and item.get("commit_id") == head_sha
-                  and body.startswith(risk_prefixes)
+                  and item.get("pull_request_review_id") in new_review_ids
               ):
                   delete_ids.append(str(item["id"]))
 
@@ -425,6 +444,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
+          BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
           SUMMARY_LANGUAGE: ${{ steps.pr_language.outputs.summary_language }}
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
@@ -433,8 +453,10 @@ jobs:
         run: |
           set -euo pipefail
           before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
+          before_review_ids="$(printf '%s' "${BEFORE_REVIEW_IDS_B64:-W10=}" | base64 -d)"
           pr_info="$(mktemp)"
           comments="$(mktemp)"
+          reviews="$(mktemp)"
           review_data="$(mktemp)"
           payload="$(mktemp)"
 
@@ -450,32 +472,46 @@ jobs:
           commit_url="https://github.com/${REPO}/commit/${HEAD_SHA}"
 
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | @json' > "${comments}"
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
 
-          python3 - "${before_ids}" "${comments}" "${review_data}" "${HEAD_SHA}" "${pr_url}" "${commit_url}" "${short_sha}" <<'PY'
+          python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${review_data}" "${HEAD_SHA}" "${pr_url}" "${commit_url}" "${short_sha}" <<'PY'
           import json
           import sys
           from pathlib import Path
 
           before_ids = set(json.loads(sys.argv[1] or "[]"))
-          comments_path = Path(sys.argv[2])
-          output_path = Path(sys.argv[3])
-          head_sha = sys.argv[4]
-          pr_url = sys.argv[5]
-          commit_url = sys.argv[6]
-          short_sha = sys.argv[7]
-          risk_prefixes = ("🔴 **High Risk**:", "🟡 **Medium Risk**:", "🔵 **Low Risk**:")
+          before_review_ids = set(json.loads(sys.argv[2] or "[]"))
+          comments_path = Path(sys.argv[3])
+          reviews_path = Path(sys.argv[4])
+          output_path = Path(sys.argv[5])
+          head_sha = sys.argv[6]
+          pr_url = sys.argv[7]
+          commit_url = sys.argv[8]
+          short_sha = sys.argv[9]
 
           comments = []
           for line in comments_path.read_text().splitlines():
               if line.strip():
                   comments.append(json.loads(line))
 
+          new_review_ids = set()
+          for line in reviews_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("id") not in before_review_ids
+                  and item.get("commit_id") == head_sha
+              ):
+                  new_review_ids.add(item["id"])
+
           new_comments = [
               item for item in comments
               if item.get("user", {}).get("login") == "github-actions[bot]"
               and item.get("id") not in before_ids
               and item.get("commit_id") == head_sha
-              and (item.get("body") or "").lstrip().startswith(risk_prefixes)
+              and item.get("pull_request_review_id") in new_review_ids
           ]
           suggestions = []
           for item in new_comments:

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -157,6 +157,7 @@ jobs:
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
         run: |
           set -euo pipefail
+          current_response="$(mktemp)"
           current_body="$(mktemp)"
           latest_body="$(mktemp)"
           latest_response="$(mktemp)"
@@ -166,7 +167,14 @@ jobs:
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
           placeholder_body="${RUNNER_TEMP}/pr-agent-body-with-placeholder.md"
 
-          gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "${current_response}"
+          python3 - "${current_response}" "${current_body}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          Path(sys.argv[2]).write_text(json.loads(Path(sys.argv[1]).read_text()).get("body") or "")
+          PY
           cp "${current_body}" "${body_backup}"
           python3 - "${current_body}" "${next_body}" <<'PY'
           import os
@@ -461,7 +469,7 @@ jobs:
           pr_code_suggestions.extra_instructions: |
             Match the configured response language.
             Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
-            Start every suggestion with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
+            Use one of these Markdown risk labels near the beginning of each visible suggestion when applicable: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
           pr_code_suggestions.num_code_suggestions_per_chunk: "2"
@@ -510,11 +518,6 @@ jobs:
           patches_path = Path(sys.argv[5])
           marker = os.environ["PR_AGENT_INLINE_MARKER"]
           marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
-          risk_prefixes = ("🔴 **High Risk**:", "🟡 **Medium Risk**:", "🔵 **Low Risk**:")
-
-          def is_pr_agent_inline_body(body: str) -> bool:
-              visible = (body or "").lstrip()
-              return visible.startswith("**Suggestion:**") or visible.startswith(risk_prefixes)
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -537,7 +540,7 @@ jobs:
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_ids
                   and item.get("pull_request_review_id") in new_review_ids
-                  and is_pr_agent_inline_body(body)
+                  and body.lstrip().startswith("**Suggestion:**")
                   and not marker_re.search(body)
               ):
                   patches.append({"id": item["id"], "body": f"{marker}\n{body}"})
@@ -973,6 +976,7 @@ jobs:
           set -euo pipefail
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
           placeholder_body="${RUNNER_TEMP}/pr-agent-body-with-placeholder.md"
+          current_response="$(mktemp)"
           current_body="$(mktemp)"
           latest_body="$(mktemp)"
           latest_response="$(mktemp)"
@@ -984,7 +988,14 @@ jobs:
             exit 0
           fi
 
-          gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "${current_response}"
+          python3 - "${current_response}" "${current_body}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          Path(sys.argv[2]).write_text(json.loads(Path(sys.argv[1]).read_text()).get("body") or "")
+          PY
           current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
           run_head_sha="${RUN_HEAD_SHA:-}"
           is_stale=false

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -115,10 +115,29 @@ jobs:
           print(f"head_sha={head_sha}")
           PY
 
+      - name: Check PR head before side effects
+        id: run_state
+        if: steps.pr_language.outputs.skip_pr_agent != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          is_stale=false
+          if [ -n "${RUN_HEAD_SHA}" ] && [ "${current_head_sha}" != "${RUN_HEAD_SHA}" ]; then
+            echo "PR head changed from ${RUN_HEAD_SHA} to ${current_head_sha}; skip stale PR-Agent run."
+            is_stale=true
+          fi
+          echo "is_stale=${is_stale}" >> "${GITHUB_OUTPUT}"
+
       - name: Prepare PR-Agent description markers
         id: prepare_description
         if: >-
           steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true' &&
           (
             github.event_name == 'pull_request_target' ||
             (
@@ -192,10 +211,32 @@ jobs:
           fi
           echo "body_changed=${body_changed}" >> "${GITHUB_OUTPUT}"
 
+      - name: Check PR head before PR-Agent
+        id: pragent_head
+        if: >-
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          is_stale=false
+          if [ -n "${RUN_HEAD_SHA}" ] && [ "${current_head_sha}" != "${RUN_HEAD_SHA}" ]; then
+            echo "PR head changed from ${RUN_HEAD_SHA} to ${current_head_sha}; skip stale PR-Agent run."
+            is_stale=true
+          fi
+          echo "is_stale=${is_stale}" >> "${GITHUB_OUTPUT}"
+
       - name: Snapshot PR-Agent inline comments
         id: inline_state_before
         if: >-
           steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true' &&
+          steps.pragent_head.outputs.is_stale != 'true' &&
           (
             github.event_name == 'pull_request_target' ||
             (
@@ -218,7 +259,10 @@ jobs:
 
       - name: Run PR-Agent
         id: pragent
-        if: steps.pr_language.outputs.skip_pr_agent != 'true'
+        if: >-
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true' &&
+          steps.pragent_head.outputs.is_stale != 'true'
         # 使用版本号加 digest 固定容器构建，避免 tag 被重推后改变运行内容。
         uses: docker://pragent/pr-agent:0.39.0-github_action@sha256:b253845caa8c7ff5ce8be78f32996647982bdd4890826a962b78eff2e385a825
         env:
@@ -291,9 +335,76 @@ jobs:
           # github_action_config.auto_improve: "true"
           # config.verbosity_level: "1"
 
+      - name: Clean stale PR-Agent inline comments
+        id: post_pragent_state
+        if: >-
+          always() &&
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true' &&
+          steps.pragent_head.outputs.is_stale != 'true' &&
+          steps.inline_state_before.outputs.inline_ids_b64 != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
+          BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
+        run: |
+          set -euo pipefail
+          current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          is_stale=false
+          if [ -n "${RUN_HEAD_SHA}" ] && [ "${current_head_sha}" != "${RUN_HEAD_SHA}" ]; then
+            is_stale=true
+          fi
+          echo "is_stale=${is_stale}" >> "${GITHUB_OUTPUT}"
+          if [ "${is_stale}" != "true" ]; then
+            exit 0
+          fi
+
+          before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
+          comments="$(mktemp)"
+          delete_ids="$(mktemp)"
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | @json' > "${comments}"
+          python3 - "${before_ids}" "${comments}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          before_ids = set(json.loads(sys.argv[1] or "[]"))
+          comments_path = Path(sys.argv[2])
+          delete_path = Path(sys.argv[3])
+          head_sha = sys.argv[4]
+
+          delete_ids = []
+          for line in comments_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("id") not in before_ids
+                  and item.get("commit_id") == head_sha
+              ):
+                  delete_ids.append(str(item["id"]))
+
+          delete_path.write_text("\n".join(delete_ids))
+          PY
+
+          if [ ! -s "${delete_ids}" ]; then
+            echo "No stale PR-Agent inline comments to clean."
+            exit 0
+          fi
+          while IFS= read -r comment_id; do
+            [ -z "${comment_id}" ] && continue
+            gh api --method DELETE "repos/${REPO}/pulls/comments/${comment_id}" >/dev/null
+          done < "${delete_ids}"
+
       - name: Publish PR-Agent code review summary
         if: >-
           steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true' &&
+          steps.pragent_head.outputs.is_stale != 'true' &&
+          steps.post_pragent_state.outputs.is_stale != 'true' &&
           (
             github.event_name == 'pull_request_target' ||
             (
@@ -514,13 +625,14 @@ jobs:
 
       - name: Restore PR-Agent description markers on failure
         if: >-
-          failure() &&
+          always() &&
           steps.prepare_description.outputs.body_changed == 'true' &&
           steps.pr_language.outputs.skip_pr_agent != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
         run: |
           set -euo pipefail
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
@@ -534,7 +646,13 @@ jobs:
           fi
 
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
-          python3 - "${body_backup}" "${placeholder_body}" "${current_body}" "${payload}" <<'PY'
+          current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          is_stale=false
+          if [ -n "${RUN_HEAD_SHA}" ] && [ "${current_head_sha}" != "${RUN_HEAD_SHA}" ]; then
+            is_stale=true
+          fi
+
+          python3 - "${body_backup}" "${placeholder_body}" "${current_body}" "${payload}" "${is_stale}" <<'PY'
           import json
           import re
           import sys
@@ -544,6 +662,7 @@ jobs:
           placeholder_body = Path(sys.argv[2]).read_text()
           current_body = Path(sys.argv[3]).read_text()
           payload_path = Path(sys.argv[4])
+          is_stale = sys.argv[5] == "true"
 
           start = "<!-- pr-agent-summary:start -->"
           end = "<!-- pr-agent-summary:end -->"
@@ -573,10 +692,10 @@ jobs:
 
           current_section = current_body[current_block[0]:current_block[1]]
           placeholder_section = placeholder_body[placeholder_block[0]:placeholder_block[1]]
-          if "pr_agent:summary" not in current_section:
+          if "pr_agent:summary" not in current_section and not is_stale:
               print("No visible PR-Agent summary placeholder to restore.")
               raise SystemExit(0)
-          if current_section != placeholder_section:
+          if current_section != placeholder_section and not is_stale:
               print("Current PR-Agent summary block changed; skip restore.")
               raise SystemExit(0)
 

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -48,7 +48,7 @@ jobs:
         )
       )
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name == 'issue_comment' && github.event.comment.id || 'auto' }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name == 'issue_comment' && (github.event.comment.body == '/ask' || startsWith(github.event.comment.body, '/ask ')) && github.event.comment.id || 'write' }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -261,6 +261,7 @@ jobs:
           set -euo pipefail
           can_describe="${CAN_DESCRIBE:-true}"
           should_improve=true
+          should_publish_existing_summary=false
           push_commands='["/describe", "/improve"]'
           if [ "${can_describe}" = "false" ]; then
             push_commands='["/improve"]'
@@ -300,6 +301,9 @@ jobs:
             fi
             if [ -n "${existing_summary_id}" ] || [ -n "${existing_inline_id}" ]; then
               should_improve=false
+              if [ -z "${existing_summary_id}" ] && [ -n "${existing_inline_id}" ]; then
+                should_publish_existing_summary=true
+              fi
               if [ "${can_describe}" = "false" ]; then
                 push_commands='[]'
               else
@@ -309,6 +313,7 @@ jobs:
             fi
           fi
           echo "should_improve=${should_improve}" >> "${GITHUB_OUTPUT}"
+          echo "should_publish_existing_summary=${should_publish_existing_summary}" >> "${GITHUB_OUTPUT}"
           echo "push_commands=${push_commands}" >> "${GITHUB_OUTPUT}"
 
       - name: Snapshot PR-Agent review state
@@ -320,7 +325,10 @@ jobs:
           (
             (
               github.event_name == 'pull_request_target' &&
-              steps.review_history.outputs.should_improve == 'true'
+              (
+                steps.review_history.outputs.should_improve == 'true' ||
+                steps.review_history.outputs.should_publish_existing_summary == 'true'
+              )
             ) ||
             (
               github.event_name == 'issue_comment' &&
@@ -640,6 +648,7 @@ jobs:
           BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
           SUMMARY_LANGUAGE: ${{ steps.pr_language.outputs.summary_language }}
+          USE_EXISTING_INLINE_SUMMARY: ${{ github.event_name == 'pull_request_target' && steps.review_history.outputs.should_publish_existing_summary == 'true' }}
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
           SUMMARY_MODEL: gpt-5.5
@@ -685,6 +694,7 @@ jobs:
           commit_url = sys.argv[8]
           short_sha = sys.argv[9]
           marker = os.environ["PR_AGENT_INLINE_MARKER"]
+          use_existing_inline_summary = (os.environ.get("USE_EXISTING_INLINE_SUMMARY") or "").lower() == "true"
           marker_re = re.compile(
               r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*",
               re.IGNORECASE,
@@ -693,7 +703,10 @@ jobs:
           def normalize_suggestion_body(body: str) -> str:
               return marker_re.sub("", body or "", count=1).strip()
 
-          def is_pr_agent_suggestion(item: dict) -> bool:
+          def has_inline_marker(item: dict) -> bool:
+              return bool(marker_re.search(item.get("body") or ""))
+
+          def has_current_run_marker(item: dict) -> bool:
               return (item.get("body") or "").lstrip().startswith(marker)
 
           comments = []
@@ -713,14 +726,22 @@ jobs:
               ):
                   new_review_ids.add(item["id"])
 
-          new_comments = [
-              item for item in comments
-              if item.get("user", {}).get("login") == "github-actions[bot]"
-              and item.get("id") not in before_ids
-              and item.get("commit_id") == head_sha
-              and item.get("pull_request_review_id") in new_review_ids
-              and is_pr_agent_suggestion(item)
-          ]
+          if use_existing_inline_summary:
+              new_comments = [
+                  item for item in comments
+                  if item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("commit_id") == head_sha
+                  and has_inline_marker(item)
+              ]
+          else:
+              new_comments = [
+                  item for item in comments
+                  if item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("id") not in before_ids
+                  and item.get("commit_id") == head_sha
+                  and item.get("pull_request_review_id") in new_review_ids
+                  and has_current_run_marker(item)
+              ]
           suggestions = []
           for item in new_comments:
               body = normalize_suggestion_body(item.get("body") or "")

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -49,7 +49,7 @@ jobs:
       )
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-      cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -492,6 +492,12 @@ jobs:
           """)
           payload_path.write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY
+
+          latest_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          if [ "${latest_head_sha}" != "${HEAD_SHA}" ]; then
+            echo "PR head changed from ${HEAD_SHA} to ${latest_head_sha}; skip stale code review summary."
+            exit 0
+          fi
 
           new_comment_id="$(gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" --jq '.id')"
           comment_ids="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.id != ${new_comment_id} and .user.login == \"github-actions[bot]\" and ((.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) or (.body | startswith(\"<!-- pr-agent-update-notification -->\")))) | .id")"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -540,7 +540,6 @@ jobs:
           python3 - "${review_data}" "${payload}" <<'PY'
           import json
           import os
-          import textwrap
           import urllib.error
           import urllib.request
           from pathlib import Path
@@ -640,14 +639,15 @@ jobs:
 
           summary = llm_summary() or fallback_summary()
           commit_label = "审查提交：" if use_chinese else "Reviewed commit:"
-          body = textwrap.dedent(f"""\
-          {marker}
-          ## Code Review
-
-          {summary}
-
-          {commit_label} [{review_data["short_sha"]}]({review_data["commit_url"]})
-          """)
+          body = "\n".join([
+              marker,
+              "## Code Review",
+              "",
+              summary.strip(),
+              "",
+              f'{commit_label} [{review_data["short_sha"]}]({review_data["commit_url"]})',
+              "",
+          ])
           payload_path.write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY
 
@@ -679,6 +679,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
         run: |
           set -euo pipefail
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
@@ -693,12 +694,13 @@ jobs:
 
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
           current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          run_head_sha="${RUN_HEAD_SHA:-}"
           is_stale=false
-          if [ -n "${RUN_HEAD_SHA}" ] && [ "${current_head_sha}" != "${RUN_HEAD_SHA}" ]; then
+          if [ -n "${run_head_sha}" ] && [ "${current_head_sha}" != "${run_head_sha}" ]; then
             is_stale=true
           fi
 
-          python3 - "${body_backup}" "${placeholder_body}" "${current_body}" "${payload}" "${RUN_HEAD_SHA}" "${is_stale}" <<'PY'
+          python3 - "${body_backup}" "${placeholder_body}" "${current_body}" "${payload}" "${run_head_sha}" "${is_stale}" <<'PY'
           import json
           import re
           import sys

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -11,11 +11,16 @@ on:
       - review_requested
       - synchronize
   issue_comment:
-    # 手动命令如 "/review"、"/describe"、"/improve" 和 "/ask ..." 只在 PR 评论中有意义。
+    # 手动命令如 "/describe"、"/improve" 和 "/ask ..." 只在 PR 评论中有意义。
     # issue_comment 同时覆盖普通 issue，因此 job 里还会再判断是否属于 PR。
     types:
       - created
       - edited
+
+concurrency:
+  # 同一 PR 上只保留最新一次 PR-Agent 运行，避免旧 commit 的 review 后完成并覆盖新结果。
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   # 读取仓库内容和 PR diff。
@@ -27,7 +32,7 @@ permissions:
 
 jobs:
   pr-agent:
-    name: PR-Agent review and describe
+    name: PR-Agent inline review
     # PR 事件自动处理；评论命令仅允许指定身份在 PR 下触发，避免任意评论消耗模型配额。
     if: >-
       github.event.sender.type != 'Bot' &&
@@ -38,8 +43,6 @@ jobs:
           github.event.issue.pull_request != null &&
           contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR"]'), github.event.comment.author_association) &&
           (
-            github.event.comment.body == '/review' ||
-            startsWith(github.event.comment.body, '/review ') ||
             github.event.comment.body == '/describe' ||
             startsWith(github.event.comment.body, '/describe ') ||
             github.event.comment.body == '/improve' ||
@@ -52,10 +55,182 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Detect PR review language
+        id: pr_language
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          pr_info="$(mktemp)"
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "${pr_info}"
+          python3 - "${pr_info}" >> "${GITHUB_OUTPUT}" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          pr = json.loads(Path(sys.argv[1]).read_text())
+          title = pr.get("title") or ""
+          body = pr.get("body") or ""
+
+          body = re.sub(
+              r"\n*##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*"
+              r"<!-- pr-agent-summary:start -->.*?<!-- pr-agent-summary:end -->",
+              " ",
+              body,
+              flags=re.IGNORECASE | re.DOTALL,
+          )
+          body = re.sub(
+              r"<!-- pr-agent-summary:start -->.*?<!-- pr-agent-summary:end -->",
+              " ",
+              body,
+              flags=re.DOTALL,
+          )
+          body = re.sub(r"```.*?```", " ", body, flags=re.DOTALL)
+
+          text = f"{title}\n{body}"
+          cjk_count = len(re.findall(r"[\u4e00-\u9fff]", text))
+          latin_words = len(re.findall(r"\b[A-Za-z][A-Za-z]{2,}\b", text))
+
+          if cjk_count >= 4:
+              response_language = "zh-CN"
+              summary_heading = "PR-Agent 摘要"
+              summary_language = "中文"
+          elif latin_words >= 8:
+              response_language = "en-US"
+              summary_heading = "PR-Agent Summary"
+              summary_language = "English"
+          else:
+              response_language = "zh-CN"
+              summary_heading = "PR-Agent 摘要"
+              summary_language = "中文"
+
+          print(f"response_language={response_language}")
+          print(f"summary_heading={summary_heading}")
+          print(f"summary_language={summary_language}")
+          PY
+
+      - name: Prepare PR-Agent description markers
+        if: >-
+          github.event_name == 'pull_request_target' ||
+          (
+            github.event_name == 'issue_comment' &&
+            (
+              github.event.comment.body == '/describe' ||
+              startsWith(github.event.comment.body, '/describe ')
+            )
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          SUMMARY_HEADING: ${{ steps.pr_language.outputs.summary_heading }}
+        run: |
+          set -euo pipefail
+          current_body="$(mktemp)"
+          next_body="$(mktemp)"
+          payload="$(mktemp)"
+
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
+          python3 - "${current_body}" "${next_body}" <<'PY'
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          current_path = Path(sys.argv[1])
+          next_path = Path(sys.argv[2])
+
+          body = current_path.read_text()
+          start = "<!-- pr-agent-summary:start -->"
+          end = "<!-- pr-agent-summary:end -->"
+          placeholder = "pr_agent:summary"
+          summary_heading = os.environ.get("SUMMARY_HEADING") or "PR-Agent 摘要"
+          agent_block = f"## {summary_heading}\n\n{start}\n{placeholder}\n{end}\n"
+          body = re.sub(
+              r"(?im)^##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*(?=<!-- pr-agent-summary:start -->)",
+              f"## {summary_heading}\n\n",
+              body,
+          )
+
+          start_index = body.find(start)
+          end_index = body.find(end)
+          if start_index >= 0 and end_index > start_index:
+              next_body = body[: start_index + len(start)] + f"\n{placeholder}\n" + body[end_index:]
+          else:
+              separator = "\n\n" if body.strip() else ""
+              next_body = body.rstrip() + separator + agent_block
+
+          next_path.write_text(next_body)
+          PY
+
+          if ! cmp -s "${current_body}" "${next_body}"; then
+            python3 - "${next_body}" "${payload}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          body = Path(sys.argv[1]).read_text()
+          Path(sys.argv[2]).write_text(json.dumps({"body": body}, ensure_ascii=False))
+          PY
+            gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+          fi
+
+      - name: Snapshot PR-Agent inline comments
+        id: inline_state_before
+        if: >-
+          github.event_name == 'pull_request_target' ||
+          (
+            github.event_name == 'issue_comment' &&
+            (
+              github.event.comment.body == '/improve' ||
+              startsWith(github.event.comment.body, '/improve ')
+            )
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          inline_ids="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | select(.user.login == "github-actions[bot]") | .id' | jq -sc '.')"
+          inline_ids_b64="$(printf '%s' "${inline_ids}" | base64 -w0)"
+          echo "inline_ids_b64=${inline_ids_b64}" >> "${GITHUB_OUTPUT}"
+
+      - name: Clean previous PR-Agent code review summary
+        if: >-
+          github.event_name == 'pull_request_target' ||
+          (
+            github.event_name == 'issue_comment' &&
+            (
+              github.event.comment.body == '/improve' ||
+              startsWith(github.event.comment.body, '/improve ')
+            )
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          comment_ids="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq '.[] | select(.user.login == "github-actions[bot]" and ((.body | startswith("<!-- pr-agent-code-review-summary -->")) or (.body | startswith("<!-- pr-agent-update-notification -->")))) | .id')"
+
+          if [ -z "${comment_ids}" ]; then
+            echo "No previous PR-Agent code review summary to clean."
+            exit 0
+          fi
+
+          while IFS= read -r comment_id; do
+            [ -z "${comment_id}" ] && continue
+            gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null
+          done <<< "${comment_ids}"
+
       - name: Run PR-Agent
         id: pragent
         # 使用版本号加 digest 固定容器构建，避免 tag 被重推后改变运行内容。
-        uses: docker://pragent/pr-agent:0.37.0-github_action@sha256:4ec7bac814050a1bc8c96ab2fab6b7b0f65df0049a5ec43f3fee1a0b551c28ca
+        uses: docker://pragent/pr-agent:0.39.0-github_action@sha256:b253845caa8c7ff5ce8be78f32996647982bdd4890826a962b78eff2e385a825
         env:
           # PR-Agent 使用该 token 读取 PR 元数据并发布评论。
           GITHUB_TOKEN: ${{ github.token }}
@@ -72,52 +247,257 @@ jobs:
           config.fallback_models: '["gpt-5.4"]'
           config.reasoning_effort: "xhigh"
           config.ai_timeout: "900"
-          config.response_language: "zh-CN"
+          config.response_language: ${{ steps.pr_language.outputs.response_language }}
           config.large_patch_policy: "clip"
           config.ignore_pr_title: '["^\\[Auto\\]", "^Auto"]'
           config.ignore_pr_labels: '["skip pr-agent"]'
 
-          # pull_request_target 事件默认自动执行 /review 和 /describe；/improve 保持手动触发。
-          github_action_config.auto_review: "true"
+          # PR 初次进入评审或后续 push 时，更新 PR 摘要并发布 GitHub Review 行内建议。
+          github_action_config.auto_review: "false"
           github_action_config.auto_describe: "true"
-          github_action_config.auto_improve: "false"
+          github_action_config.auto_improve: "true"
 
-          # 允许触发自动工具的 PR 动作。包含 synchronize，便于新 commit 推送后刷新结果。
-          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested", "synchronize"]'
+          # synchronize 由 push_commands 单独处理；每次 push 更新摘要和行内 Review，旧行评由 GitHub 标记 outdated。
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'
+          github_action_config.handle_push_trigger: "true"
+          github_action_config.push_commands: '["/describe", "/improve"]'
 
           # 保留 action outputs，便于后续 workflow 编排或排查。
           github_action_config.enable_output: "true"
 
-          # /describe 行为控制；与自动触发配置放在同一层，避免使用默认图表和标签策略。
+          # /describe 行为控制；只更新 PR body 中的 PR-Agent 摘要占位符。
           pr_description.generate_ai_title: "false"
           pr_description.publish_labels: "false"
+          pr_description.publish_description_as_comment: "false"
+          pr_description.publish_description_as_comment_persistent: "false"
           pr_description.enable_pr_diagram: "false"
+          pr_description.enable_pr_type: "false"
+          pr_description.enable_help_text: "false"
+          pr_description.enable_help_comment: "false"
+          pr_description.enable_semantic_files_types: "false"
           pr_description.collapsible_file_list: "adaptive"
           pr_description.add_original_user_description: "true"
+          pr_description.use_description_markers: "true"
+          pr_description.final_update_message: "false"
+          pr_description.extra_instructions: |
+            Match the configured response language.
+            Generate a moderately detailed PR summary covering the change goal, key implementation details, configuration or compatibility impact, tests, and notable risks.
+            Use 2-4 bullets for small PRs; use 4-8 bullets for feature or multi-file PRs.
+            Avoid low-value file lists and local command transcripts.
 
-          # /review 输出策略，聚焦维护者需要处理的风险和缺口。
-          pr_reviewer.extra_instructions: |
-            请用中文输出。
-            优先指出 P0/P1 风险，避免纠结纯格式问题。
-            重点检查安全、权限、状态一致性、异步/缓存、副作用和测试缺口。
-          pr_reviewer.num_max_findings: "5"
-          pr_reviewer.persistent_comment: "true"
-          pr_reviewer.publish_output_no_suggestions: "true"
-          pr_reviewer.require_tests_review: "true"
-          pr_reviewer.require_security_review: "true"
-          pr_reviewer.require_estimate_effort_to_review: "true"
-          pr_reviewer.require_can_be_split_review: "true"
-          pr_reviewer.require_todo_scan: "false"
-          pr_reviewer.enable_review_labels_effort: "false"
-          pr_reviewer.enable_review_labels_security: "true"
-
-          # /improve 和 /ask 的手动命令策略。
+          # /improve 以 GitHub 内联建议呈现，便于像正式 review discussion 一样逐条处理。
+          pr_code_suggestions.extra_instructions: |
+            Match the configured response language.
+            Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
+            For prioritized issues, start the suggestion body with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
-          pr_code_suggestions.suggestions_score_threshold: "7"
-          pr_code_suggestions.commitable_code_suggestions: "false"
+          pr_code_suggestions.suggestions_score_threshold: "8"
+          pr_code_suggestions.num_code_suggestions_per_chunk: "2"
+          pr_code_suggestions.commitable_code_suggestions: "true"
+          pr_code_suggestions.publish_output_no_suggestions: "false"
           pr_questions.use_conversation_history: "true"
 
           # 可选成本和噪音控制：
           # github_action_config.auto_improve: "true"
           # config.verbosity_level: "1"
-          # pr_reviewer.num_max_findings: "3"
+
+      - name: Publish PR-Agent code review summary
+        if: >-
+          github.event_name == 'pull_request_target' ||
+          (
+            github.event_name == 'issue_comment' &&
+            (
+              github.event.comment.body == '/improve' ||
+              startsWith(github.event.comment.body, '/improve ')
+            )
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          SUMMARY_LANGUAGE: ${{ steps.pr_language.outputs.summary_language }}
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
+          SUMMARY_MODEL: gpt-5.5
+        run: |
+          set -euo pipefail
+          before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
+          pr_info="$(mktemp)"
+          comments="$(mktemp)"
+          review_data="$(mktemp)"
+          payload="$(mktemp)"
+
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "${pr_info}"
+          CURRENT_HEAD_SHA="$(jq -r '.head.sha' "${pr_info}")"
+          HEAD_SHA="${EVENT_HEAD_SHA:-${CURRENT_HEAD_SHA}}"
+          if [ "${CURRENT_HEAD_SHA}" != "${HEAD_SHA}" ]; then
+            echo "PR head changed from ${HEAD_SHA} to ${CURRENT_HEAD_SHA}; skip stale code review summary."
+            exit 0
+          fi
+          short_sha="${HEAD_SHA:0:7}"
+          pr_url="https://github.com/${REPO}/pull/${PR_NUMBER}"
+          commit_url="https://github.com/${REPO}/commit/${HEAD_SHA}"
+
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | @json' > "${comments}"
+
+          python3 - "${before_ids}" "${comments}" "${review_data}" "${HEAD_SHA}" "${pr_url}" "${commit_url}" "${short_sha}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          before_ids = set(json.loads(sys.argv[1] or "[]"))
+          comments_path = Path(sys.argv[2])
+          output_path = Path(sys.argv[3])
+          head_sha = sys.argv[4]
+          pr_url = sys.argv[5]
+          commit_url = sys.argv[6]
+          short_sha = sys.argv[7]
+
+          comments = []
+          for line in comments_path.read_text().splitlines():
+              if line.strip():
+                  comments.append(json.loads(line))
+
+          new_comments = [
+              item for item in comments
+              if item.get("user", {}).get("login") == "github-actions[bot]"
+              and item.get("id") not in before_ids
+              and item.get("commit_id") == head_sha
+          ]
+          suggestions = []
+          for item in new_comments:
+              body = (item.get("body") or "").strip()
+              first_line = next((line.strip() for line in body.splitlines() if line.strip()), "")
+              suggestions.append({
+                  "path": item.get("path"),
+                  "line": item.get("line") or item.get("start_line"),
+                  "url": item.get("html_url"),
+                  "summary": first_line[:500],
+                  "body": body[:1500],
+              })
+
+          output_path.write_text(json.dumps({
+              "pr_url": pr_url,
+              "commit_url": commit_url,
+              "short_sha": short_sha,
+              "suggestions": suggestions,
+          }, ensure_ascii=False))
+          PY
+
+          python3 - "${review_data}" "${payload}" <<'PY'
+          import json
+          import os
+          import textwrap
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          review_data = json.loads(Path(os.sys.argv[1]).read_text())
+          payload_path = Path(os.sys.argv[2])
+          suggestions = review_data["suggestions"]
+          marker = "<!-- pr-agent-code-review-summary -->"
+          summary_language = os.environ.get("SUMMARY_LANGUAGE") or "中文"
+          use_chinese = summary_language != "English"
+
+          def fallback_summary() -> str:
+              if not suggestions:
+                  if use_chinese:
+                      return "已审查本次变更，未发现需要进一步反馈或调整的问题。"
+                  return "Reviewed this change and found no further feedback or required adjustments."
+              if use_chinese:
+                  lines = [f"本轮代码审查新增 {len(suggestions)} 条行内建议，建议优先查看以下位置："]
+              else:
+                  noun = "suggestion" if len(suggestions) == 1 else "suggestions"
+                  lines = [f"This review added {len(suggestions)} inline {noun}. Consider reviewing these locations first:"]
+              for item in suggestions[:5]:
+                  location = f"{item.get('path')}:{item.get('line')}" if item.get("line") else str(item.get("path"))
+                  summary = item.get("summary") or "查看行内建议"
+                  url = item.get("url")
+                  if use_chinese:
+                      lines.append(f"- [{location}]({url})：{summary}" if url else f"- {location}：{summary}")
+                  else:
+                      lines.append(f"- [{location}]({url}): {summary}" if url else f"- {location}: {summary}")
+              if len(suggestions) > 5:
+                  if use_chinese:
+                      lines.append(f"- 其余 {len(suggestions) - 5} 条请在 Files changed 的行内评论中查看。")
+                  else:
+                      lines.append(f"- Review the remaining {len(suggestions) - 5} inline comments in Files changed.")
+              return "\n".join(lines)
+
+          def llm_summary() -> str | None:
+              if not suggestions:
+                  return None
+
+              api_base = (os.environ.get("OPENAI_API_BASE") or "").rstrip("/")
+              api_key = os.environ.get("OPENAI_KEY") or ""
+              model = os.environ.get("SUMMARY_MODEL") or "gpt-5.5"
+              if not api_base or not api_key:
+                  return None
+
+              if use_chinese:
+                  task = (
+                      "你是独立的代码审查摘要助手。只基于本轮已经发布的行内审查意见做简短汇总，"
+                      "不新增审查结论，不替维护者判断 PR 是否可以合并。请用中文 Markdown 输出："
+                      "第一段说明本轮审查已完成，并已在行内留下需要关注的建议；如有建议，"
+                      "概括 1-3 个主要关注点，使用“建议关注”“可能影响”“可优先查看”等中立表述。"
+                      "不要输出表格，不要复述所有文件，不要使用“可以合并”“不建议合并”“阻塞合并”"
+                      "“先处理后再合入”等合并裁决措辞。"
+                  )
+                  system_prompt = "你是严谨、中立的代码审查摘要助手。输出中文 Markdown，简洁自然。"
+              else:
+                  task = (
+                      "You are an independent code review summarizer. Summarize only the inline review comments "
+                      "already posted in this run; do not add new review conclusions or decide whether the PR should merge. "
+                      "Write concise Markdown in English. Start by noting that review completed and inline suggestions "
+                      "were left; then summarize 1-3 main points using neutral phrasing such as \"consider\", "
+                      "\"may affect\", or \"worth reviewing\". Do not output tables, list every file, or use merge-gate "
+                      "wording such as \"ready to merge\", \"do not merge\", \"blocks merging\", or \"must be fixed before merge\"."
+                  )
+                  system_prompt = "You are a rigorous, neutral code review summarizer. Write concise English Markdown."
+
+              user_content = {
+                  "task": task,
+                  "suggestions": suggestions[:10],
+              }
+
+              request_body = {
+                  "model": model,
+                  "messages": [
+                      {"role": "system", "content": system_prompt},
+                      {"role": "user", "content": json.dumps(user_content, ensure_ascii=False)},
+                  ],
+                  "temperature": 0.2,
+              }
+              request = urllib.request.Request(
+                  f"{api_base}/chat/completions",
+                  data=json.dumps(request_body).encode("utf-8"),
+                  headers={
+                      "Authorization": f"Bearer {api_key}",
+                      "Content-Type": "application/json",
+                  },
+                  method="POST",
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=60) as response:
+                      data = json.loads(response.read().decode("utf-8"))
+                  content = data["choices"][0]["message"]["content"].strip()
+                  return content or None
+              except (KeyError, TimeoutError, urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError):
+                  return None
+
+          summary = llm_summary() or fallback_summary()
+          commit_label = "审查提交：" if use_chinese else "Reviewed commit:"
+          body = textwrap.dedent(f"""\
+          {marker}
+          ## Code Review
+
+          {summary}
+
+          {commit_label} [{review_data["short_sha"]}]({review_data["commit_url"]})
+          """)
+          payload_path.write_text(json.dumps({"body": body}, ensure_ascii=False))
+          PY
+
+          gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" >/dev/null

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -49,7 +49,7 @@ jobs:
       )
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -74,6 +74,7 @@ jobs:
           body = pr.get("body") or ""
           labels = {item.get("name", "") for item in pr.get("labels") or []}
           skip_pr_agent = "true" if "skip pr-agent" in labels or re.search(r"^(?:\[Auto\]|Auto)", title) else "false"
+          head_sha = pr.get("head", {}).get("sha") or ""
 
           body = re.sub(
               r"\n*##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*"
@@ -111,6 +112,7 @@ jobs:
           print(f"summary_heading={summary_heading}")
           print(f"summary_language={summary_language}")
           print(f"skip_pr_agent={skip_pr_agent}")
+          print(f"head_sha={head_sha}")
           PY
 
       - name: Prepare PR-Agent description markers
@@ -138,6 +140,7 @@ jobs:
           next_body="$(mktemp)"
           payload="$(mktemp)"
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
+          placeholder_body="${RUNNER_TEMP}/pr-agent-body-with-placeholder.md"
 
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
           cp "${current_body}" "${body_backup}"
@@ -172,6 +175,7 @@ jobs:
 
           next_path.write_text(next_body)
           PY
+          cp "${next_body}" "${placeholder_body}"
 
           body_changed=false
           if ! cmp -s "${current_body}" "${next_body}"; then
@@ -336,7 +340,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
           SUMMARY_LANGUAGE: ${{ steps.pr_language.outputs.summary_language }}
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
@@ -351,7 +355,7 @@ jobs:
 
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "${pr_info}"
           CURRENT_HEAD_SHA="$(jq -r '.head.sha' "${pr_info}")"
-          HEAD_SHA="${EVENT_HEAD_SHA:-${CURRENT_HEAD_SHA}}"
+          HEAD_SHA="${RUN_HEAD_SHA:-${CURRENT_HEAD_SHA}}"
           if [ "${CURRENT_HEAD_SHA}" != "${HEAD_SHA}" ]; then
             echo "PR head changed from ${HEAD_SHA} to ${CURRENT_HEAD_SHA}; skip stale code review summary."
             exit 0
@@ -534,26 +538,67 @@ jobs:
         run: |
           set -euo pipefail
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
+          placeholder_body="${RUNNER_TEMP}/pr-agent-body-with-placeholder.md"
           current_body="$(mktemp)"
           payload="$(mktemp)"
 
-          if [ ! -s "${body_backup}" ]; then
+          if [ ! -s "${body_backup}" ] || [ ! -s "${placeholder_body}" ]; then
             echo "No PR body backup found."
             exit 0
           fi
 
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
-          if ! grep -q 'pr_agent:summary' "${current_body}"; then
-            echo "No visible PR-Agent summary placeholder to restore."
-            exit 0
-          fi
-
-          python3 - "${body_backup}" "${payload}" <<'PY'
+          python3 - "${body_backup}" "${placeholder_body}" "${current_body}" "${payload}" <<'PY'
           import json
+          import re
           import sys
           from pathlib import Path
 
-          body = Path(sys.argv[1]).read_text()
-          Path(sys.argv[2]).write_text(json.dumps({"body": body}, ensure_ascii=False))
+          backup_body = Path(sys.argv[1]).read_text()
+          placeholder_body = Path(sys.argv[2]).read_text()
+          current_body = Path(sys.argv[3]).read_text()
+          payload_path = Path(sys.argv[4])
+
+          start = "<!-- pr-agent-summary:start -->"
+          end = "<!-- pr-agent-summary:end -->"
+          heading_re = re.compile(r"(?im)^##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*")
+
+          def find_block(body: str) -> tuple[int, int] | None:
+              start_index = body.find(start)
+              end_index = body.find(end)
+              if start_index < 0 or end_index <= start_index:
+                  return None
+              end_index += len(end)
+              heading_start = start_index
+              prefix = body[:start_index]
+              matches = list(heading_re.finditer(prefix))
+              if matches:
+                  last = matches[-1]
+                  if prefix[last.end():].strip() == "":
+                      heading_start = last.start()
+              return heading_start, end_index
+
+          current_block = find_block(current_body)
+          placeholder_block = find_block(placeholder_body)
+          backup_block = find_block(backup_body)
+          if not current_block or not placeholder_block:
+              print("No PR-Agent summary block to restore.")
+              raise SystemExit(0)
+
+          current_section = current_body[current_block[0]:current_block[1]]
+          placeholder_section = placeholder_body[placeholder_block[0]:placeholder_block[1]]
+          if "pr_agent:summary" not in current_section:
+              print("No visible PR-Agent summary placeholder to restore.")
+              raise SystemExit(0)
+          if current_section != placeholder_section:
+              print("Current PR-Agent summary block changed; skip restore.")
+              raise SystemExit(0)
+
+          restored_section = backup_body[backup_block[0]:backup_block[1]] if backup_block else ""
+          next_body = current_body[:current_block[0]] + restored_section + current_body[current_block[1]:]
+          next_body = re.sub(r"\n{4,}", "\n\n\n", next_body).rstrip() + "\n"
+          payload_path.write_text(json.dumps({"body": next_body}, ensure_ascii=False))
           PY
-          gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+          if [ -s "${payload}" ]; then
+            gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+          fi

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -440,105 +440,6 @@ jobs:
           # github_action_config.auto_improve: "true"
           # config.verbosity_level: "1"
 
-      - name: Mark PR-Agent inline comments
-        if: >-
-          always() &&
-          steps.pr_language.outputs.skip_pr_agent != 'true' &&
-          steps.run_state.outputs.is_stale != 'true' &&
-          steps.pragent_head.outputs.is_stale != 'true' &&
-          steps.inline_state_before.outputs.inline_ids_b64 != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
-          BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
-          BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
-          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
-        run: |
-          set -euo pipefail
-          before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
-          before_review_ids="$(printf '%s' "${BEFORE_REVIEW_IDS_B64:-W10=}" | base64 -d)"
-          comments="$(mktemp)"
-          reviews="$(mktemp)"
-          patches="$(mktemp)"
-          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | @json' > "${comments}"
-          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
-          python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${patches}" "${RUN_HEAD_SHA}" <<'PY'
-          import json
-          import os
-          import re
-          import sys
-          from pathlib import Path
-
-          before_ids = set(json.loads(sys.argv[1] or "[]"))
-          before_review_ids = set(json.loads(sys.argv[2] or "[]"))
-          comments_path = Path(sys.argv[3])
-          reviews_path = Path(sys.argv[4])
-          patches_path = Path(sys.argv[5])
-          head_sha = sys.argv[6]
-          marker = os.environ["PR_AGENT_INLINE_MARKER"]
-          marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
-          risk_prefix_re = re.compile(
-              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
-              re.IGNORECASE,
-          )
-
-          def looks_like_pr_agent_suggestion(body: str) -> bool:
-              body = marker_re.sub("", body or "", count=1).lstrip()
-              return bool(risk_prefix_re.search(body))
-
-          new_review_ids = set()
-          for line in reviews_path.read_text().splitlines():
-              if not line.strip():
-                  continue
-              item = json.loads(line)
-              if (
-                  item.get("user", {}).get("login") == "github-actions[bot]"
-                  and item.get("id") not in before_review_ids
-                  and item.get("commit_id") == head_sha
-              ):
-                  new_review_ids.add(item["id"])
-
-          patches = []
-          for line in comments_path.read_text().splitlines():
-              if not line.strip():
-                  continue
-              item = json.loads(line)
-              body = item.get("body") or ""
-              if (
-                  item.get("user", {}).get("login") == "github-actions[bot]"
-                  and item.get("id") not in before_ids
-                  and item.get("commit_id") == head_sha
-                  and item.get("pull_request_review_id") in new_review_ids
-                  and body.strip()
-                  and not marker_re.search(body)
-                  and looks_like_pr_agent_suggestion(body)
-              ):
-                  patches.append({"id": item["id"], "body": f"{marker}\n{body}"})
-
-          patches_path.write_text("\n".join(json.dumps(item, ensure_ascii=False) for item in patches))
-          PY
-
-          if [ ! -s "${patches}" ]; then
-            echo "No PR-Agent inline comments to mark."
-            exit 0
-          fi
-          patch_failed=false
-          while IFS= read -r patch || [ -n "${patch}" ]; do
-            [ -z "${patch}" ] && continue
-            comment_id="$(printf '%s' "${patch}" | jq -r '.id')"
-            payload="$(mktemp)"
-            printf '%s' "${patch}" | jq '{body:.body}' > "${payload}"
-            if ! gh api --method PATCH "repos/${REPO}/pulls/comments/${comment_id}" --input "${payload}" >/dev/null 2>&1; then
-              echo "PR-Agent inline comment ${comment_id} could not be marked."
-              patch_failed=true
-            fi
-          done < "${patches}"
-          if [ "${patch_failed}" = "true" ]; then
-            exit 1
-          fi
-
       - name: Clean stale PR-Agent inline comments
         id: post_pragent_state
         if: >-
@@ -624,12 +525,23 @@ jobs:
             echo "No stale PR-Agent inline comments to clean."
             exit 0
           fi
+          delete_failed=false
           while IFS= read -r comment_id || [ -n "${comment_id}" ]; do
             [ -z "${comment_id}" ] && continue
-            if ! gh api --method DELETE "repos/${REPO}/pulls/comments/${comment_id}" >/dev/null 2>&1; then
-              echo "PR-Agent inline comment ${comment_id} was already removed; continue."
+            err="$(mktemp)"
+            if ! gh api --method DELETE "repos/${REPO}/pulls/comments/${comment_id}" >/dev/null 2>"${err}"; then
+              if grep -qiE "HTTP 404|Not Found" "${err}"; then
+                echo "PR-Agent inline comment ${comment_id} was already removed; continue."
+              else
+                cat "${err}" >&2
+                echo "PR-Agent inline comment ${comment_id} could not be deleted."
+                delete_failed=true
+              fi
             fi
           done < "${delete_ids}"
+          if [ "${delete_failed}" = "true" ]; then
+            exit 1
+          fi
 
       - name: Publish PR-Agent code review summary
         if: >-
@@ -906,12 +818,23 @@ jobs:
             exit 0
           fi
 
+          delete_failed=false
           while IFS= read -r comment_id; do
             [ -z "${comment_id}" ] && continue
-            if ! gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null 2>&1; then
-              echo "PR-Agent summary comment ${comment_id} was already removed; continue."
+            err="$(mktemp)"
+            if ! gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null 2>"${err}"; then
+              if grep -qiE "HTTP 404|Not Found" "${err}"; then
+                echo "PR-Agent summary comment ${comment_id} was already removed; continue."
+              else
+                cat "${err}" >&2
+                echo "PR-Agent summary comment ${comment_id} could not be deleted."
+                delete_failed=true
+              fi
             fi
           done <<< "${comment_ids}"
+          if [ "${delete_failed}" = "true" ]; then
+            exit 1
+          fi
 
       - name: Restore PR-Agent description markers on failure
         if: >-

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -48,7 +48,7 @@ jobs:
         )
       )
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name == 'issue_comment' && github.event.comment.id || 'pr' }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name == 'issue_comment' && (github.event.comment.body == '/ask' || startsWith(github.event.comment.body, '/ask ')) && github.event.comment.id || 'write' }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -368,7 +368,6 @@ jobs:
           pr_code_suggestions.extra_instructions: |
             Match the configured response language.
             Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
-            Start every suggestion body with this exact hidden marker on the first line: <!-- pr-agent-inline-comment:${{ github.run_id }} -->.
             Start every suggestion body with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
@@ -396,7 +395,6 @@ jobs:
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
           BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
           BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
-          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
         run: |
           set -euo pipefail
           current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
@@ -418,8 +416,6 @@ jobs:
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
           import json
-          import os
-          import re
           import sys
           from pathlib import Path
 
@@ -429,17 +425,9 @@ jobs:
           reviews_path = Path(sys.argv[4])
           delete_path = Path(sys.argv[5])
           head_sha = sys.argv[6]
-          pr_agent_inline_marker = os.environ.get("PR_AGENT_INLINE_MARKER") or "<!-- pr-agent-inline-comment -->"
-          risk_prefix_re = re.compile(
-              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
-              re.IGNORECASE,
-          )
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              body = (item.get("body") or "").lstrip()
-              if not body.startswith(pr_agent_inline_marker):
-                  return False
-              return bool(risk_prefix_re.search(body[len(pr_agent_inline_marker):].lstrip()))
+              return bool((item.get("body") or "").strip())
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -511,7 +499,6 @@ jobs:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
           SUMMARY_MODEL: gpt-5.5
-          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
         run: |
           set -euo pipefail
           before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
@@ -552,23 +539,16 @@ jobs:
           pr_url = sys.argv[7]
           commit_url = sys.argv[8]
           short_sha = sys.argv[9]
-          pr_agent_inline_marker = os.environ.get("PR_AGENT_INLINE_MARKER") or "<!-- pr-agent-inline-comment -->"
-          risk_prefix_re = re.compile(
-              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+          marker_re = re.compile(
+              r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*",
               re.IGNORECASE,
           )
 
           def normalize_suggestion_body(body: str) -> str:
-              stripped = (body or "").lstrip()
-              if stripped.startswith(pr_agent_inline_marker):
-                  return stripped[len(pr_agent_inline_marker):].lstrip()
-              return stripped.strip()
+              return marker_re.sub("", body or "", count=1).strip()
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              body = (item.get("body") or "").lstrip()
-              if not body.startswith(pr_agent_inline_marker):
-                  return False
-              return bool(risk_prefix_re.search(body[len(pr_agent_inline_marker):].lstrip()))
+              return bool((item.get("body") or "").strip())
 
           comments = []
           for line in comments_path.read_text().splitlines():

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -48,7 +48,7 @@ jobs:
         )
       )
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name == 'issue_comment' && github.event.comment.id || 'pr' }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -307,6 +307,7 @@ jobs:
           steps.pr_language.outputs.skip_pr_agent != 'true' &&
           steps.run_state.outputs.is_stale != 'true' &&
           steps.pragent_head.outputs.is_stale != 'true'
+        timeout-minutes: 40
         # 使用版本号加 digest 固定容器构建，避免 tag 被重推后改变运行内容。
         uses: docker://pragent/pr-agent:0.39.0-github_action@sha256:b253845caa8c7ff5ce8be78f32996647982bdd4890826a962b78eff2e385a825
         env:
@@ -443,7 +444,6 @@ jobs:
               if (
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_review_ids
-                  and item.get("commit_id") == head_sha
               ):
                   new_review_ids.add(item["id"])
 
@@ -455,7 +455,6 @@ jobs:
               if (
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_ids
-                  and item.get("commit_id") == head_sha
                   and item.get("pull_request_review_id") in new_review_ids
                   and is_pr_agent_suggestion(item)
               ):
@@ -547,18 +546,13 @@ jobs:
               r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
               re.IGNORECASE,
           )
-          risk_prefix_re = re.compile(
-              r"^\s*"
-              r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
-              re.IGNORECASE,
-          )
 
           def normalize_suggestion_body(body: str) -> str:
               return re.sub(r"^\s*<!-- pr-agent-inline-comment -->\s*", "", body or "").strip()
 
           def is_pr_agent_suggestion(item: dict) -> bool:
               body = item.get("body") or ""
-              return bool(pr_agent_marker_re.search(body) or risk_prefix_re.search(body))
+              return bool(pr_agent_marker_re.search(body))
 
           comments = []
           for line in comments_path.read_text().splitlines():
@@ -753,6 +747,7 @@ jobs:
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
           placeholder_body="${RUNNER_TEMP}/pr-agent-body-with-placeholder.md"
           current_body="$(mktemp)"
+          latest_body="$(mktemp)"
           payload="$(mktemp)"
 
           if [ ! -s "${body_backup}" ] || [ ! -s "${placeholder_body}" ]; then
@@ -832,5 +827,10 @@ jobs:
           payload_path.write_text(json.dumps({"body": next_body}, ensure_ascii=False))
           PY
           if [ -s "${payload}" ]; then
+            gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${latest_body}"
+            if ! cmp -s "${current_body}" "${latest_body}"; then
+              echo "PR body changed while preparing restore payload; skip restore."
+              exit 0
+            fi
             gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
           fi

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -218,14 +218,20 @@ jobs:
           headers = parts[-2] if len(parts) > 1 else ""
           body = parts[-1]
           etag = ""
+          last_modified = ""
           for line in headers.splitlines():
-              if line.lower().startswith("etag:"):
+              lower = line.lower()
+              if lower.startswith("etag:"):
                   etag = line.split(":", 1)[1].strip()
-                  break
+              elif lower.startswith("last-modified:"):
+                  last_modified = line.split(":", 1)[1].strip()
           Path(sys.argv[2]).write_text(json.loads(body).get("body") or "")
-          if etag.lower().startswith("w/"):
-              etag = ""
-          Path(sys.argv[3]).write_text(etag)
+          condition_header = ""
+          if etag and not etag.lower().startswith("w/"):
+              condition_header = f"If-Match: {etag}"
+          elif last_modified:
+              condition_header = f"If-Unmodified-Since: {last_modified}"
+          Path(sys.argv[3]).write_text(condition_header)
           PY
             if ! cmp -s "${current_body}" "${latest_body}"; then
               echo "PR body changed while preparing PR-Agent markers; skip placeholder update."
@@ -239,13 +245,14 @@ jobs:
           body = Path(sys.argv[1]).read_text()
           Path(sys.argv[2]).write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY
-              etag="$(cat "${etag_file}")"
-              if [ -n "${etag}" ]; then
-                gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" -H "If-Match: ${etag}" --input "${payload}" >/dev/null
+              condition_header="$(cat "${etag_file}")"
+              if [ -z "${condition_header}" ]; then
+                echo "No conditional validator available; skip placeholder update."
+                can_describe=false
               else
-                gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+                gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" -H "${condition_header}" --input "${payload}" >/dev/null
+                body_changed=true
               fi
-              body_changed=true
             fi
           fi
           echo "body_changed=${body_changed}" >> "${GITHUB_OUTPUT}"
@@ -1065,23 +1072,29 @@ jobs:
           headers = parts[-2] if len(parts) > 1 else ""
           body = parts[-1]
           etag = ""
+          last_modified = ""
           for line in headers.splitlines():
-              if line.lower().startswith("etag:"):
+              lower = line.lower()
+              if lower.startswith("etag:"):
                   etag = line.split(":", 1)[1].strip()
-                  break
+              elif lower.startswith("last-modified:"):
+                  last_modified = line.split(":", 1)[1].strip()
           Path(sys.argv[2]).write_text(json.loads(body).get("body") or "")
-          if etag.lower().startswith("w/"):
-              etag = ""
-          Path(sys.argv[3]).write_text(etag)
+          condition_header = ""
+          if etag and not etag.lower().startswith("w/"):
+              condition_header = f"If-Match: {etag}"
+          elif last_modified:
+              condition_header = f"If-Unmodified-Since: {last_modified}"
+          Path(sys.argv[3]).write_text(condition_header)
           PY
             if ! cmp -s "${current_body}" "${latest_body}"; then
               echo "PR body changed while preparing restore payload; skip restore."
               exit 0
             fi
-            etag="$(cat "${etag_file}")"
-            if [ -n "${etag}" ]; then
-              gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" -H "If-Match: ${etag}" --input "${payload}" >/dev/null
-            else
-              gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+            condition_header="$(cat "${etag_file}")"
+            if [ -z "${condition_header}" ]; then
+              echo "No conditional validator available; skip restore."
+              exit 0
             fi
+            gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" -H "${condition_header}" --input "${payload}" >/dev/null
           fi


### PR DESCRIPTION
### **User description**
## 变更说明

- 将 PR-Agent 工作流调整为 PR Body 摘要标记区、行内审查建议和 Code Review 总结评论的输出形态。
- 去掉 Reviewer Guide 入口，避免重复和低价值评论。
- 保持当前上游触发事件和自动触发范围不变。

## 验证

- YAML 解析通过
- git diff --check
- 确认触发事件保持当前上游配置

本 PR 为 Codex 协作提交


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- 对齐 PR-Agent 行内审查

- 自动维护 PR 摘要区块

- 加固并发与过期保护

- 清理恢复机器人评论


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>配置变更</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>重构 PR-Agent 审查输出与防护流程</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>将工作流聚焦为 PR-Agent 行内审查，移除手动 <code>/review</code> 触发入口。<br> <li> 新增 PR 语言检测、摘要占位符管理和 PR Body 条件更新逻辑。<br> <li> 增加 head SHA 过期检查、并发分组和重复审查跳过机制。<br> <li> 标记、清理行内建议，并发布可恢复的代码审查总结评论。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot-Plugins/pull/1074/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+1022/-34</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

