### PR TITLE
docs: document local federation watch builds

### DIFF
--- a/docs/Repository_Guide.md
+++ b/docs/Repository_Guide.md
@@ -212,6 +212,14 @@ yarn build
 
 然后再把构建产物拷贝到插件目录中的 `dist/assets/`。
 
+本地开发时，可将前端工程的 `dev` 脚本配置为监听构建：
+
+```bash
+yarn dev
+```
+
+其中 `dev` 执行 `vite build --watch`。通过 `PLUGIN_LOCAL_REPO_PATHS` 开发已安装插件，并启用 `DEV` 或 `PLUGIN_AUTO_RELOAD` 后，MoviePilot 会同步新的构建产物；刷新页面即可查看修改。
+
 ### 7.3 宿主联调
 
 以下场景必须回到宿主仓库验证：

--- a/docs/V2_Plugin_Development.md
+++ b/docs/V2_Plugin_Development.md
@@ -530,7 +530,17 @@ def get_render_mode(self) -> Tuple[str, str]:
 
 若需要独立侧栏页面，还要实现 `get_sidebar_nav()`。
 
-### 7.3 侧栏全页入口 `get_sidebar_nav()`
+### 7.3 本地监听构建
+
+本地开发时，可将前端工程的 `dev` 脚本配置为 `vite build --watch`，然后运行：
+
+```bash
+yarn dev
+```
+
+通过 `PLUGIN_LOCAL_REPO_PATHS` 开发已安装插件，并启用 `DEV` 或 `PLUGIN_AUTO_RELOAD` 后，MoviePilot 会同步新的构建产物；刷新页面即可查看修改。
+
+### 7.4 侧栏全页入口 `get_sidebar_nav()`
 
 只有 Vue 模式插件才会被主界面侧栏聚合。
 


### PR DESCRIPTION
## 变更说明

- 在仓库指南和 V2 插件开发指南中补充 Vue 联邦插件的本地监听构建方式。
- 说明通过本地插件仓开发时，MoviePilot 可同步新的构建产物，刷新页面即可查看修改。

## 影响路径

- `docs/Repository_Guide.md`
- `docs/V2_Plugin_Development.md`

## 验证

- `tests/ci/test_plugin_release_gate.py`：10 passed
- V2 插件测试：27 passed
- V1 插件测试：2 passed
- 插件版本门禁
- JSON 格式检查
- `git diff --check`

本 PR 为 Codex 协作提交

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 9b42af2db7eb660737316e78425a81bad78d5bbc

- 记录 `yarn dev` 监听构建
- 说明 `PLUGIN_LOCAL_REPO_PATHS` 同步流程
- 标注 `DEV`/`PLUGIN_AUTO_RELOAD` 启用条件
- 纯文档变更，未新增测试

<!-- pr-agent-summary:end -->