### PR TITLE
test: strengthen plugin runtime isolation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -13,9 +13,5 @@ markers =
 # 仅忽略主程序依赖链或三方库在 Python 3.12 下的已知弃用告警；插件仓自身告警应直接修复
 filterwarnings =
     ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning
-    ignore:websockets.legacy is deprecated:DeprecationWarning
-    ignore:websockets.InvalidStatusCode is deprecated:DeprecationWarning
-    ignore:pkg_resources is deprecated as an API:DeprecationWarning
-    ignore:Deprecated call to .pkg_resources.declare_namespace:DeprecationWarning
     ignore:'crypt' is deprecated:DeprecationWarning
     ignore:'audioop' is deprecated:DeprecationWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 # 相对导入本仓薄壳，先定位同级 MoviePilot 后端并加入 ``sys.path``，再复用主程序共享引导。
@@ -43,3 +44,30 @@ def pytest_configure(config) -> None:
         prepare_v2_backend()
     else:
         prepare_v1_backend()
+
+
+def _report_session_cleanup_error(session, name: str, err: Exception) -> None:
+    """记录收尾错误；原测试绿色时将会话标记为失败。"""
+    sys.stderr.write(f"\npytest session cleanup failed: {name}: {err!r}\n")
+    if session.exitstatus == 0:
+        session.exitstatus = 1
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:
+    """释放测试过程中创建的消息队列与日志后台线程"""
+    if _selected_generation(session.config) == "ci":
+        return
+
+    try:
+        from app.helper.message import stop_message
+
+        stop_message()
+    except Exception as err:
+        _report_session_cleanup_error(session, "message service", err)
+
+    try:
+        from app.log import LoggerManager
+
+        LoggerManager.shutdown()
+    except Exception as err:
+        _report_session_cleanup_error(session, "logger manager", err)


### PR DESCRIPTION
## 变更说明

- 为插件测试会话增加消息服务与 Logger 清理，避免 pytest 退出时遗留后台线程。
- 清理四条当前测试不再产生的 warning 过滤规则，保留三条精确的第三方弃用过滤。

## 影响范围

- `tests/conftest.py`：测试会话资源清理。
- `pytest.ini`：warning 过滤策略。

## 联动说明

- 主程序资源清理语义同步见 https://github.com/jxxghp/MoviePilot/pull/6116 。

## 验证

- `tests/run.py -q`：10 个 CI 测试、27 个 v2 测试及 2 个 v1 测试通过。
- 插件版本门禁通过。
- `git diff --check`：通过。

本 PR 为 Codex 协作提交

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 9fde8499e1b113e9ee6a3deae3175f28fcc123b0

- 测试会话结束时释放后台资源
- 清理消息服务与日志线程
- 清理失败将标记会话失败
- 收紧过期告警的忽略范围

<!-- pr-agent-summary:end -->