### PR TITLE
[codex] Agent Tokens 支持 provider 定向路由与配置复制

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -853,15 +853,16 @@
   },
   "AgentTokens": {
     "name": "Agent Tokens 管理",
-    "description": "管理多平台免费 Token 配额，按优先级自动切换 Agent LLM 供应商。",
+    "description": "管理多平台免费 Token 配额，支持定向选择及按优先级切换 Agent LLM 供应商。",
     "labels": "Agent,AI,系统",
-    "version": "1.0.13",
+    "version": "1.1.0",
     "icon": "agentresourceofficer.png",
     "author": "jxxghp",
     "level": 1,
     "system_version": ">=2.13.2",
     "release": true,
     "history": {
+      "v1.1.0": "支持按 provider ID 定向选择供应商、显式控制不可用时自动回退，并新增供应商配置复制功能",
       "v1.0.13": "区分限量模型使用进度和不限量模型调用量统计，避免不限量用量计入配额进度",
       "v1.0.12": "优化仪表板组件主题 token 适配和手动调整大小后的紧凑自适应布局",
       "v1.0.11": "重设计仪表板组件，改为紧凑卡片式配额概览并对齐主仪表板视觉风格",

--- a/plugins.v2/agenttokens/__init__.py
+++ b/plugins.v2/agenttokens/__init__.py
@@ -22,9 +22,9 @@ class AgentTokens(_PluginBase):
     """
 
     plugin_name = "Agent Tokens 管理"
-    plugin_desc = "管理多平台免费 Token 配额，按优先级自动切换 Agent LLM 供应商。"
+    plugin_desc = "管理多平台免费 Token 配额，支持定向选择及按优先级切换 Agent LLM 供应商。"
     plugin_icon = "agentresourceofficer.png"
-    plugin_version = "1.0.13"
+    plugin_version = "1.1.0"
     plugin_author = "jxxghp"
     author_url = "https://github.com/jxxghp"
     plugin_config_prefix = "agenttokens_"
@@ -192,6 +192,43 @@ class AgentTokens(_PluginBase):
             event_data[key] = value
         else:
             setattr(event_data, key, value)
+
+    @classmethod
+    def _event_metadata(cls, event_data: Any) -> Dict[str, Any]:
+        """
+        读取事件扩展元数据并返回可安全修改的副本。
+        """
+        metadata = cls._event_get(event_data, "metadata", {})
+        return dict(metadata) if isinstance(metadata, dict) else {}
+
+    @staticmethod
+    def _to_bool(value: Any) -> bool:
+        """
+        将事件中的布尔值兼容转换为 bool，避免字符串 false 被视为真值。
+        """
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    @classmethod
+    def _requested_provider_id(cls, event_data: Any, metadata: Dict[str, Any]) -> str:
+        """
+        从显式事件字段或扩展元数据中读取调用方指定的供应商 ID。
+        """
+        return cls._clean_text(
+            cls._event_get(event_data, "requested_provider_id")
+            or metadata.get("requested_provider_id")
+        )
+
+    @classmethod
+    def _allow_provider_failover(cls, event_data: Any, metadata: Dict[str, Any]) -> bool:
+        """
+        读取调用方是否允许指定供应商不可用时自动回退。
+        """
+        direct_value = cls._event_get(event_data, "allow_failover")
+        if direct_value is not None:
+            return cls._to_bool(direct_value)
+        return cls._to_bool(metadata.get("allow_failover"))
 
     @classmethod
     def _normalize_provider(cls, provider: dict, index: int) -> dict:
@@ -362,21 +399,63 @@ class AgentTokens(_PluginBase):
             "limited_usage_percent": limited_usage_percent,
         }
 
-    def _select_provider(self) -> Optional[dict]:
+    def _find_provider(self, provider_id: str) -> Optional[dict]:
         """
-        按优先级选择第一个启用且未耗尽 token 配额的供应商。
+        按稳定 ID 查找供应商配置。
+        """
+        return next(
+            (
+                provider
+                for provider in getattr(self, "_providers", [])
+                if provider.get("id") == provider_id
+            ),
+            None,
+        )
+
+    def _provider_unavailable_reason(
+        self,
+        provider: Optional[dict],
+        usage: Dict[str, dict],
+    ) -> Optional[str]:
+        """
+        校验供应商启用状态、连接配置和剩余额度，返回不可用原因。
+        """
+        if not provider:
+            return "供应商不存在"
+        if not provider.get("enabled"):
+            return "供应商已停用"
+        if not provider.get("base_url"):
+            return "供应商缺少 API 地址"
+        if not provider.get("api_key"):
+            return "供应商缺少 API Key"
+        if not provider.get("model"):
+            return "供应商缺少模型"
+        if self._provider_usage(provider, usage)["exhausted"]:
+            return "供应商 Token 额度已耗尽"
+        return None
+
+    def _select_provider(
+        self,
+        requested_provider_id: str = "",
+        allow_failover: bool = False,
+    ) -> Tuple[Optional[dict], Optional[str]]:
+        """
+        优先选择调用方指定供应商；允许回退时再按优先级选择其他可用项。
         """
         usage = self._load_usage()
+        requested_error = None
+        if requested_provider_id:
+            requested_provider = self._find_provider(requested_provider_id)
+            requested_error = self._provider_unavailable_reason(requested_provider, usage)
+            if not requested_error:
+                return requested_provider, None
+            if not allow_failover:
+                return None, requested_error
+
         for provider in getattr(self, "_providers", []):
-            if not provider.get("enabled"):
-                continue
-            if not provider.get("api_key") or not provider.get("model") or not provider.get("base_url"):
-                continue
-            provider_usage = self._provider_usage(provider, usage)
-            if provider_usage["exhausted"]:
-                continue
-            return provider
-        return None
+            if not self._provider_unavailable_reason(provider, usage):
+                return provider, requested_error
+        return None, requested_error
 
     def get_status(self) -> schemas.Response:
         """
@@ -430,20 +509,50 @@ class AgentTokens(_PluginBase):
     @eventmanager.register(ChainEventType.AgentLLMProvider, priority=50)
     def select_llm_provider(self, event: Event):
         """
-        响应 Agent LLM 供应商链式事件，写入当前可用供应商配置。
+        响应 Agent LLM 供应商链式事件，按定向或自动模式写入可用供应商配置。
         """
         if not self.get_state() or not event or not event.event_data:
             return
         if self._event_get(event.event_data, "selected_provider_id"):
             return
 
-        provider = self._select_provider()
+        metadata = self._event_metadata(event.event_data)
+        requested_provider_id = self._requested_provider_id(event.event_data, metadata)
+        allow_failover = self._allow_provider_failover(event.event_data, metadata)
+        provider, requested_error = self._select_provider(
+            requested_provider_id=requested_provider_id,
+            allow_failover=allow_failover,
+        )
         if not provider:
-            logger.info("Agent Tokens 没有可用供应商，Agent 将使用系统 LLM 配置")
+            metadata["provider_selection_status"] = "unavailable"
+            metadata["provider_selection_error"] = requested_error or "没有可用供应商"
+            if requested_provider_id:
+                metadata["requested_provider_id"] = requested_provider_id
+                logger.warning(
+                    f"Agent Tokens 指定供应商 [{requested_provider_id}] 不可用："
+                    f"{metadata['provider_selection_error']}"
+                )
+            else:
+                logger.info("Agent Tokens 没有可用供应商，Agent 将使用系统 LLM 配置")
+            self._event_set(event.event_data, "metadata", metadata)
             return
 
         provider_name = provider.get("name")
         model = provider.get("model")
+        if requested_provider_id:
+            metadata["requested_provider_id"] = requested_provider_id
+            if requested_error:
+                metadata["provider_selection_status"] = "fallback"
+                metadata["requested_provider_error"] = requested_error
+                logger.warning(
+                    f"Agent Tokens 指定供应商 [{requested_provider_id}] 不可用：{requested_error}，"
+                    f"已回退到 [{provider_name}]"
+                )
+            else:
+                metadata["provider_selection_status"] = "selected"
+        else:
+            metadata["provider_selection_status"] = "automatic"
+        metadata.pop("provider_selection_error", None)
         logger.info(f"Agent Tokens 分配 LLM 供应商：[{provider_name}] 模型：[{model}]")
 
         self._event_set(event.event_data, "provider", provider.get("provider") or "openai")
@@ -456,6 +565,7 @@ class AgentTokens(_PluginBase):
         self._event_set(event.event_data, "selected_provider_id", provider.get("id"))
         self._event_set(event.event_data, "selected_provider_name", provider.get("name"))
         self._event_set(event.event_data, "source", self.__class__.__name__)
+        self._event_set(event.event_data, "metadata", metadata)
 
     @eventmanager.register(EventType.AgentTokensUsage)
     def record_tokens_usage(self, event: Event):

--- a/plugins.v2/agenttokens/dist/assets/AgentTokensManager-BrJRxPdo.js
+++ b/plugins.v2/agenttokens/dist/assets/AgentTokensManager-BrJRxPdo.js
@@ -1,5 +1,5 @@
 import { importShared } from './__federation_fn_import-JrT3xvdd.js';
-import { _ as _export_sfc, f as formatTokens, P as PROVIDER_TYPE_OPTIONS, d as createProvider, b as buildProviderRows, a as buildProviderSummary, g as getNextProviderPriority, n as normalizeProvider } from './_plugin-vue_export-helper-hPgBDeLJ.js';
+import { _ as _export_sfc, f as formatTokens, P as PROVIDER_TYPE_OPTIONS, d as createProvider, b as buildProviderRows, a as buildProviderSummary, g as getNextProviderPriority, e as duplicateProvider, n as normalizeProvider } from './_plugin-vue_export-helper-CwgBSK_U.js';
 
 const {createElementVNode:_createElementVNode$3,openBlock:_openBlock$4,createElementBlock:_createElementBlock$2,createCommentVNode:_createCommentVNode$2,renderList:_renderList$1,Fragment:_Fragment$1,resolveComponent:_resolveComponent$4,createVNode:_createVNode$4,toDisplayString:_toDisplayString$4,createTextVNode:_createTextVNode$4,withCtx:_withCtx$4,unref:_unref$4,createBlock:_createBlock$4} = await importShared('vue');
 
@@ -32,7 +32,7 @@ const _sfc_main$4 = {
     default: false,
   },
 },
-  emits: ['edit', 'remove'],
+  emits: ['duplicate', 'edit', 'remove'],
   setup(__props, { emit: __emit }) {
 
 const props = __props;
@@ -47,6 +47,7 @@ function getMaskedApiKey(index) {
 return (_ctx, _cache) => {
   const _component_VSwitch = _resolveComponent$4("VSwitch");
   const _component_VChip = _resolveComponent$4("VChip");
+  const _component_VTooltip = _resolveComponent$4("VTooltip");
   const _component_VBtn = _resolveComponent$4("VBtn");
   const _component_VTable = _resolveComponent$4("VTable");
   const _component_VSheet = _resolveComponent$4("VSheet");
@@ -116,6 +117,22 @@ return (_ctx, _cache) => {
                 _createElementVNode$3("td", null, _toDisplayString$4(row.token_limit > 0 ? _unref$4(formatTokens)(row.token_limit) : '不限'), 1),
                 _createElementVNode$3("td", _hoisted_5$2, [
                   _createVNode$4(_component_VBtn, {
+                    icon: "mdi-content-copy",
+                    size: "small",
+                    variant: "text",
+                    onClick: $event => (emit('duplicate', index))
+                  }, {
+                    default: _withCtx$4(() => [
+                      _createVNode$4(_component_VTooltip, { activator: "parent" }, {
+                        default: _withCtx$4(() => [...(_cache[8] || (_cache[8] = [
+                          _createTextVNode$4("复制", -1)
+                        ]))]),
+                        _: 1
+                      })
+                    ]),
+                    _: 1
+                  }, 8, ["onClick"]),
+                  _createVNode$4(_component_VBtn, {
                     icon: "mdi-pencil",
                     size: "small",
                     variant: "text",
@@ -150,7 +167,7 @@ return (_ctx, _cache) => {
 }
 
 };
-const ProviderConfigTable = /*#__PURE__*/_export_sfc(_sfc_main$4, [['__scopeId',"data-v-cd4337d8"]]);
+const ProviderConfigTable = /*#__PURE__*/_export_sfc(_sfc_main$4, [['__scopeId',"data-v-41ff8fe1"]]);
 
 const {toDisplayString:_toDisplayString$3,createTextVNode:_createTextVNode$3,resolveComponent:_resolveComponent$3,withCtx:_withCtx$3,createVNode:_createVNode$3,unref:_unref$3,openBlock:_openBlock$3,createBlock:_createBlock$3} = await importShared('vue');
 
@@ -724,6 +741,13 @@ function editProvider(index) {
   showEditor.value = true;
 }
 
+// 复制供应商配置并以新增模式打开编辑弹窗。
+function copyProvider(index) {
+  editedProvider.value = duplicateProvider(providers.value[index]);
+  editorIndex.value = -1;
+  showEditor.value = true;
+}
+
 // 将弹窗中的供应商写回配置列表。
 function commitProvider() {
   const nextProviders = [...providers.value];
@@ -963,6 +987,7 @@ return (_ctx, _cache) => {
                   providers: providers.value,
                   "provider-rows": displayProviderRows.value,
                   "show-credentials": "",
+                  onDuplicate: copyProvider,
                   onEdit: editProvider,
                   onRemove: removeProvider
                 }, null, 8, ["providers", "provider-rows"])
@@ -987,6 +1012,6 @@ return (_ctx, _cache) => {
 }
 
 };
-const AgentTokensManager = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-0ad3e3fe"]]);
+const AgentTokensManager = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-1f84ec00"]]);
 
 export { AgentTokensManager as A };

--- a/plugins.v2/agenttokens/dist/assets/AgentTokensManager-HEXWTirG.css
+++ b/plugins.v2/agenttokens/dist/assets/AgentTokensManager-HEXWTirG.css
@@ -1,11 +1,11 @@
 
-.provider-table-shell[data-v-cd4337d8] {
+.provider-table-shell[data-v-41ff8fe1] {
   overflow-x: auto;
 }
-.provider-table-shell[data-v-cd4337d8] table {
+.provider-table-shell[data-v-41ff8fe1] table {
   min-width: 960px;
 }
-.truncate-cell[data-v-cd4337d8] {
+.truncate-cell[data-v-41ff8fe1] {
   max-width: 280px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -67,67 +67,67 @@
 }
 }
 
-.agenttokens-page[data-v-0ad3e3fe] {
+.agenttokens-page[data-v-1f84ec00] {
   display: flex;
   flex-direction: column;
   gap: 16px;
   padding: 16px;
 }
-.agenttokens-header[data-v-0ad3e3fe] {
+.agenttokens-header[data-v-1f84ec00] {
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
   gap: 8px;
 }
-.agenttokens-control-panel[data-v-0ad3e3fe] {
+.agenttokens-control-panel[data-v-1f84ec00] {
   display: flex;
   align-items: center;
   padding: 12px 16px;
 }
-.agenttokens-control-panel__switches[data-v-0ad3e3fe] {
+.agenttokens-control-panel__switches[data-v-1f84ec00] {
   display: flex;
   flex-wrap: wrap;
   gap: 8px 20px;
 }
-.agenttokens-overview-grid[data-v-0ad3e3fe] {
+.agenttokens-overview-grid[data-v-1f84ec00] {
   display: grid;
   grid-template-columns: minmax(0, 2fr) repeat(3, minmax(10rem, 1fr));
   gap: 12px;
 }
-.agenttokens-overview-card[data-v-0ad3e3fe] {
+.agenttokens-overview-card[data-v-1f84ec00] {
   min-block-size: 172px;
 }
-.agenttokens-stat-card[data-v-0ad3e3fe] {
+.agenttokens-stat-card[data-v-1f84ec00] {
   display: flex;
   align-items: center;
   gap: 12px;
   min-block-size: 104px;
   padding: 16px;
 }
-.agenttokens-stat-card__value[data-v-0ad3e3fe] {
+.agenttokens-stat-card__value[data-v-1f84ec00] {
   margin-block-start: 2px;
   font-size: 1.35rem;
   font-weight: 700;
   line-height: 1.25;
   overflow-wrap: anywhere;
 }
-.agenttokens-stat-card__hint[data-v-0ad3e3fe] {
+.agenttokens-stat-card__hint[data-v-1f84ec00] {
   margin-block-start: 2px;
   color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity));
   font-size: 0.78rem;
   line-height: 1.25;
   overflow-wrap: anywhere;
 }
-.agenttokens-content-panel[data-v-0ad3e3fe] {
+.agenttokens-content-panel[data-v-1f84ec00] {
   overflow: hidden;
 }
-.agenttokens-tabs-row[data-v-0ad3e3fe] {
+.agenttokens-tabs-row[data-v-1f84ec00] {
   padding-inline: 8px;
 }
-.agenttokens-window[data-v-0ad3e3fe] {
+.agenttokens-window[data-v-1f84ec00] {
   padding: 12px;
 }
-.agenttokens-table-actions[data-v-0ad3e3fe] {
+.agenttokens-table-actions[data-v-1f84ec00] {
   display: flex;
   justify-content: flex-end;
   flex-wrap: wrap;
@@ -135,21 +135,21 @@
   margin-block-end: 12px;
 }
 @media (max-width: 1100px) {
-.agenttokens-overview-grid[data-v-0ad3e3fe] {
+.agenttokens-overview-grid[data-v-1f84ec00] {
     grid-template-columns: repeat(3, minmax(0, 1fr));
 }
-.agenttokens-overview-card[data-v-0ad3e3fe] {
+.agenttokens-overview-card[data-v-1f84ec00] {
     grid-column: 1 / -1;
 }
 }
 @media (max-width: 700px) {
-.agenttokens-page[data-v-0ad3e3fe] {
+.agenttokens-page[data-v-1f84ec00] {
     padding: 12px;
 }
-.agenttokens-overview-grid[data-v-0ad3e3fe] {
+.agenttokens-overview-grid[data-v-1f84ec00] {
     grid-template-columns: 1fr;
 }
-.agenttokens-stat-card[data-v-0ad3e3fe] {
+.agenttokens-stat-card[data-v-1f84ec00] {
     min-block-size: 88px;
 }
 }

--- a/plugins.v2/agenttokens/dist/assets/__federation_expose_AppPage-DQUdXdQU.js
+++ b/plugins.v2/agenttokens/dist/assets/__federation_expose_AppPage-DQUdXdQU.js
@@ -1,6 +1,6 @@
 import { importShared } from './__federation_fn_import-JrT3xvdd.js';
-import { A as AgentTokensManager } from './AgentTokensManager-ldQ2v6Va.js';
-import { u as unwrapResponse } from './_plugin-vue_export-helper-hPgBDeLJ.js';
+import { A as AgentTokensManager } from './AgentTokensManager-BrJRxPdo.js';
+import { u as unwrapResponse } from './_plugin-vue_export-helper-CwgBSK_U.js';
 
 const {openBlock:_openBlock,createBlock:_createBlock} = await importShared('vue');
 

--- a/plugins.v2/agenttokens/dist/assets/__federation_expose_Config-SzyC8FhE.js
+++ b/plugins.v2/agenttokens/dist/assets/__federation_expose_Config-SzyC8FhE.js
@@ -1,6 +1,6 @@
 import { importShared } from './__federation_fn_import-JrT3xvdd.js';
-import { A as AgentTokensManager } from './AgentTokensManager-ldQ2v6Va.js';
-import { c as cloneConfig } from './_plugin-vue_export-helper-hPgBDeLJ.js';
+import { A as AgentTokensManager } from './AgentTokensManager-BrJRxPdo.js';
+import { c as cloneConfig } from './_plugin-vue_export-helper-CwgBSK_U.js';
 
 const {createElementVNode:_createElementVNode,resolveComponent:_resolveComponent,createVNode:_createVNode,withCtx:_withCtx,openBlock:_openBlock,createElementBlock:_createElementBlock} = await importShared('vue');
 

--- a/plugins.v2/agenttokens/dist/assets/__federation_expose_Dashboard-DOX-2z_5.js
+++ b/plugins.v2/agenttokens/dist/assets/__federation_expose_Dashboard-DOX-2z_5.js
@@ -1,5 +1,5 @@
 import { importShared } from './__federation_fn_import-JrT3xvdd.js';
-import { _ as _export_sfc, f as formatTokens, u as unwrapResponse } from './_plugin-vue_export-helper-hPgBDeLJ.js';
+import { _ as _export_sfc, f as formatTokens, u as unwrapResponse } from './_plugin-vue_export-helper-CwgBSK_U.js';
 
 const {resolveComponent:_resolveComponent,createVNode:_createVNode,withCtx:_withCtx,toDisplayString:_toDisplayString,createTextVNode:_createTextVNode,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,createBlock:_createBlock,createElementVNode:_createElementVNode,unref:_unref,renderList:_renderList,Fragment:_Fragment,normalizeClass:_normalizeClass} = await importShared('vue');
 

--- a/plugins.v2/agenttokens/dist/assets/__federation_expose_Page-CjuWA0yS.js
+++ b/plugins.v2/agenttokens/dist/assets/__federation_expose_Page-CjuWA0yS.js
@@ -1,6 +1,6 @@
 import { importShared } from './__federation_fn_import-JrT3xvdd.js';
-import _sfc_main$1 from './__federation_expose_AppPage-Bm_kDQkZ.js';
-import { _ as _export_sfc } from './_plugin-vue_export-helper-hPgBDeLJ.js';
+import _sfc_main$1 from './__federation_expose_AppPage-DQUdXdQU.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-CwgBSK_U.js';
 
 const {createElementVNode:_createElementVNode,resolveComponent:_resolveComponent,createVNode:_createVNode,withCtx:_withCtx,openBlock:_openBlock,createElementBlock:_createElementBlock} = await importShared('vue');
 

--- a/plugins.v2/agenttokens/dist/assets/_plugin-vue_export-helper-CwgBSK_U.js
+++ b/plugins.v2/agenttokens/dist/assets/_plugin-vue_export-helper-CwgBSK_U.js
@@ -24,6 +24,23 @@ function createProvider() {
   }
 }
 
+// 生成前端临时稳定 ID，保存后继续由服务端标准化并持久化。
+function createProviderId() {
+  const randomUuid = globalThis.crypto?.randomUUID?.();
+  if (randomUuid) return randomUuid.replaceAll('-', '')
+  return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`
+}
+
+// 复制供应商连接配置，同时清空用量并生成独立 ID。
+function duplicateProvider(provider) {
+  return {
+    ...provider,
+    id: createProviderId(),
+    name: provider?.name ? `${provider.name} 副本` : '',
+    used_tokens: 0,
+  }
+}
+
 // 生成深拷贝配置，避免直接修改父组件传入对象。
 function cloneConfig(config) {
   return JSON.parse(JSON.stringify(config || { enabled: false, show_sidebar_nav: true, providers: [] }))
@@ -123,4 +140,4 @@ const _export_sfc = (sfc, props) => {
   return target;
 };
 
-export { PROVIDER_TYPE_OPTIONS as P, _export_sfc as _, buildProviderSummary as a, buildProviderRows as b, cloneConfig as c, createProvider as d, formatTokens as f, getNextProviderPriority as g, normalizeProvider as n, unwrapResponse as u };
+export { PROVIDER_TYPE_OPTIONS as P, _export_sfc as _, buildProviderSummary as a, buildProviderRows as b, cloneConfig as c, createProvider as d, duplicateProvider as e, formatTokens as f, getNextProviderPriority as g, normalizeProvider as n, unwrapResponse as u };

--- a/plugins.v2/agenttokens/dist/assets/index-D2eo9pXS.js
+++ b/plugins.v2/agenttokens/dist/assets/index-D2eo9pXS.js
@@ -1,5 +1,5 @@
 import { importShared } from './__federation_fn_import-JrT3xvdd.js';
-import _sfc_main from './__federation_expose_AppPage-Bm_kDQkZ.js';
+import _sfc_main from './__federation_expose_AppPage-DQUdXdQU.js';
 
 true&&(function polyfill() {
   const relList = document.createElement("link").relList;

--- a/plugins.v2/agenttokens/dist/assets/remoteEntry.js
+++ b/plugins.v2/agenttokens/dist/assets/remoteEntry.js
@@ -2,17 +2,17 @@ const currentImports = {};
       const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
       let moduleMap = {
 "./Page":()=>{
-      dynamicLoadingCss(["__federation_expose_Page-vwwFlnk-.css","AgentTokensManager-Dx6GhC_n.css"], false, './Page');
-      return __federation_import('./__federation_expose_Page-BIduEcvQ.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_Page-vwwFlnk-.css","AgentTokensManager-HEXWTirG.css"], false, './Page');
+      return __federation_import('./__federation_expose_Page-CjuWA0yS.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Config":()=>{
-      dynamicLoadingCss(["AgentTokensManager-Dx6GhC_n.css"], false, './Config');
-      return __federation_import('./__federation_expose_Config-CgJ_szxu.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["AgentTokensManager-HEXWTirG.css"], false, './Config');
+      return __federation_import('./__federation_expose_Config-SzyC8FhE.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Dashboard":()=>{
       dynamicLoadingCss(["__federation_expose_Dashboard-C8H85WtC.css"], false, './Dashboard');
-      return __federation_import('./__federation_expose_Dashboard-DE4MEn6w.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      return __federation_import('./__federation_expose_Dashboard-DOX-2z_5.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./AppPage":()=>{
-      dynamicLoadingCss(["AgentTokensManager-Dx6GhC_n.css"], false, './AppPage');
-      return __federation_import('./__federation_expose_AppPage-Bm_kDQkZ.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
+      dynamicLoadingCss(["AgentTokensManager-HEXWTirG.css"], false, './AppPage');
+      return __federation_import('./__federation_expose_AppPage-DQUdXdQU.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
       const seen = {};
       const dynamicLoadingCss = (cssFilePaths, dontAppendStylesToHead, exposeItemName) => {
         const metaUrl = import.meta.url;

--- a/plugins.v2/agenttokens/dist/index.html
+++ b/plugins.v2/agenttokens/dist/index.html
@@ -1,7 +1,7 @@
-<script type="module" crossorigin src="/assets/index-DaM_wfdH.js"></script>
+<script type="module" crossorigin src="/assets/index-D2eo9pXS.js"></script>
 <link rel="modulepreload" crossorigin href="/assets/__federation_fn_import-JrT3xvdd.js">
-<link rel="modulepreload" crossorigin href="/assets/_plugin-vue_export-helper-hPgBDeLJ.js">
-<link rel="modulepreload" crossorigin href="/assets/AgentTokensManager-ldQ2v6Va.js">
-<link rel="modulepreload" crossorigin href="/assets/__federation_expose_AppPage-Bm_kDQkZ.js">
-<link rel="stylesheet" crossorigin href="/assets/AgentTokensManager-Dx6GhC_n.css">
+<link rel="modulepreload" crossorigin href="/assets/_plugin-vue_export-helper-CwgBSK_U.js">
+<link rel="modulepreload" crossorigin href="/assets/AgentTokensManager-BrJRxPdo.js">
+<link rel="modulepreload" crossorigin href="/assets/__federation_expose_AppPage-DQUdXdQU.js">
+<link rel="stylesheet" crossorigin href="/assets/AgentTokensManager-HEXWTirG.css">
 <div id="app"></div>

--- a/plugins.v2/agenttokens/package.json
+++ b/plugins.v2/agenttokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moviepilot-agenttokens-plugin",
   "private": true,
-  "version": "1.0.13",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/plugins.v2/agenttokens/src/components/AgentTokensManager.vue
+++ b/plugins.v2/agenttokens/src/components/AgentTokensManager.vue
@@ -8,6 +8,7 @@ import {
   buildProviderRows,
   buildProviderSummary,
   createProvider,
+  duplicateProvider,
   formatTokens,
   getNextProviderPriority,
   normalizeProvider,
@@ -73,6 +74,13 @@ function addProvider() {
 function editProvider(index) {
   editedProvider.value = { ...providers.value[index] }
   editorIndex.value = index
+  showEditor.value = true
+}
+
+// 复制供应商配置并以新增模式打开编辑弹窗。
+function copyProvider(index) {
+  editedProvider.value = duplicateProvider(providers.value[index])
+  editorIndex.value = -1
   showEditor.value = true
 }
 
@@ -185,6 +193,7 @@ function resetAllUsage() {
             :providers="providers"
             :provider-rows="displayProviderRows"
             show-credentials
+            @duplicate="copyProvider"
             @edit="editProvider"
             @remove="removeProvider"
           />

--- a/plugins.v2/agenttokens/src/components/ProviderConfigTable.vue
+++ b/plugins.v2/agenttokens/src/components/ProviderConfigTable.vue
@@ -16,7 +16,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['edit', 'remove'])
+const emit = defineEmits(['duplicate', 'edit', 'remove'])
 
 // 获取管理页服务端返回的脱敏 Key。
 function getMaskedApiKey(index) {
@@ -59,6 +59,9 @@ function getMaskedApiKey(index) {
           <td>{{ row.model }}</td>
           <td>{{ row.token_limit > 0 ? formatTokens(row.token_limit) : '不限' }}</td>
           <td class="text-right">
+            <VBtn icon="mdi-content-copy" size="small" variant="text" @click="emit('duplicate', index)">
+              <VTooltip activator="parent">复制</VTooltip>
+            </VBtn>
             <VBtn icon="mdi-pencil" size="small" variant="text" @click="emit('edit', index)" />
             <VBtn icon="mdi-delete" size="small" variant="text" color="error" @click="emit('remove', index)" />
           </td>

--- a/plugins.v2/agenttokens/src/provider.js
+++ b/plugins.v2/agenttokens/src/provider.js
@@ -24,6 +24,23 @@ export function createProvider() {
   }
 }
 
+// 生成前端临时稳定 ID，保存后继续由服务端标准化并持久化。
+export function createProviderId() {
+  const randomUuid = globalThis.crypto?.randomUUID?.()
+  if (randomUuid) return randomUuid.replaceAll('-', '')
+  return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`
+}
+
+// 复制供应商连接配置，同时清空用量并生成独立 ID。
+export function duplicateProvider(provider) {
+  return {
+    ...provider,
+    id: createProviderId(),
+    name: provider?.name ? `${provider.name} 副本` : '',
+    used_tokens: 0,
+  }
+}
+
 // 生成深拷贝配置，避免直接修改父组件传入对象。
 export function cloneConfig(config) {
   return JSON.parse(JSON.stringify(config || { enabled: false, show_sidebar_nav: true, providers: [] }))

--- a/tests/v2/agenttokens/test_plugin.py
+++ b/tests/v2/agenttokens/test_plugin.py
@@ -5,8 +5,33 @@
 再以顶层包名导入插件。
 """
 from unittest.mock import patch
+from types import SimpleNamespace
 
 from agenttokens import AgentTokens  # noqa: E402
+
+
+def _provider(provider_id: str, priority: int, **overrides) -> dict:
+    """构造具备完整连接配置的供应商测试数据。"""
+    provider = {
+        "id": provider_id,
+        "enabled": True,
+        "name": provider_id.title(),
+        "provider": "openai",
+        "base_url": f"https://{provider_id}.example.com",
+        "api_key": f"{provider_id}-key",
+        "model": f"{provider_id}-model",
+        "priority": priority,
+    }
+    provider.update(overrides)
+    return provider
+
+
+def _initialized_plugin(providers: list[dict]) -> AgentTokens:
+    """创建启用状态的插件实例，并隔离配置持久化副作用。"""
+    plugin = AgentTokens()
+    with patch.object(plugin, "update_config"):
+        plugin.init_plugin({"enabled": True, "providers": providers})
+    return plugin
 
 
 def test_sidebar_nav_respects_config():
@@ -70,3 +95,82 @@ def test_summary_separates_limited_progress_from_unlimited_usage():
     assert summary["total_used"] == 1350
     assert summary["limited_remaining"] == 600
     assert summary["limited_usage_percent"] == 40
+
+
+def test_select_llm_provider_uses_requested_provider_from_metadata():
+    """metadata 指定的供应商应优先于自动优先级选择并完整回填配置。"""
+    plugin = _initialized_plugin([
+        _provider("primary", 1),
+        _provider("requested", 2),
+    ])
+    event = SimpleNamespace(event_data={
+        "metadata": {"requested_provider_id": "requested"},
+    })
+
+    with patch.object(plugin, "get_data", return_value={}):
+        plugin.select_llm_provider(event)
+
+    assert event.event_data["selected_provider_id"] == "requested"
+    assert event.event_data["selected_provider_name"] == "Requested"
+    assert event.event_data["base_url"] == "https://requested.example.com"
+    assert event.event_data["api_key"] == "requested-key"
+    assert event.event_data["model"] == "requested-model"
+    assert event.event_data["metadata"]["provider_selection_status"] == "selected"
+
+
+def test_select_llm_provider_accepts_direct_requested_provider_field():
+    """字典事件中的兼容字段 requested_provider_id 应支持定向选择。"""
+    plugin = _initialized_plugin([
+        _provider("primary", 1),
+        _provider("requested", 2),
+    ])
+    event = SimpleNamespace(event_data={"requested_provider_id": "requested"})
+
+    with patch.object(plugin, "get_data", return_value={}):
+        plugin.select_llm_provider(event)
+
+    assert event.event_data["selected_provider_id"] == "requested"
+    assert event.event_data["metadata"]["requested_provider_id"] == "requested"
+
+
+def test_requested_provider_unavailable_does_not_fallback_by_default():
+    """指定供应商不可用且未授权回退时，应保持未选择状态并写回失败原因。"""
+    plugin = _initialized_plugin([
+        _provider("primary", 1),
+        _provider("requested", 2, enabled=False),
+    ])
+    event = SimpleNamespace(event_data={
+        "metadata": {"requested_provider_id": "requested"},
+    })
+
+    with patch.object(plugin, "get_data", return_value={}):
+        plugin.select_llm_provider(event)
+
+    assert "selected_provider_id" not in event.event_data
+    assert event.event_data["metadata"]["provider_selection_status"] == "unavailable"
+    assert event.event_data["metadata"]["provider_selection_error"] == "供应商已停用"
+
+
+def test_requested_provider_can_explicitly_fallback():
+    """调用方显式允许回退时，应在指定项不可用后选择优先级最高的可用供应商。"""
+    plugin = _initialized_plugin([
+        _provider("primary", 1),
+        _provider("requested", 2, token_limit=100),
+    ])
+    event = SimpleNamespace(event_data={
+        "metadata": {
+            "requested_provider_id": "requested",
+            "allow_failover": True,
+        },
+    })
+
+    with patch.object(
+        plugin,
+        "get_data",
+        return_value={"requested": {"total_tokens": 100}},
+    ):
+        plugin.select_llm_provider(event)
+
+    assert event.event_data["selected_provider_id"] == "primary"
+    assert event.event_data["metadata"]["provider_selection_status"] == "fallback"
+    assert event.event_data["metadata"]["requested_provider_error"] == "供应商 Token 额度已耗尽"


### PR DESCRIPTION
## 变更内容

- 支持通过 `requested_provider_id` 事件字段或 `metadata.requested_provider_id` 定向选择供应商
- 校验供应商启用状态、连接配置和剩余额度；指定项不可用时默认不静默回退
- 支持调用方通过 `allow_failover` 显式允许按优先级回退，并在 metadata 写回选择状态与原因
- 在供应商操作区增加复制按钮，复制连接配置、生成新 ID、清零用量并打开编辑窗口
- 将 Agent Tokens 版本升级至 1.1.0，并更新前端构建产物和插件索引

## 原因与影响

原选择逻辑只会返回优先级最高的可用供应商，并将 `selected_provider_id` 仅作为结果标识，调用方无法为独立场景请求指定配置。新协议保持未指定 ID 时的原有自动选择行为，同时让定向调用具备明确、可观察的失败与回退语义。

Issue 评论中提出的“同一次 LLM 请求失败后重试并切换供应商”需要 MoviePilot 调用运行时提供失败重试/重新选路钩子；插件目前只参与调用前选择和调用后汇总记录，因此本 PR 不伪造该运行时能力。

Refs #1094

## 验证

- `.venv/bin/python tests/run.py -q`（V1 10 passed、V2 50 passed、CI 2 passed）
- `.venv/bin/python .github/scripts/check_plugin_versions.py package.json package.v2.json`
- `npm run build`（Agent Tokens）
- `duplicateProvider` Node 独立检查
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 8602b024037c5a78a385aace71196e5904927d73

- 支持按 `provider ID` 定向路由
  - 兼容事件字段及 `metadata` 请求
  - 校验配置、启用状态与额度
  - 可显式允许优先级回退
  - 写回选择状态和失败原因
- 新增供应商配置复制入口
  - 生成独立 ID 并清零用量
  - 自动打开新增编辑窗口
- 升级 Agent Tokens 至 `1.1.0`
- 补充定向选择与回退单元测试
<!-- pr-agent-summary:end -->
