### PR TITLE
sync: publish StorageCleanup v1.0.15 source

### DIFF
--- a/plugins.v2/storagecleanup/__init__.py
+++ b/plugins.v2/storagecleanup/__init__.py
@@ -14,9 +14,9 @@ from .bridge_client import DEFAULT_GATEWAY, DEFAULT_TOKEN_FILE, CleanupBridge
 
 class StorageCleanup(_PluginBase):
     plugin_name = "存储清理"
-    plugin_desc = "看清媒体、做种、H&R 与硬链接关系后再清理。"
+    plugin_desc = "一键清理全链路耦合：自动发现 MoviePilot、qB、媒体目录与硬链接关系，联动核验做种、H&R 后安全释放空间。无特定媒体服务器也能使用。需先部署 NAS 清理台服务。"
     plugin_icon = "https://raw.githubusercontent.com/Hommchen/nas-storage-cleanup-ui-public/main/public/storagecleanup.svg"
-    plugin_version = "1.0.7"
+    plugin_version = "1.0.15"
     plugin_author = "Hommchen"
     author_url = "https://github.com/Hommchen/nas-storage-cleanup-ui-public"
     plugin_config_prefix = "storagecleanup_"
@@ -40,7 +40,7 @@ class StorageCleanup(_PluginBase):
 
     @staticmethod
     def get_render_mode() -> Tuple[str, str]:
-        return "vue", "dist/v1.0.7/assets"
+        return "vue", "dist/v1.0.15/assets"
 
     @staticmethod
     def get_form() -> Tuple[List[dict], Dict[str, Any]]:
@@ -48,9 +48,10 @@ class StorageCleanup(_PluginBase):
             {
                 "key": "gateway_url",
                 "type": "text",
-                "title": "清理台网关地址",
+                "title": "清理台后台地址（管理员）",
                 "required": True,
                 "placeholder": DEFAULT_GATEWAY,
+                "help": "由 NAS 管理员部署清理台后提供；插件不会通过 SSH 登录 NAS。",
             },
             {
                 "key": "token_file",
@@ -58,7 +59,7 @@ class StorageCleanup(_PluginBase):
                 "title": "控制令牌文件路径",
                 "required": True,
                 "placeholder": DEFAULT_TOKEN_FILE,
-                "help": "仅填写 MoviePilot 容器内可读的文件路径，不填写令牌内容。",
+                "help": "由 NAS 管理员部署清理台后提供；仅填写 MoviePilot 容器内可读的文件路径，不填写令牌内容。",
             },
         ], {
             "gateway_url": DEFAULT_GATEWAY,
@@ -87,6 +88,7 @@ class StorageCleanup(_PluginBase):
             self._route("/status", self.status, ["GET"], "读取清理台状态"),
             self._route("/config", self.config_status, ["GET"], "读取清理台配置"),
             self._route("/config", self.update_config, ["POST"], "保存清理台配置"),
+            self._route("/discover", self.discover, ["GET"], "自动发现 NAS 配置"),
             self._route("/snapshot", self.snapshot, ["GET"], "读取资源快照"),
             self._route("/refresh", self.refresh, ["POST"], "刷新资源快照"),
             self._route("/plan", self.plan, ["POST"], "生成清理计划"),
@@ -162,6 +164,9 @@ class StorageCleanup(_PluginBase):
 
     def update_config(self, payload: dict = Body(...)) -> JSONResponse:
         return self._proxy("/v1/config", method="POST", payload=payload)
+
+    def discover(self) -> JSONResponse:
+        return self._proxy("/v1/discover")
 
     def refresh(self, payload: dict = Body(default={})) -> JSONResponse:
         return self._proxy("/v1/refresh", method="POST", payload=payload)

--- a/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_expose_AppPage-DHXLALqV.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_expose_AppPage-DHXLALqV.css
@@ -1,0 +1,354 @@
+
+.cleanup-app[data-v-4d4b6cc7] {
+  --ink: rgb(var(--v-theme-on-background, 30, 41, 59));
+  --muted: rgba(var(--v-theme-on-background, 30, 41, 59), .58);
+  --line: rgba(var(--v-border-color, 100, 116, 139), .18);
+  --surface: rgb(var(--v-theme-surface, 255, 255, 255));
+  --primary: rgb(var(--v-theme-primary, 59, 130, 246));
+  --primary-soft: rgba(var(--v-theme-primary, 59, 130, 246), .10);
+  --good: #16836b;
+  --warn: #b86b11;
+  --danger: #c44b47;
+  color: var(--ink);
+  min-width: 980px;
+  padding: 18px 24px 110px;
+}
+button[data-v-4d4b6cc7], input[data-v-4d4b6cc7] { font: inherit;
+}
+button[data-v-4d4b6cc7] { color: inherit;
+}
+.page-header[data-v-4d4b6cc7] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+.eyebrow[data-v-4d4b6cc7] { margin: 0 0 4px; color: var(--primary); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase;
+}
+.page-header h1[data-v-4d4b6cc7] { margin: 0; font-size: 30px; line-height: 1.2;
+}
+.page-header > div > span[data-v-4d4b6cc7] { color: var(--muted); font-size: 14px;
+}
+.status-card[data-v-4d4b6cc7] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 220px;
+  padding: 10px 14px;
+  border: 1px solid rgba(22, 131, 107, .22);
+  border-radius: 12px;
+  background: rgba(22, 131, 107, .08);
+}
+.status-card.danger[data-v-4d4b6cc7] { border-color: rgba(196, 75, 71, .24); background: rgba(196, 75, 71, .08);
+}
+.status-card i[data-v-4d4b6cc7], .notice i[data-v-4d4b6cc7], .safety-note i[data-v-4d4b6cc7] {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  background: rgba(22, 131, 107, .12);
+  color: var(--good);
+  font-style: normal;
+  font-weight: 900;
+}
+.status-card p[data-v-4d4b6cc7], .notice p[data-v-4d4b6cc7], .safety-note p[data-v-4d4b6cc7], .plan-resources p[data-v-4d4b6cc7], .gap-row p[data-v-4d4b6cc7], .recovery-row p[data-v-4d4b6cc7] { display: grid; gap: 2px; margin: 0;
+}
+.status-card strong[data-v-4d4b6cc7] { font-size: 13px;
+}
+.status-card span[data-v-4d4b6cc7] { color: var(--muted); font-size: 12px;
+}
+.toolbar[data-v-4d4b6cc7] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.search[data-v-4d4b6cc7] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  height: 46px;
+  padding: 0 15px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+}
+.search span[data-v-4d4b6cc7] { color: var(--muted); font-size: 21px;
+}
+.search input[data-v-4d4b6cc7] { width: 100%; border: 0; outline: 0; color: inherit; background: transparent; font-size: 15px;
+}
+.safe-toggle[data-v-4d4b6cc7] { display: flex; align-items: center; gap: 8px; height: 44px; white-space: nowrap; font-size: 14px; font-weight: 650;
+}
+.safe-toggle input[data-v-4d4b6cc7], .risk-check input[data-v-4d4b6cc7] { position: absolute; opacity: 0;
+}
+.safe-toggle > span[data-v-4d4b6cc7] {
+  width: 38px;
+  height: 22px;
+  padding: 3px;
+  border-radius: 99px;
+  background: rgba(100, 116, 139, .24);
+}
+.safe-toggle > span[data-v-4d4b6cc7]::after { display: block; width: 16px; height: 16px; border-radius: 50%; background: white; content: ''; transition: .2s;
+}
+.safe-toggle input:checked + span[data-v-4d4b6cc7] { background: var(--primary);
+}
+.safe-toggle input:checked + span[data-v-4d4b6cc7]::after { transform: translateX(16px);
+}
+.soft-button[data-v-4d4b6cc7], .icon-button[data-v-4d4b6cc7] {
+  height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: var(--surface);
+  cursor: pointer;
+}
+.soft-button[data-v-4d4b6cc7] { padding: 0 14px;
+}
+.icon-button[data-v-4d4b6cc7] { width: 42px; font-size: 20px;
+}
+.notice[data-v-4d4b6cc7] {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin: 0 0 14px;
+  padding: 12px 16px;
+  border: 1px solid rgba(184, 107, 17, .22);
+  border-radius: 12px;
+  background: rgba(184, 107, 17, .07);
+  text-align: left;
+  cursor: pointer;
+}
+.notice p[data-v-4d4b6cc7] { flex: 1;
+}
+.notice p span[data-v-4d4b6cc7] { color: var(--muted); font-size: 13px;
+}
+.notice b[data-v-4d4b6cc7] { color: var(--warn); font-size: 13px;
+}
+.notice.critical[data-v-4d4b6cc7] { border-color: rgba(196, 75, 71, .25); background: rgba(196, 75, 71, .08);
+}
+.notice.critical b[data-v-4d4b6cc7] { color: var(--danger);
+}
+.filters[data-v-4d4b6cc7] { display: flex; gap: 6px; margin-bottom: 12px;
+}
+.filters button[data-v-4d4b6cc7] {
+  padding: 8px 13px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.filters button.active[data-v-4d4b6cc7] { border-color: var(--line); background: var(--surface); color: var(--ink); font-weight: 750; box-shadow: 0 4px 12px rgba(15, 23, 42, .04);
+}
+.filters span[data-v-4d4b6cc7] { margin-left: 5px; padding: 2px 6px; border-radius: 99px; background: rgba(100, 116, 139, .10); font-size: 11px;
+}
+.resource-card[data-v-4d4b6cc7] { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--surface);
+}
+.table-head[data-v-4d4b6cc7], .resource-row[data-v-4d4b6cc7] {
+  display: grid;
+  grid-template-columns: 42px minmax(270px, 1.55fr) minmax(170px, .85fr) minmax(360px, 1.65fr) minmax(125px, .65fr) minmax(230px, 1fr);
+  align-items: center;
+}
+.table-head[data-v-4d4b6cc7] { min-height: 50px; padding: 0 16px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 12px; font-weight: 800;
+}
+.resource-row[data-v-4d4b6cc7] { min-height: 126px; padding: 0 16px; border-bottom: 1px solid var(--line);
+}
+.resource-row[data-v-4d4b6cc7]:last-child { border-bottom: 0;
+}
+.resource-row.selected[data-v-4d4b6cc7] { background: var(--primary-soft);
+}
+.select-all[data-v-4d4b6cc7], .row-check[data-v-4d4b6cc7] {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid rgba(100, 116, 139, .35);
+  border-radius: 7px;
+  background: transparent;
+  cursor: pointer;
+}
+.row-check.locked[data-v-4d4b6cc7] { border-color: rgba(184, 107, 17, .25); background: rgba(184, 107, 17, .08); color: var(--warn); font-size: 10px; cursor: not-allowed;
+}
+.resource-title[data-v-4d4b6cc7], .stack-cell[data-v-4d4b6cc7] { display: grid; gap: 4px; min-width: 0; padding-right: 16px;
+}
+.resource-title strong[data-v-4d4b6cc7] { font-size: 17px;
+}
+.resource-title b[data-v-4d4b6cc7] { overflow: hidden; color: var(--ink); font-size: 13px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; opacity: .78;
+}
+.resource-title span[data-v-4d4b6cc7], .stack-cell span[data-v-4d4b6cc7], .impact span[data-v-4d4b6cc7], .seed-task span[data-v-4d4b6cc7] { color: var(--muted); font-size: 12px; line-height: 1.45;
+}
+.stack-cell strong[data-v-4d4b6cc7] { font-size: 14px;
+}
+.stack-cell.library strong[data-v-4d4b6cc7] { color: var(--good);
+}
+.stack-cell.size strong[data-v-4d4b6cc7] { font-size: 16px;
+}
+.seed-cell[data-v-4d4b6cc7] { display: grid; gap: 4px; padding-right: 18px;
+}
+.seed-task[data-v-4d4b6cc7] {
+  display: grid;
+  grid-template-columns: 62px minmax(72px, auto) minmax(100px, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding-left: 8px;
+  border-left: 2px solid rgba(100, 116, 139, .28);
+}
+.seed-task i[data-v-4d4b6cc7] { padding: 4px 8px; border-radius: 99px; background: rgba(100, 116, 139, .1); font-size: 11px; font-style: normal; font-weight: 800; text-align: center; white-space: nowrap;
+}
+.seed-task strong[data-v-4d4b6cc7] { font-size: 13px;
+}
+.seed-task.warning[data-v-4d4b6cc7] { border-color: rgba(184, 107, 17, .45);
+}
+.seed-task.warning i[data-v-4d4b6cc7] { color: var(--warn); background: rgba(184, 107, 17, .1);
+}
+.seed-task.protected[data-v-4d4b6cc7] { border-color: rgba(196, 75, 71, .45);
+}
+.seed-task.protected i[data-v-4d4b6cc7] { color: var(--danger); background: rgba(196, 75, 71, .1);
+}
+.impact[data-v-4d4b6cc7] { display: grid; gap: 4px; padding-left: 10px; border-left: 2px solid rgba(22, 131, 107, .35);
+}
+.impact strong[data-v-4d4b6cc7] { font-size: 13px;
+}
+.impact.danger[data-v-4d4b6cc7] { border-color: rgba(196, 75, 71, .5);
+}
+.impact.danger strong[data-v-4d4b6cc7] { color: var(--danger);
+}
+.empty-state[data-v-4d4b6cc7] { display: grid; place-items: center; min-height: 150px; color: var(--muted);
+}
+.action-bar[data-v-4d4b6cc7] {
+  position: fixed;
+  z-index: 20;
+  right: 30px;
+  bottom: 22px;
+  left: calc(var(--v-layout-left, 0px) + 30px);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, .14);
+  border-radius: 16px;
+  background: #17243a;
+  color: white;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, .28);
+}
+.selected-count[data-v-4d4b6cc7] { display: grid; place-items: center; width: 44px; height: 44px; border-radius: 12px; background: #3f70b7; font-size: 18px; font-weight: 900;
+}
+.action-bar > p[data-v-4d4b6cc7] { display: grid; gap: 1px; min-width: 160px; margin: 0;
+}
+.action-bar > p span[data-v-4d4b6cc7], .action-level span[data-v-4d4b6cc7] { color: rgba(255, 255, 255, .64); font-size: 11px;
+}
+.clear-button[data-v-4d4b6cc7] { border: 0; background: transparent; color: rgba(255, 255, 255, .66); cursor: pointer;
+}
+.action-level[data-v-4d4b6cc7] { display: grid; flex: 1; gap: 3px; padding: 10px 14px; border: 1px solid rgba(255, 255, 255, .17); border-radius: 11px; background: rgba(255, 255, 255, .06); color: white; text-align: left; cursor: pointer;
+}
+.action-level.delete[data-v-4d4b6cc7] { border-color: rgba(255, 142, 136, .32); background: rgba(196, 75, 71, .28);
+}
+.modal-backdrop[data-v-4d4b6cc7] {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  background: rgba(15, 23, 42, .55);
+  backdrop-filter: blur(6px);
+}
+.modal[data-v-4d4b6cc7] {
+  overflow: auto;
+  width: min(760px, 90vw);
+  max-height: 90vh;
+  padding: 24px;
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, .3);
+}
+.modal > header[data-v-4d4b6cc7] { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 16px;
+}
+.modal > header span[data-v-4d4b6cc7] { color: var(--primary); font-size: 11px; font-weight: 850; letter-spacing: .08em;
+}
+.modal h2[data-v-4d4b6cc7] { margin: 3px 0 0; font-size: 24px;
+}
+.modal > header button[data-v-4d4b6cc7] { width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 10px; background: transparent; font-size: 22px; cursor: pointer;
+}
+.mode-summary[data-v-4d4b6cc7], .plan-state[data-v-4d4b6cc7], .safety-note[data-v-4d4b6cc7] { display: grid; gap: 4px; margin-bottom: 12px; padding: 13px 15px; border-radius: 12px; background: var(--primary-soft);
+}
+.mode-summary span[data-v-4d4b6cc7], .plan-state span[data-v-4d4b6cc7], .safety-note span[data-v-4d4b6cc7] { color: var(--muted); font-size: 12px;
+}
+.mode-summary.delete[data-v-4d4b6cc7] { background: rgba(196, 75, 71, .08);
+}
+.plan-resources[data-v-4d4b6cc7] { max-height: 170px; overflow: auto; margin-bottom: 12px; border: 1px solid var(--line); border-radius: 12px;
+}
+.plan-resources > div[data-v-4d4b6cc7] { display: flex; justify-content: space-between; align-items: center; padding: 10px 13px; border-bottom: 1px solid var(--line);
+}
+.plan-resources > div[data-v-4d4b6cc7]:last-child { border-bottom: 0;
+}
+.plan-resources span[data-v-4d4b6cc7] { color: var(--muted); font-size: 11px;
+}
+.plan-state.passed[data-v-4d4b6cc7] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.plan-state.blocked[data-v-4d4b6cc7], .issues.blocked[data-v-4d4b6cc7] { color: var(--danger); background: rgba(196, 75, 71, .08);
+}
+.issues[data-v-4d4b6cc7] { display: grid; gap: 6px; margin: 0 0 12px; padding: 12px 16px 12px 34px; border-radius: 12px; font-size: 13px;
+}
+.issues.warning[data-v-4d4b6cc7] { color: var(--warn); background: rgba(184, 107, 17, .08);
+}
+.risk-check[data-v-4d4b6cc7] { position: relative; display: flex; align-items: center; gap: 9px; margin: 12px 0; font-size: 13px; font-weight: 700;
+}
+.risk-check > span[data-v-4d4b6cc7] { width: 20px; height: 20px; border: 1px solid rgba(100, 116, 139, .35); border-radius: 6px;
+}
+.risk-check input:checked + span[data-v-4d4b6cc7] { border-color: var(--primary); background: var(--primary); box-shadow: inset 0 0 0 4px var(--surface);
+}
+.safety-note[data-v-4d4b6cc7] { display: flex; align-items: center; background: rgba(100, 116, 139, .08);
+}
+.safety-note p[data-v-4d4b6cc7] { flex: 1;
+}
+.confirm-button[data-v-4d4b6cc7], .execution-result button[data-v-4d4b6cc7] {
+  width: 100%;
+  min-height: 46px;
+  border: 0;
+  border-radius: 11px;
+  background: var(--primary);
+  color: white;
+  font-weight: 800;
+  cursor: pointer;
+}
+.confirm-button[data-v-4d4b6cc7]:disabled { background: rgba(100, 116, 139, .22); color: var(--muted); cursor: not-allowed;
+}
+.final-confirmation[data-v-4d4b6cc7], .execution-result[data-v-4d4b6cc7] { display: grid; gap: 10px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.final-confirmation > div[data-v-4d4b6cc7] { display: flex; gap: 8px;
+}
+.final-confirmation button[data-v-4d4b6cc7] { flex: 1; min-height: 42px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); cursor: pointer;
+}
+.final-confirmation button.danger[data-v-4d4b6cc7] { border-color: transparent; background: var(--danger); color: white;
+}
+.error-text[data-v-4d4b6cc7] { color: var(--danger); font-size: 13px;
+}
+.execution-result[data-v-4d4b6cc7] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.compact-modal[data-v-4d4b6cc7] { width: min(650px, 90vw);
+}
+.gap-row[data-v-4d4b6cc7], .recovery-row[data-v-4d4b6cc7] { display: flex; align-items: center; gap: 8px; padding: 11px 4px; border-bottom: 1px solid var(--line);
+}
+.gap-row p[data-v-4d4b6cc7], .recovery-row p[data-v-4d4b6cc7] { flex: 1;
+}
+.gap-row span[data-v-4d4b6cc7], .recovery-row span[data-v-4d4b6cc7] { color: var(--muted); font-size: 11px;
+}
+.gap-row b[data-v-4d4b6cc7] { font-size: 12px; color: var(--warn);
+}
+.recovery-row button[data-v-4d4b6cc7], .recovery-confirm button[data-v-4d4b6cc7] { padding: 7px 10px; border: 1px solid var(--line); border-radius: 8px; background: transparent; cursor: pointer;
+}
+.recovery-confirm[data-v-4d4b6cc7] { display: grid; gap: 8px; margin-top: 14px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.recovery-confirm input[data-v-4d4b6cc7] { height: 40px; padding: 0 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); color: inherit;
+}
+@media (max-width: 1250px) {
+.table-head[data-v-4d4b6cc7], .resource-row[data-v-4d4b6cc7] {
+    grid-template-columns: 38px minmax(240px, 1.3fr) minmax(150px, .7fr) minmax(310px, 1.35fr) 120px minmax(200px, .9fr);
+}
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_expose_AppPage-Jh9a-Wh_.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_expose_AppPage-Jh9a-Wh_.js
@@ -1,0 +1,946 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
+
+const FILTERS = [
+  { id: 'all', label: '全部资源' },
+  { id: 'library', label: '媒体库已入库' },
+  { id: 'hr', label: 'H&R 保护中' },
+  { id: 'brush', label: '刷流任务' },
+  { id: 'review', label: '无做种限制' },
+  { id: 'names', label: '名称待核' },
+];
+
+const ACTIONS = {
+  pause: {
+    title: '停止做种',
+    detail: '保留 qB 任务和全部文件',
+  },
+  retire: {
+    title: '退出做种',
+    detail: '移除 qB 任务，媒体仍保留',
+  },
+  delete: {
+    title: '完整删除',
+    detail: '移除任务、媒体和全部链接',
+  },
+};
+
+function unwrapResponse(response) {
+  if (response && Object.prototype.hasOwnProperty.call(response, 'data') && response.success !== undefined) {
+    return response.data
+  }
+  return response?.data ?? response
+}
+
+function matchesFilter(item, filter) {
+  if (filter === 'all') return true
+  if (filter === 'library') return Boolean(item.library)
+  if (filter === 'hr') return Boolean(item.hr || item.hrPending)
+  if (filter === 'brush') return Boolean(item.brush)
+  if (filter === 'review') return !item.protected && item.qbSummary === '无 qB 任务'
+  return item.metadataVerified === false
+}
+
+function isDirectlyCleanable(item) {
+  return !item.protected && item.qbSummary === '无 qB 任务'
+}
+
+function filterResources(resources, { filter, search, safeOnly, descending }) {
+  const query = String(search || '').trim().toLowerCase();
+  return [...(resources || [])]
+    .filter(item => {
+      const text = `${item.title || ''} ${item.englishTitle || ''} ${item.edition || ''} ${item.siteSummary || ''}`.toLowerCase();
+      return matchesFilter(item, filter) &&
+        (!safeOnly || isDirectlyCleanable(item)) &&
+        (!query || text.includes(query))
+    })
+    .sort((left, right) => {
+      const order = descending ? Number(right.size || 0) - Number(left.size || 0) : Number(left.size || 0) - Number(right.size || 0);
+      return order || String(left.title || '').localeCompare(String(right.title || ''), 'zh-CN')
+    })
+}
+
+function formatGiB(size) {
+  const numeric = Number(size || 0);
+  return numeric >= 1024 ? `${(numeric / 1024).toFixed(2)} TB` : `${numeric.toFixed(1)} GB`
+}
+
+function formatBytes(size) {
+  return formatGiB(Number(size || 0) / 1024 ** 3)
+}
+
+function issueKey(issue, index) {
+  return `${issue?.code || 'issue'}-${index}`
+}
+
+const {createElementVNode:_createElementVNode,toDisplayString:_toDisplayString,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,normalizeClass:_normalizeClass,vModelText:_vModelText,withDirectives:_withDirectives,vModelCheckbox:_vModelCheckbox,createTextVNode:_createTextVNode,renderList:_renderList,Fragment:_Fragment,unref:_unref,Teleport:_Teleport,createBlock:_createBlock,withModifiers:_withModifiers} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "cleanup-app" };
+const _hoisted_2 = {
+  key: 0,
+  class: "page-header"
+};
+const _hoisted_3 = { key: 0 };
+const _hoisted_4 = { class: "toolbar" };
+const _hoisted_5 = { class: "search" };
+const _hoisted_6 = { class: "safe-toggle" };
+const _hoisted_7 = ["disabled"];
+const _hoisted_8 = {
+  class: "filters",
+  "aria-label": "资源筛选"
+};
+const _hoisted_9 = ["onClick"];
+const _hoisted_10 = { class: "resource-card" };
+const _hoisted_11 = { class: "table-head" };
+const _hoisted_12 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_13 = ["disabled", "onClick"];
+const _hoisted_14 = { class: "resource-title" };
+const _hoisted_15 = { class: "stack-cell library" };
+const _hoisted_16 = { class: "seed-cell" };
+const _hoisted_17 = {
+  key: 1,
+  class: "stack-cell"
+};
+const _hoisted_18 = { class: "stack-cell size" };
+const _hoisted_19 = {
+  key: 2,
+  class: "empty-state"
+};
+const _hoisted_20 = {
+  key: 0,
+  class: "action-bar"
+};
+const _hoisted_21 = { class: "selected-count" };
+const _hoisted_22 = ["onClick"];
+const _hoisted_23 = {
+  class: "modal plan-modal",
+  role: "dialog",
+  "aria-modal": "true"
+};
+const _hoisted_24 = ["disabled"];
+const _hoisted_25 = { key: 0 };
+const _hoisted_26 = { key: 1 };
+const _hoisted_27 = { class: "plan-resources" };
+const _hoisted_28 = {
+  key: 0,
+  class: "plan-state"
+};
+const _hoisted_29 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_30 = {
+  key: 0,
+  class: "issues blocked"
+};
+const _hoisted_31 = {
+  key: 1,
+  class: "issues warning"
+};
+const _hoisted_32 = {
+  key: 2,
+  class: "risk-check"
+};
+const _hoisted_33 = ["checked"];
+const _hoisted_34 = {
+  key: 3,
+  class: "plan-state blocked"
+};
+const _hoisted_35 = { class: "safety-note" };
+const _hoisted_36 = {
+  key: 3,
+  class: "execution-result"
+};
+const _hoisted_37 = {
+  key: 4,
+  class: "final-confirmation"
+};
+const _hoisted_38 = {
+  key: 0,
+  class: "error-text"
+};
+const _hoisted_39 = ["disabled"];
+const _hoisted_40 = ["disabled"];
+const _hoisted_41 = ["disabled"];
+const _hoisted_42 = { class: "modal compact-modal" };
+const _hoisted_43 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_44 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_45 = { class: "modal compact-modal" };
+const _hoisted_46 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_47 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_48 = ["onClick"];
+const _hoisted_49 = ["onClick"];
+const _hoisted_50 = {
+  key: 2,
+  class: "recovery-confirm"
+};
+const _hoisted_51 = ["disabled"];
+
+const {computed,onMounted,ref} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'AppPage',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+  hideTitle: { type: Boolean, default: false },
+},
+  setup(__props) {
+
+const props = __props;
+
+const emptySnapshot = {
+  schemaVersion: 2,
+  snapshotId: '',
+  generatedAt: '',
+  stats: {},
+  resources: [],
+};
+
+const snapshot = ref(emptySnapshot);
+const health = ref({});
+const loading = ref(true);
+const refreshing = ref(false);
+const error = ref('');
+const search = ref('');
+const activeFilter = ref('all');
+const safeOnly = ref(false);
+const descending = ref(true);
+const selected = ref([]);
+
+const planOpen = ref(false);
+const planMode = ref(null);
+const plan = ref(null);
+const planLoading = ref(false);
+const planError = ref('');
+const acknowledgeSiteRisk = ref(false);
+const finalConfirmation = ref(false);
+const executing = ref(false);
+const executeError = ref('');
+const executeResult = ref(null);
+
+const gapOpen = ref(false);
+const gapLoading = ref(false);
+const gaps = ref([]);
+const gapError = ref('');
+
+const recoveryOpen = ref(false);
+const recoveryLoading = ref(false);
+const recoveries = ref([]);
+const recoveryError = ref('');
+const recoveryTarget = ref(null);
+const recoveryAction = ref(null);
+const recoveryPhrase = ref('');
+const recovering = ref(false);
+
+const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`);
+const resources = computed(() => snapshot.value.resources || []);
+const visible = computed(() => filterResources(resources.value, {
+  filter: activeFilter.value,
+  search: search.value,
+  safeOnly: safeOnly.value,
+  descending: descending.value,
+}));
+const selectedItems = computed(() => resources.value.filter(item => selected.value.includes(item.id)));
+const selectedSize = computed(() => selectedItems.value.reduce((total, item) => total + Number(item.size || 0), 0));
+const executionEnabled = computed(() => Boolean(health.value.executionEnabled));
+const inventoryCurrent = computed(() => health.value.inventoryCurrent !== false);
+const unresolvedTransactions = computed(() => Number(snapshot.value.stats?.unresolvedTransactions || 0));
+const hrGap = computed(() => Math.max(
+  0,
+  Number(
+    snapshot.value.stats?.hrMissingQbTasks ??
+    Number(snapshot.value.stats?.hrActiveTitles || 0) - Number(snapshot.value.stats?.hrMatchedQbTasks || 0),
+  ),
+));
+const hrUnassigned = computed(() => Number(
+  snapshot.value.stats?.hrMissingUnassigned ??
+  snapshot.value.stats?.hrMissingUncovered ??
+  0,
+));
+const filters = computed(() => FILTERS.map(filter => ({
+  ...filter,
+  count: resources.value.filter(item => {
+    if (filter.id === 'all') return true
+    return filterResources([item], {
+      filter: filter.id,
+      search: '',
+      safeOnly: false,
+      descending: true,
+    }).length === 1
+  }).length,
+})));
+const allVisibleSelected = computed(() => {
+  const selectable = visible.value.filter(item => !item.protected);
+  return selectable.length > 0 && selectable.every(item => selected.value.includes(item.id))
+});
+const currentAction = computed(() => planMode.value ? ACTIONS[planMode.value] : null);
+const planExpired = computed(() => Boolean(plan.value && Date.parse(plan.value.expiresAt) <= Date.now()));
+
+function payloadError(payload, fallback) {
+  return payload?.error?.message || fallback
+}
+
+async function get(path) {
+  return unwrapResponse(await props.api.get(`${pluginBase.value}${path}`))
+}
+
+async function post(path, body) {
+  return unwrapResponse(await props.api.post(`${pluginBase.value}${path}`, body))
+}
+
+function acceptSnapshot(next) {
+  if (!next || next.schemaVersion !== 2 || !next.snapshotId || !Array.isArray(next.resources)) {
+    throw new Error('资源快照格式不受支持。')
+  }
+  snapshot.value = next;
+  const available = new Set(next.resources.map(item => item.id));
+  selected.value = selected.value.filter(id => available.has(id));
+}
+
+async function loadStatus() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const payload = await get('/status');
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '无法读取清理台状态。'))
+    health.value = payload.health || {};
+    acceptSnapshot(payload.snapshot);
+  } catch (err) {
+    error.value = err?.message || '无法读取清理台状态。';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function refreshSnapshot() {
+  refreshing.value = true;
+  error.value = '';
+  try {
+    const payload = await post('/refresh', {});
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '刷新失败。'))
+    acceptSnapshot(payload.snapshot);
+    health.value = { ...health.value, inventoryCurrent: true };
+  } catch (err) {
+    error.value = err?.message || '刷新失败，继续显示上次快照。';
+    health.value = { ...health.value, inventoryCurrent: false };
+  } finally {
+    refreshing.value = false;
+  }
+}
+
+function toggle(item) {
+  if (item.protected) return
+  selected.value = selected.value.includes(item.id)
+    ? selected.value.filter(id => id !== item.id)
+    : [...selected.value, item.id];
+}
+
+function toggleVisible() {
+  const ids = visible.value.filter(item => !item.protected).map(item => item.id);
+  selected.value = allVisibleSelected.value
+    ? selected.value.filter(id => !ids.includes(id))
+    : [...new Set([...selected.value, ...ids])];
+}
+
+async function requestPlan(mode, acknowledged = false) {
+  planLoading.value = true;
+  planError.value = '';
+  plan.value = null;
+  finalConfirmation.value = false;
+  try {
+    const payload = await post('/plan', {
+      snapshotId: snapshot.value.snapshotId,
+      resourceIds: selected.value,
+      mode,
+      acknowledgeSiteRisk: acknowledged,
+    });
+    if (!payload?.ok || !payload.plan) throw new Error(payloadError(payload, '无法生成执行计划。'))
+    plan.value = payload.plan;
+  } catch (err) {
+    planError.value = err?.message || '无法生成执行计划。';
+  } finally {
+    planLoading.value = false;
+  }
+}
+
+function openPlan(mode) {
+  planMode.value = mode;
+  planOpen.value = true;
+  acknowledgeSiteRisk.value = false;
+  executeResult.value = null;
+  executeError.value = '';
+  requestPlan(mode, false);
+}
+
+function closePlan() {
+  if (executing.value) return
+  planOpen.value = false;
+  planMode.value = null;
+  plan.value = null;
+  planError.value = '';
+  finalConfirmation.value = false;
+  executeResult.value = null;
+}
+
+async function setSiteRisk(value) {
+  acknowledgeSiteRisk.value = value;
+  await requestPlan(planMode.value, value);
+}
+
+async function executePlan() {
+  if (!plan.value || planExpired.value || executing.value) return
+  executing.value = true;
+  executeError.value = '';
+  try {
+    const payload = await post('/execute', {
+      planId: plan.value.planId,
+      confirmPhrase: plan.value.confirmPhrase,
+    });
+    if (!payload?.ok || !payload.result) {
+      if (payload?.error?.plan) plan.value = payload.error.plan;
+      throw new Error(payloadError(payload, '执行失败。'))
+    }
+    executeResult.value = payload.result;
+    selected.value = [];
+    if (payload.result.snapshotRefreshPending) {
+      health.value = { ...health.value, inventoryCurrent: false };
+    } else {
+      const latest = await get('/snapshot');
+      if (latest?.snapshot) acceptSnapshot(latest.snapshot);
+    }
+  } catch (err) {
+    executeError.value = err?.message || '执行失败。';
+    finalConfirmation.value = false;
+  } finally {
+    executing.value = false;
+  }
+}
+
+async function loadGaps() {
+  gapOpen.value = true;
+  gapLoading.value = true;
+  gapError.value = '';
+  try {
+    const payload = await get('/protection-gaps');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取 H&R 缺口。'))
+    gaps.value = payload.gaps || [];
+  } catch (err) {
+    gapError.value = err?.message || '无法读取 H&R 缺口。';
+  } finally {
+    gapLoading.value = false;
+  }
+}
+
+async function loadRecoveries() {
+  recoveryOpen.value = true;
+  recoveryLoading.value = true;
+  recoveryError.value = '';
+  recoveryTarget.value = null;
+  try {
+    const payload = await get('/recovery');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取恢复状态。'))
+    recoveries.value = payload.recoveries || [];
+  } catch (err) {
+    recoveryError.value = err?.message || '无法读取恢复状态。';
+  } finally {
+    recoveryLoading.value = false;
+  }
+}
+
+function chooseRecovery(item, action) {
+  recoveryTarget.value = item;
+  recoveryAction.value = action;
+  recoveryPhrase.value = '';
+  recoveryError.value = '';
+}
+
+async function runRecovery() {
+  if (!recoveryTarget.value || !recoveryAction.value || recovering.value) return
+  recovering.value = true;
+  recoveryError.value = '';
+  try {
+    const payload = await post('/recovery', {
+      planId: recoveryTarget.value.planId,
+      action: recoveryAction.value,
+      confirmPhrase: recoveryPhrase.value,
+    });
+    if (!payload?.ok) throw new Error(payloadError(payload, '恢复操作失败。'))
+    await refreshSnapshot();
+    await loadRecoveries();
+  } catch (err) {
+    recoveryError.value = err?.message || '恢复操作失败。';
+  } finally {
+    recovering.value = false;
+  }
+}
+
+function recoveryExpectedPhrase() {
+  if (!recoveryTarget.value || !recoveryAction.value) return ''
+  return recoveryAction.value === 'rollback'
+    ? recoveryTarget.value.rollbackPhrase
+    : recoveryTarget.value.finalizePhrase
+}
+
+onMounted(loadStatus);
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("main", _hoisted_1, [
+    (!__props.hideTitle)
+      ? (_openBlock(), _createElementBlock("header", _hoisted_2, [
+          _cache[12] || (_cache[12] = _createElementVNode("div", null, [
+            _createElementVNode("p", { class: "eyebrow" }, "PiNAS · MoviePilot 原生页面"),
+            _createElementVNode("h1", null, "存储清理"),
+            _createElementVNode("span", null, "一部电影一行，一部剧一行；先看清影响，再选择清理等级。")
+          ], -1)),
+          _createElementVNode("div", {
+            class: _normalizeClass(['status-card', { danger: error.value || !inventoryCurrent.value }])
+          }, [
+            _createElementVNode("i", null, _toDisplayString(error.value || !inventoryCurrent.value ? '!' : '✓'), 1),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(error.value || (executionEnabled.value ? '执行链路已连接' : '只读模式')), 1),
+              (snapshot.value.generatedAt)
+                ? (_openBlock(), _createElementBlock("span", _hoisted_3, "更新于 " + _toDisplayString(snapshot.value.generatedAt.slice(5, 16).replace('T', ' ')), 1))
+                : _createCommentVNode("", true)
+            ])
+          ], 2)
+        ]))
+      : _createCommentVNode("", true),
+    _createElementVNode("section", _hoisted_4, [
+      _createElementVNode("label", _hoisted_5, [
+        _cache[13] || (_cache[13] = _createElementVNode("span", null, "⌕", -1)),
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((search).value = $event)),
+          "aria-label": "搜索资源",
+          placeholder: "搜索电影、剧集、季度或站点"
+        }, null, 512), [
+          [_vModelText, search.value]
+        ])
+      ]),
+      _createElementVNode("label", _hoisted_6, [
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[1] || (_cache[1] = $event => ((safeOnly).value = $event)),
+          type: "checkbox"
+        }, null, 512), [
+          [_vModelCheckbox, safeOnly.value]
+        ]),
+        _cache[14] || (_cache[14] = _createElementVNode("span", null, null, -1)),
+        _cache[15] || (_cache[15] = _createTextVNode(" 仅看无做种限制 ", -1))
+      ]),
+      _createElementVNode("button", {
+        class: "soft-button",
+        type: "button",
+        onClick: _cache[2] || (_cache[2] = $event => (descending.value = !descending.value))
+      }, " 实际占用 " + _toDisplayString(descending.value ? '↓' : '↑'), 1),
+      _createElementVNode("button", {
+        class: "icon-button",
+        type: "button",
+        disabled: refreshing.value,
+        onClick: refreshSnapshot
+      }, _toDisplayString(refreshing.value ? '…' : '↻'), 9, _hoisted_7)
+    ]),
+    (unresolvedTransactions.value)
+      ? (_openBlock(), _createElementBlock("button", {
+          key: 1,
+          class: "notice critical",
+          type: "button",
+          onClick: loadRecoveries
+        }, [
+          _cache[17] || (_cache[17] = _createElementVNode("i", null, "!", -1)),
+          _createElementVNode("p", null, [
+            _createElementVNode("strong", null, _toDisplayString(unresolvedTransactions.value) + " 个未完成清理事务", 1),
+            _cache[16] || (_cache[16] = _createElementVNode("span", null, "新操作已锁定；请先核对并恢复原事务。", -1))
+          ]),
+          _cache[18] || (_cache[18] = _createElementVNode("b", null, "查看恢复状态", -1))
+        ]))
+      : (hrGap.value)
+        ? (_openBlock(), _createElementBlock("button", {
+            key: 2,
+            class: _normalizeClass(['notice', { warning: hrUnassigned.value }]),
+            type: "button",
+            onClick: loadGaps
+          }, [
+            _cache[19] || (_cache[19] = _createElementVNode("i", null, "H", -1)),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(hrGap.value) + " 个学校站 H&R 尚未恢复完成", 1),
+              _createElementVNode("span", null, _toDisplayString(hrUnassigned.value
+            ? `${hrUnassigned.value} 个未精确关联媒体；不会锁定无关资源。`
+            : '缺失任务只锁定精确关联资源，其他资源可独立清理。'), 1)
+            ]),
+            _cache[20] || (_cache[20] = _createElementVNode("b", null, "查看明细", -1))
+          ], 2))
+        : _createCommentVNode("", true),
+    _createElementVNode("nav", _hoisted_8, [
+      (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(filters.value, (filter) => {
+        return (_openBlock(), _createElementBlock("button", {
+          key: filter.id,
+          class: _normalizeClass({ active: activeFilter.value === filter.id }),
+          type: "button",
+          onClick: $event => (activeFilter.value = filter.id)
+        }, [
+          _createTextVNode(_toDisplayString(filter.label) + " ", 1),
+          _createElementVNode("span", null, _toDisplayString(filter.count), 1)
+        ], 10, _hoisted_9))
+      }), 128))
+    ]),
+    _createElementVNode("section", _hoisted_10, [
+      _createElementVNode("div", _hoisted_11, [
+        _createElementVNode("button", {
+          class: "select-all",
+          type: "button",
+          onClick: toggleVisible
+        }, _toDisplayString(allVisibleSelected.value ? '✓' : ''), 1),
+        _cache[21] || (_cache[21] = _createElementVNode("span", null, "资源", -1)),
+        _cache[22] || (_cache[22] = _createElementVNode("span", null, "媒体库", -1)),
+        _cache[23] || (_cache[23] = _createElementVNode("span", null, "做种与保护", -1)),
+        _cache[24] || (_cache[24] = _createElementVNode("span", null, "实际占用", -1)),
+        _cache[25] || (_cache[25] = _createElementVNode("span", null, "完整删除影响", -1))
+      ]),
+      (loading.value)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_12, "正在读取真实资源关系…"))
+        : (_openBlock(true), _createElementBlock(_Fragment, { key: 1 }, _renderList(visible.value, (item) => {
+            return (_openBlock(), _createElementBlock("article", {
+              key: item.id,
+              class: _normalizeClass(['resource-row', { selected: selected.value.includes(item.id) }])
+            }, [
+              _createElementVNode("button", {
+                class: _normalizeClass(['row-check', { locked: item.protected }]),
+                type: "button",
+                disabled: item.protected,
+                onClick: $event => (toggle(item))
+              }, _toDisplayString(item.protected ? '锁' : selected.value.includes(item.id) ? '✓' : ''), 11, _hoisted_13),
+              _createElementVNode("div", _hoisted_14, [
+                _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                _createElementVNode("b", null, _toDisplayString(item.englishTitle), 1),
+                _createElementVNode("span", null, _toDisplayString([item.type, item.year, item.edition].filter(Boolean).join(' · ')), 1)
+              ]),
+              _createElementVNode("div", _hoisted_15, [
+                _createElementVNode("strong", null, _toDisplayString(item.librarySummary), 1),
+                _createElementVNode("span", null, _toDisplayString(item.libraryDetail), 1)
+              ]),
+              _createElementVNode("div", _hoisted_16, [
+                (item.seedTasks?.length)
+                  ? (_openBlock(true), _createElementBlock(_Fragment, { key: 0 }, _renderList(item.seedTasks, (task, index) => {
+                      return (_openBlock(), _createElementBlock("div", {
+                        key: `${task.site}-${task.scope}-${index}`,
+                        class: _normalizeClass(['seed-task', task.tone])
+                      }, [
+                        _createElementVNode("i", null, _toDisplayString(task.status), 1),
+                        _createElementVNode("strong", null, _toDisplayString(task.site), 1),
+                        _createElementVNode("span", null, _toDisplayString(task.scope) + _toDisplayString(task.count > 1 ? ` · ${task.count} 个任务` : ''), 1)
+                      ], 2))
+                    }), 128))
+                  : (_openBlock(), _createElementBlock("div", _hoisted_17, [
+                      _createElementVNode("strong", null, _toDisplayString(item.qbSummary), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.siteSummary), 1)
+                    ]))
+              ]),
+              _createElementVNode("div", _hoisted_18, [
+                _createElementVNode("strong", null, _toDisplayString(item.sizeLabel), 1),
+                _createElementVNode("span", null, _toDisplayString(item.reclaimLabel), 1)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['impact', { danger: item.protected }])
+              }, [
+                _createElementVNode("strong", null, _toDisplayString(item.impactTitle), 1),
+                _createElementVNode("span", null, _toDisplayString(item.impactDetail), 1)
+              ], 2)
+            ], 2))
+          }), 128)),
+      (!loading.value && !visible.value.length)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_19, " 没有符合条件的资源，请取消筛选或更换关键词。 "))
+        : _createCommentVNode("", true)
+    ]),
+    (_openBlock(), _createBlock(_Teleport, { to: "body" }, [
+      (selected.value.length)
+        ? (_openBlock(), _createElementBlock("aside", _hoisted_20, [
+            _createElementVNode("div", _hoisted_21, _toDisplayString(selected.value.length), 1),
+            _createElementVNode("p", null, [
+              _cache[26] || (_cache[26] = _createElementVNode("strong", null, "已加入清理计划", -1)),
+              _createElementVNode("span", null, "完整删除上限 " + _toDisplayString(_unref(formatGiB)(selectedSize.value)), 1)
+            ]),
+            _createElementVNode("button", {
+              class: "clear-button",
+              type: "button",
+              onClick: _cache[3] || (_cache[3] = $event => (selected.value = []))
+            }, "清空"),
+            (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(ACTIONS), (action, mode) => {
+              return (_openBlock(), _createElementBlock("button", {
+                key: mode,
+                class: _normalizeClass(['action-level', { delete: mode === 'delete' }]),
+                type: "button",
+                onClick: $event => (openPlan(mode))
+              }, [
+                _createElementVNode("strong", null, _toDisplayString(action.title), 1),
+                _createElementVNode("span", null, _toDisplayString(action.detail), 1)
+              ], 10, _hoisted_22))
+            }), 128))
+          ]))
+        : _createCommentVNode("", true)
+    ])),
+    (planOpen.value)
+      ? (_openBlock(), _createElementBlock("div", {
+          key: 3,
+          class: "modal-backdrop",
+          onClick: _withModifiers(closePlan, ["self"])
+        }, [
+          _createElementVNode("section", _hoisted_23, [
+            _createElementVNode("header", null, [
+              _createElementVNode("div", null, [
+                _cache[27] || (_cache[27] = _createElementVNode("span", null, "清理等级 · 真实预演", -1)),
+                _createElementVNode("h2", null, _toDisplayString(currentAction.value?.title), 1)
+              ]),
+              _createElementVNode("button", {
+                type: "button",
+                disabled: executing.value,
+                onClick: closePlan
+              }, "×", 8, _hoisted_24)
+            ]),
+            _createElementVNode("div", {
+              class: _normalizeClass(['mode-summary', planMode.value])
+            }, [
+              (plan.value && planMode.value === 'delete')
+                ? (_openBlock(), _createElementBlock("strong", _hoisted_25, "已核算可释放 " + _toDisplayString(_unref(formatBytes)(plan.value.estimatedReclaimBytes)), 1))
+                : (_openBlock(), _createElementBlock("strong", _hoisted_26, _toDisplayString(currentAction.value?.detail), 1)),
+              _createElementVNode("span", null, _toDisplayString(planMode.value === 'pause'
+              ? '只改变 qB 运行状态，不删除任务或文件。'
+              : planMode.value === 'retire'
+                ? '移除 qB 任务但保留文件，媒体库继续可播放。'
+                : '仅当全部路径、硬链接、H&R 与任务状态通过校验才会放行。'), 1)
+            ], 2),
+            _createElementVNode("div", _hoisted_27, [
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(selectedItems.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.id
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.englishTitle) + " · " + _toDisplayString(item.edition), 1)
+                  ]),
+                  _createElementVNode("b", null, _toDisplayString(item.sizeLabel), 1)
+                ]))
+              }), 128))
+            ]),
+            (planLoading.value)
+              ? (_openBlock(), _createElementBlock("div", _hoisted_28, "正在刷新 NAS 状态并复核关系…"))
+              : (planError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_29, [
+                    _cache[28] || (_cache[28] = _createElementVNode("strong", null, "无法生成计划", -1)),
+                    _createElementVNode("span", null, _toDisplayString(planError.value), 1)
+                  ]))
+                : (plan.value)
+                  ? (_openBlock(), _createElementBlock(_Fragment, { key: 2 }, [
+                      _createElementVNode("div", {
+                        class: _normalizeClass(['plan-state', plan.value.canExecute ? 'passed' : 'blocked'])
+                      }, [
+                        _createElementVNode("strong", null, _toDisplayString(plan.value.canExecute ? '安全预演通过' : '计划已被安全门禁拦截'), 1),
+                        _createElementVNode("span", null, " 停止 " + _toDisplayString(plan.value.operationCounts.qbStop) + " 个任务 · 退出 " + _toDisplayString(plan.value.operationCounts.qbRemoveKeepFiles) + " 个任务 · 解除 " + _toDisplayString(plan.value.operationCounts.unlinkFiles) + " 个文件入口 ", 1)
+                      ], 2),
+                      (plan.value.blocks?.length)
+                        ? (_openBlock(), _createElementBlock("ul", _hoisted_30, [
+                            (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.blocks, (issue, index) => {
+                              return (_openBlock(), _createElementBlock("li", {
+                                key: _unref(issueKey)(issue, index)
+                              }, _toDisplayString(issue.message), 1))
+                            }), 128))
+                          ]))
+                        : _createCommentVNode("", true),
+                      (plan.value.warnings?.length)
+                        ? (_openBlock(), _createElementBlock("ul", _hoisted_31, [
+                            (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.warnings, (issue, index) => {
+                              return (_openBlock(), _createElementBlock("li", {
+                                key: _unref(issueKey)(issue, index)
+                              }, _toDisplayString(issue.message), 1))
+                            }), 128))
+                          ]))
+                        : _createCommentVNode("", true),
+                      (plan.value.requiresSiteAcknowledgement)
+                        ? (_openBlock(), _createElementBlock("label", _hoisted_32, [
+                            _createElementVNode("input", {
+                              checked: acknowledgeSiteRisk.value,
+                              type: "checkbox",
+                              onChange: _cache[4] || (_cache[4] = $event => (setSiteRisk($event.target.checked)))
+                            }, null, 40, _hoisted_33),
+                            _cache[29] || (_cache[29] = _createElementVNode("span", null, null, -1)),
+                            _cache[30] || (_cache[30] = _createTextVNode(" 我已确认会影响私有站做种，并接受站点规则风险 ", -1))
+                          ]))
+                        : _createCommentVNode("", true),
+                      (planExpired.value)
+                        ? (_openBlock(), _createElementBlock("div", _hoisted_34, [...(_cache[31] || (_cache[31] = [
+                            _createElementVNode("strong", null, "安全预演已过期", -1),
+                            _createElementVNode("span", null, "请关闭后重新生成。", -1)
+                          ]))]))
+                        : _createCommentVNode("", true)
+                    ], 64))
+                  : _createCommentVNode("", true),
+            _createElementVNode("div", _hoisted_35, [
+              _cache[33] || (_cache[33] = _createElementVNode("i", null, "盾", -1)),
+              _createElementVNode("p", null, [
+                _createElementVNode("strong", null, _toDisplayString(executionEnabled.value ? '执行前还需第二次确认' : '执行引擎未启用'), 1),
+                _cache[32] || (_cache[32] = _createElementVNode("span", null, "最终执行前会重新读取 qB、路径、硬链接和保护状态。", -1))
+              ])
+            ]),
+            (executeResult.value)
+              ? (_openBlock(), _createElementBlock("div", _hoisted_36, [
+                  _createElementVNode("strong", null, _toDisplayString(currentAction.value?.title) + "已完成", 1),
+                  _createElementVNode("span", null, " 停止 " + _toDisplayString(executeResult.value.qbStopped) + " · 退出 " + _toDisplayString(executeResult.value.qbRemoved) + " · 删除文件入口 " + _toDisplayString(executeResult.value.filesDeleted) + " · 清理索引 " + _toDisplayString(executeResult.value.moviepilotIndexesDeleted), 1),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: closePlan
+                  }, "完成")
+                ]))
+              : (finalConfirmation.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_37, [
+                    _cache[34] || (_cache[34] = _createElementVNode("strong", null, "再次确认：系统将立即执行这份计划", -1)),
+                    (executeError.value)
+                      ? (_openBlock(), _createElementBlock("span", _hoisted_38, _toDisplayString(executeError.value), 1))
+                      : _createCommentVNode("", true),
+                    _createElementVNode("div", null, [
+                      _createElementVNode("button", {
+                        type: "button",
+                        disabled: executing.value,
+                        onClick: _cache[5] || (_cache[5] = $event => (finalConfirmation.value = false))
+                      }, "返回", 8, _hoisted_39),
+                      _createElementVNode("button", {
+                        class: _normalizeClass({ danger: planMode.value === 'delete' }),
+                        type: "button",
+                        disabled: executing.value || planExpired.value,
+                        onClick: executePlan
+                      }, _toDisplayString(executing.value ? '正在二次复核…' : `确认${currentAction.value?.title}`), 11, _hoisted_40)
+                    ])
+                  ]))
+                : (_openBlock(), _createElementBlock("button", {
+                    key: 5,
+                    class: "confirm-button",
+                    type: "button",
+                    disabled: !executionEnabled.value || !plan.value?.canExecute || planExpired.value,
+                    onClick: _cache[6] || (_cache[6] = $event => (finalConfirmation.value = true))
+                  }, " 进入最终确认 ", 8, _hoisted_41))
+          ])
+        ]))
+      : _createCommentVNode("", true),
+    (gapOpen.value)
+      ? (_openBlock(), _createElementBlock("div", {
+          key: 4,
+          class: "modal-backdrop",
+          onClick: _cache[8] || (_cache[8] = _withModifiers($event => (gapOpen.value = false), ["self"]))
+        }, [
+          _createElementVNode("section", _hoisted_42, [
+            _createElementVNode("header", null, [
+              _cache[35] || (_cache[35] = _createElementVNode("div", null, [
+                _createElementVNode("span", null, "学校站实时保护"),
+                _createElementVNode("h2", null, "H&R 缺口明细")
+              ], -1)),
+              _createElementVNode("button", {
+                onClick: _cache[7] || (_cache[7] = $event => (gapOpen.value = false))
+              }, "×")
+            ]),
+            (gapLoading.value)
+              ? (_openBlock(), _createElementBlock("div", _hoisted_43, "正在核对…"))
+              : _createCommentVNode("", true),
+            (gapError.value)
+              ? (_openBlock(), _createElementBlock("div", _hoisted_44, _toDisplayString(gapError.value), 1))
+              : _createCommentVNode("", true),
+            (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(gaps.value, (item) => {
+              return (_openBlock(), _createElementBlock("div", {
+                key: item.title,
+                class: "gap-row"
+              }, [
+                _createElementVNode("p", null, [
+                  _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                  _createElementVNode("span", null, _toDisplayString(item.linkedResourceTitle || '尚未精确关联媒体'), 1)
+                ]),
+                _createElementVNode("b", null, _toDisplayString(item.qbTaskPresent ? 'qB 已存在' : item.coveredByCandidate ? '候选恢复中' : '任务缺失'), 1)
+              ]))
+            }), 128))
+          ])
+        ]))
+      : _createCommentVNode("", true),
+    (recoveryOpen.value)
+      ? (_openBlock(), _createElementBlock("div", {
+          key: 5,
+          class: "modal-backdrop",
+          onClick: _cache[11] || (_cache[11] = _withModifiers($event => (recoveryOpen.value = false), ["self"]))
+        }, [
+          _createElementVNode("section", _hoisted_45, [
+            _createElementVNode("header", null, [
+              _cache[36] || (_cache[36] = _createElementVNode("div", null, [
+                _createElementVNode("span", null, "失败关闭"),
+                _createElementVNode("h2", null, "恢复未完成清理")
+              ], -1)),
+              _createElementVNode("button", {
+                onClick: _cache[9] || (_cache[9] = $event => (recoveryOpen.value = false))
+              }, "×")
+            ]),
+            (recoveryLoading.value)
+              ? (_openBlock(), _createElementBlock("div", _hoisted_46, "正在读取事务…"))
+              : _createCommentVNode("", true),
+            (recoveryError.value)
+              ? (_openBlock(), _createElementBlock("div", _hoisted_47, _toDisplayString(recoveryError.value), 1))
+              : _createCommentVNode("", true),
+            (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(recoveries.value, (item) => {
+              return (_openBlock(), _createElementBlock("div", {
+                key: item.planId,
+                class: "recovery-row"
+              }, [
+                _createElementVNode("p", null, [
+                  _createElementVNode("strong", null, _toDisplayString(item.mode) + " · " + _toDisplayString(item.phase), 1),
+                  _createElementVNode("span", null, _toDisplayString(item.planId.slice(-10)), 1)
+                ]),
+                _createElementVNode("button", {
+                  type: "button",
+                  onClick: $event => (chooseRecovery(item, 'rollback'))
+                }, "回滚", 8, _hoisted_48),
+                _createElementVNode("button", {
+                  type: "button",
+                  onClick: $event => (chooseRecovery(item, 'finalize'))
+                }, "完成原事务", 8, _hoisted_49)
+              ]))
+            }), 128)),
+            (recoveryTarget.value)
+              ? (_openBlock(), _createElementBlock("div", _hoisted_50, [
+                  _createElementVNode("label", null, [
+                    _cache[37] || (_cache[37] = _createTextVNode("输入确认短语 ", -1)),
+                    _createElementVNode("code", null, _toDisplayString(recoveryExpectedPhrase()), 1)
+                  ]),
+                  _withDirectives(_createElementVNode("input", {
+                    "onUpdate:modelValue": _cache[10] || (_cache[10] = $event => ((recoveryPhrase).value = $event)),
+                    autocomplete: "off"
+                  }, null, 512), [
+                    [_vModelText, recoveryPhrase.value]
+                  ]),
+                  _createElementVNode("button", {
+                    type: "button",
+                    disabled: recovering.value || recoveryPhrase.value !== recoveryExpectedPhrase(),
+                    onClick: runRecovery
+                  }, _toDisplayString(recovering.value ? '处理中…' : '执行恢复'), 9, _hoisted_51)
+                ]))
+              : _createCommentVNode("", true)
+          ])
+        ]))
+      : _createCommentVNode("", true)
+  ]))
+}
+}
+
+};
+const AppPage = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-4d4b6cc7"]]);
+
+export { AppPage as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_expose_Config-SYLmVfvj.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_expose_Config-SYLmVfvj.css
@@ -1,0 +1,10 @@
+
+.config-note[data-v-ed9f201d] {
+  display: grid;
+  gap: 6px;
+  padding: 20px;
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+  border-radius: 12px;
+}
+.config-note span[data-v-ed9f201d] { opacity: .7;
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_expose_Config-jwIyjrQZ.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_expose_Config-jwIyjrQZ.js
@@ -1,0 +1,30 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
+
+const {createElementVNode:_createElementVNode,openBlock:_openBlock,createElementBlock:_createElementBlock} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "config-note" };
+
+
+const _sfc_main = {
+  __name: 'Config',
+  props: {
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("div", _hoisted_1, [...(_cache[0] || (_cache[0] = [
+    _createElementVNode("strong", null, "存储清理已接入 MoviePilot", -1),
+    _createElementVNode("span", null, "请从左侧“存储清理”进入完整页面。3000 端口页面继续保留。", -1)
+  ]))]))
+}
+}
+
+};
+const Config = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-ed9f201d"]]);
+
+export { Config as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_expose_Page-KJioYuOl.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_expose_Page-KJioYuOl.js
@@ -1,0 +1,27 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage from './__federation_expose_AppPage-Jh9a-Wh_.js';
+
+const {openBlock:_openBlock,createBlock:_createBlock} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'Page',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createBlock(AppPage, {
+    api: __props.api,
+    "plugin-id": __props.pluginId
+  }, null, 8, ["api", "plugin-id"]))
+}
+}
+
+};
+
+export { _sfc_main as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_fn_import-JrT3xvdd.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.1/assets/__federation_fn_import-JrT3xvdd.js
@@ -1,0 +1,418 @@
+const buildIdentifier = "[0-9A-Za-z-]+";
+const build = `(?:\\+(${buildIdentifier}(?:\\.${buildIdentifier})*))`;
+const numericIdentifier = "0|[1-9]\\d*";
+const numericIdentifierLoose = "[0-9]+";
+const nonNumericIdentifier = "\\d*[a-zA-Z-][a-zA-Z0-9-]*";
+const preReleaseIdentifierLoose = `(?:${numericIdentifierLoose}|${nonNumericIdentifier})`;
+const preReleaseLoose = `(?:-?(${preReleaseIdentifierLoose}(?:\\.${preReleaseIdentifierLoose})*))`;
+const preReleaseIdentifier = `(?:${numericIdentifier}|${nonNumericIdentifier})`;
+const preRelease = `(?:-(${preReleaseIdentifier}(?:\\.${preReleaseIdentifier})*))`;
+const xRangeIdentifier = `${numericIdentifier}|x|X|\\*`;
+const xRangePlain = `[v=\\s]*(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:${preRelease})?${build}?)?)?`;
+const hyphenRange = `^\\s*(${xRangePlain})\\s+-\\s+(${xRangePlain})\\s*$`;
+const mainVersionLoose = `(${numericIdentifierLoose})\\.(${numericIdentifierLoose})\\.(${numericIdentifierLoose})`;
+const loosePlain = `[v=\\s]*${mainVersionLoose}${preReleaseLoose}?${build}?`;
+const gtlt = "((?:<|>)?=?)";
+const comparatorTrim = `(\\s*)${gtlt}\\s*(${loosePlain}|${xRangePlain})`;
+const loneTilde = "(?:~>?)";
+const tildeTrim = `(\\s*)${loneTilde}\\s+`;
+const loneCaret = "(?:\\^)";
+const caretTrim = `(\\s*)${loneCaret}\\s+`;
+const star = "(<|>)?=?\\s*\\*";
+const caret = `^${loneCaret}${xRangePlain}$`;
+const mainVersion = `(${numericIdentifier})\\.(${numericIdentifier})\\.(${numericIdentifier})`;
+const fullPlain = `v?${mainVersion}${preRelease}?${build}?`;
+const tilde = `^${loneTilde}${xRangePlain}$`;
+const xRange = `^${gtlt}\\s*${xRangePlain}$`;
+const comparator = `^${gtlt}\\s*(${fullPlain})$|^$`;
+const gte0 = "^\\s*>=\\s*0.0.0\\s*$";
+function parseRegex(source) {
+  return new RegExp(source);
+}
+function isXVersion(version) {
+  return !version || version.toLowerCase() === "x" || version === "*";
+}
+function pipe(...fns) {
+  return (x) => {
+    return fns.reduce((v, f) => f(v), x);
+  };
+}
+function extractComparator(comparatorString) {
+  return comparatorString.match(parseRegex(comparator));
+}
+function combineVersion(major, minor, patch, preRelease2) {
+  const mainVersion2 = `${major}.${minor}.${patch}`;
+  if (preRelease2) {
+    return `${mainVersion2}-${preRelease2}`;
+  }
+  return mainVersion2;
+}
+function parseHyphen(range) {
+  return range.replace(
+    parseRegex(hyphenRange),
+    (_range, from, fromMajor, fromMinor, fromPatch, _fromPreRelease, _fromBuild, to, toMajor, toMinor, toPatch, toPreRelease) => {
+      if (isXVersion(fromMajor)) {
+        from = "";
+      } else if (isXVersion(fromMinor)) {
+        from = `>=${fromMajor}.0.0`;
+      } else if (isXVersion(fromPatch)) {
+        from = `>=${fromMajor}.${fromMinor}.0`;
+      } else {
+        from = `>=${from}`;
+      }
+      if (isXVersion(toMajor)) {
+        to = "";
+      } else if (isXVersion(toMinor)) {
+        to = `<${+toMajor + 1}.0.0-0`;
+      } else if (isXVersion(toPatch)) {
+        to = `<${toMajor}.${+toMinor + 1}.0-0`;
+      } else if (toPreRelease) {
+        to = `<=${toMajor}.${toMinor}.${toPatch}-${toPreRelease}`;
+      } else {
+        to = `<=${to}`;
+      }
+      return `${from} ${to}`.trim();
+    }
+  );
+}
+function parseComparatorTrim(range) {
+  return range.replace(parseRegex(comparatorTrim), "$1$2$3");
+}
+function parseTildeTrim(range) {
+  return range.replace(parseRegex(tildeTrim), "$1~");
+}
+function parseCaretTrim(range) {
+  return range.replace(parseRegex(caretTrim), "$1^");
+}
+function parseCarets(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(caret),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          if (major === "0") {
+            return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+          } else {
+            return `>=${major}.${minor}.0 <${+major + 1}.0.0-0`;
+          }
+        } else if (preRelease2) {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+            }
+          } else {
+            return `>=${major}.${minor}.${patch}-${preRelease2} <${+major + 1}.0.0-0`;
+          }
+        } else {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+            }
+          }
+          return `>=${major}.${minor}.${patch} <${+major + 1}.0.0-0`;
+        }
+      }
+    );
+  }).join(" ");
+}
+function parseTildes(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(tilde),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+        } else if (preRelease2) {
+          return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+      }
+    );
+  }).join(" ");
+}
+function parseXRanges(range) {
+  return range.split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.trim().replace(
+      parseRegex(xRange),
+      (ret, gtlt2, major, minor, patch, preRelease2) => {
+        const isXMajor = isXVersion(major);
+        const isXMinor = isXMajor || isXVersion(minor);
+        const isXPatch = isXMinor || isXVersion(patch);
+        if (gtlt2 === "=" && isXPatch) {
+          gtlt2 = "";
+        }
+        preRelease2 = "";
+        if (isXMajor) {
+          if (gtlt2 === ">" || gtlt2 === "<") {
+            return "<0.0.0-0";
+          } else {
+            return "*";
+          }
+        } else if (gtlt2 && isXPatch) {
+          if (isXMinor) {
+            minor = 0;
+          }
+          patch = 0;
+          if (gtlt2 === ">") {
+            gtlt2 = ">=";
+            if (isXMinor) {
+              major = +major + 1;
+              minor = 0;
+              patch = 0;
+            } else {
+              minor = +minor + 1;
+              patch = 0;
+            }
+          } else if (gtlt2 === "<=") {
+            gtlt2 = "<";
+            if (isXMinor) {
+              major = +major + 1;
+            } else {
+              minor = +minor + 1;
+            }
+          }
+          if (gtlt2 === "<") {
+            preRelease2 = "-0";
+          }
+          return `${gtlt2 + major}.${minor}.${patch}${preRelease2}`;
+        } else if (isXMinor) {
+          return `>=${major}.0.0${preRelease2} <${+major + 1}.0.0-0`;
+        } else if (isXPatch) {
+          return `>=${major}.${minor}.0${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return ret;
+      }
+    );
+  }).join(" ");
+}
+function parseStar(range) {
+  return range.trim().replace(parseRegex(star), "");
+}
+function parseGTE0(comparatorString) {
+  return comparatorString.trim().replace(parseRegex(gte0), "");
+}
+function compareAtom(rangeAtom, versionAtom) {
+  rangeAtom = +rangeAtom || rangeAtom;
+  versionAtom = +versionAtom || versionAtom;
+  if (rangeAtom > versionAtom) {
+    return 1;
+  }
+  if (rangeAtom === versionAtom) {
+    return 0;
+  }
+  return -1;
+}
+function comparePreRelease(rangeAtom, versionAtom) {
+  const { preRelease: rangePreRelease } = rangeAtom;
+  const { preRelease: versionPreRelease } = versionAtom;
+  if (rangePreRelease === void 0 && !!versionPreRelease) {
+    return 1;
+  }
+  if (!!rangePreRelease && versionPreRelease === void 0) {
+    return -1;
+  }
+  if (rangePreRelease === void 0 && versionPreRelease === void 0) {
+    return 0;
+  }
+  for (let i = 0, n = rangePreRelease.length; i <= n; i++) {
+    const rangeElement = rangePreRelease[i];
+    const versionElement = versionPreRelease[i];
+    if (rangeElement === versionElement) {
+      continue;
+    }
+    if (rangeElement === void 0 && versionElement === void 0) {
+      return 0;
+    }
+    if (!rangeElement) {
+      return 1;
+    }
+    if (!versionElement) {
+      return -1;
+    }
+    return compareAtom(rangeElement, versionElement);
+  }
+  return 0;
+}
+function compareVersion(rangeAtom, versionAtom) {
+  return compareAtom(rangeAtom.major, versionAtom.major) || compareAtom(rangeAtom.minor, versionAtom.minor) || compareAtom(rangeAtom.patch, versionAtom.patch) || comparePreRelease(rangeAtom, versionAtom);
+}
+function eq(rangeAtom, versionAtom) {
+  return rangeAtom.version === versionAtom.version;
+}
+function compare(rangeAtom, versionAtom) {
+  switch (rangeAtom.operator) {
+    case "":
+    case "=":
+      return eq(rangeAtom, versionAtom);
+    case ">":
+      return compareVersion(rangeAtom, versionAtom) < 0;
+    case ">=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) < 0;
+    case "<":
+      return compareVersion(rangeAtom, versionAtom) > 0;
+    case "<=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) > 0;
+    case void 0: {
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+function parseComparatorString(range) {
+  return pipe(
+    parseCarets,
+    parseTildes,
+    parseXRanges,
+    parseStar
+  )(range);
+}
+function parseRange(range) {
+  return pipe(
+    parseHyphen,
+    parseComparatorTrim,
+    parseTildeTrim,
+    parseCaretTrim
+  )(range.trim()).split(/\s+/).join(" ");
+}
+function satisfy(version, range) {
+  if (!version) {
+    return false;
+  }
+  const parsedRange = parseRange(range);
+  const parsedComparator = parsedRange.split(" ").map((rangeVersion) => parseComparatorString(rangeVersion)).join(" ");
+  const comparators = parsedComparator.split(/\s+/).map((comparator2) => parseGTE0(comparator2));
+  const extractedVersion = extractComparator(version);
+  if (!extractedVersion) {
+    return false;
+  }
+  const [
+    ,
+    versionOperator,
+    ,
+    versionMajor,
+    versionMinor,
+    versionPatch,
+    versionPreRelease
+  ] = extractedVersion;
+  const versionAtom = {
+    version: combineVersion(
+      versionMajor,
+      versionMinor,
+      versionPatch,
+      versionPreRelease
+    ),
+    major: versionMajor,
+    minor: versionMinor,
+    patch: versionPatch,
+    preRelease: versionPreRelease == null ? void 0 : versionPreRelease.split(".")
+  };
+  for (const comparator2 of comparators) {
+    const extractedComparator = extractComparator(comparator2);
+    if (!extractedComparator) {
+      return false;
+    }
+    const [
+      ,
+      rangeOperator,
+      ,
+      rangeMajor,
+      rangeMinor,
+      rangePatch,
+      rangePreRelease
+    ] = extractedComparator;
+    const rangeAtom = {
+      operator: rangeOperator,
+      version: combineVersion(
+        rangeMajor,
+        rangeMinor,
+        rangePatch,
+        rangePreRelease
+      ),
+      major: rangeMajor,
+      minor: rangeMinor,
+      patch: rangePatch,
+      preRelease: rangePreRelease == null ? void 0 : rangePreRelease.split(".")
+    };
+    if (!compare(rangeAtom, versionAtom)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// eslint-disable-next-line no-undef
+const moduleMap = {};
+const moduleCache = Object.create(null);
+async function importShared(name, shareScope = 'default') {
+  return moduleCache[name]
+    ? new Promise((r) => r(moduleCache[name]))
+    : (await getSharedFromRuntime(name, shareScope)) || getSharedFromLocal(name)
+}
+async function getSharedFromRuntime(name, shareScope) {
+  let module = null;
+  if (globalThis?.__federation_shared__?.[shareScope]?.[name]) {
+    const versionObj = globalThis.__federation_shared__[shareScope][name];
+    const requiredVersion = moduleMap[name]?.requiredVersion;
+    const hasRequiredVersion = !!requiredVersion;
+    if (hasRequiredVersion) {
+      const versionKey = Object.keys(versionObj).find((version) =>
+        satisfy(version, requiredVersion)
+      );
+      if (versionKey) {
+        const versionValue = versionObj[versionKey];
+        module = await (await versionValue.get())();
+      } else {
+        console.log(
+          `provider support ${name}(${versionKey}) is not satisfied requiredVersion(\${moduleMap[name].requiredVersion})`
+        );
+      }
+    } else {
+      const versionKey = Object.keys(versionObj)[0];
+      const versionValue = versionObj[versionKey];
+      module = await (await versionValue.get())();
+    }
+  }
+  if (module) {
+    return flattenModule(module, name)
+  }
+}
+async function getSharedFromLocal(name) {
+  if (moduleMap[name]?.import) {
+    let module = await (await moduleMap[name].get())();
+    return flattenModule(module, name)
+  } else {
+    console.error(
+      `consumer config import=false,so cant use callback shared module`
+    );
+  }
+}
+function flattenModule(module, name) {
+  // use a shared module which export default a function will getting error 'TypeError: xxx is not a function'
+  if (typeof module.default === 'function') {
+    Object.keys(module).forEach((key) => {
+      if (key !== 'default') {
+        module.default[key] = module[key];
+      }
+    });
+    moduleCache[name] = module.default;
+    return module.default
+  }
+  if (module.default) module = Object.assign({}, module.default, module);
+  moduleCache[name] = module;
+  return module
+}
+
+export { importShared, getSharedFromLocal as importSharedLocal, getSharedFromRuntime as importSharedRuntime };

--- a/plugins.v2/storagecleanup/dist/v1.0.1/assets/_plugin-vue_export-helper-pcqpp-6-.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.1/assets/_plugin-vue_export-helper-pcqpp-6-.js
@@ -1,0 +1,9 @@
+const _export_sfc = (sfc, props) => {
+  const target = sfc.__vccOpts || sfc;
+  for (const [key, val] of props) {
+    target[key] = val;
+  }
+  return target;
+};
+
+export { _export_sfc as _ };

--- a/plugins.v2/storagecleanup/dist/v1.0.1/assets/index-C0PlkGw0.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.1/assets/index-C0PlkGw0.js
@@ -1,0 +1,44 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage from './__federation_expose_AppPage-Jh9a-Wh_.js';
+
+true              &&(function polyfill() {
+  const relList = document.createElement("link").relList;
+  if (relList && relList.supports && relList.supports("modulepreload")) {
+    return;
+  }
+  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+    processPreload(link);
+  }
+  new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type !== "childList") {
+        continue;
+      }
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === "LINK" && node.rel === "modulepreload")
+          processPreload(node);
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  function getFetchOpts(link) {
+    const fetchOpts = {};
+    if (link.integrity) fetchOpts.integrity = link.integrity;
+    if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
+    if (link.crossOrigin === "use-credentials")
+      fetchOpts.credentials = "include";
+    else if (link.crossOrigin === "anonymous") fetchOpts.credentials = "omit";
+    else fetchOpts.credentials = "same-origin";
+    return fetchOpts;
+  }
+  function processPreload(link) {
+    if (link.ep)
+      return;
+    link.ep = true;
+    const fetchOpts = getFetchOpts(link);
+    fetch(link.href, fetchOpts);
+  }
+}());
+
+const {createApp} = await importShared('vue');
+
+createApp(AppPage).mount('#app');

--- a/plugins.v2/storagecleanup/dist/v1.0.1/assets/remoteEntry.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.1/assets/remoteEntry.js
@@ -2,14 +2,14 @@ const currentImports = {};
       const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
       let moduleMap = {
 "./AppPage":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './AppPage');
-      return __federation_import('./__federation_expose_AppPage-WrNLRDkU.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-DHXLALqV.css"], false, './AppPage');
+      return __federation_import('./__federation_expose_AppPage-Jh9a-Wh_.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Page":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './Page');
-      return __federation_import('./__federation_expose_Page-DAUTopwb.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-DHXLALqV.css"], false, './Page');
+      return __federation_import('./__federation_expose_Page-KJioYuOl.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Config":()=>{
-      dynamicLoadingCss(["__federation_expose_Config-BHIxEI63.css"], false, './Config');
-      return __federation_import('./__federation_expose_Config-BlunJQWM.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
+      dynamicLoadingCss(["__federation_expose_Config-SYLmVfvj.css"], false, './Config');
+      return __federation_import('./__federation_expose_Config-jwIyjrQZ.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
       const seen = {};
       const dynamicLoadingCss = (cssFilePaths, dontAppendStylesToHead, exposeItemName) => {
         const metaUrl = import.meta.url;
@@ -48,7 +48,7 @@ const currentImports = {};
          } else {
            href = cssPath;
          }
-         
+
           if (dontAppendStylesToHead) {
             const key = 'css__StorageCleanup__' + exposeItemName;
             window[key] = window[key] || [];

--- a/plugins.v2/storagecleanup/dist/v1.0.1/index.html
+++ b/plugins.v2/storagecleanup/dist/v1.0.1/index.html
@@ -1,0 +1,6 @@
+<script type="module" crossorigin src="/assets/index-C0PlkGw0.js"></script>
+<link rel="modulepreload" crossorigin href="/assets/__federation_fn_import-JrT3xvdd.js">
+<link rel="modulepreload" crossorigin href="/assets/_plugin-vue_export-helper-pcqpp-6-.js">
+<link rel="modulepreload" crossorigin href="/assets/__federation_expose_AppPage-Jh9a-Wh_.js">
+<link rel="stylesheet" crossorigin href="/assets/__federation_expose_AppPage-DHXLALqV.css">
+<div id="app"></div>

--- a/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_expose_AppPage-Bdp0MSc6.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_expose_AppPage-Bdp0MSc6.js
@@ -1,0 +1,1374 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import Config, { _ as _export_sfc } from './__federation_expose_Config-D6hmMvYZ.js';
+
+const FILTER_GROUPS = [
+  {
+    id: 'type',
+    label: '资源类型',
+    multi: false,
+    options: [
+      { id: 'all', label: '全部资源' },
+      { id: 'movie', label: '电影' },
+      { id: 'tv', label: '电视剧' },
+    ],
+  },
+  {
+    id: 'library',
+    label: '媒体库状态',
+    multi: false,
+    options: [
+      { id: 'all', label: '全部' },
+      { id: 'imported', label: '已入库' },
+      { id: 'not-imported', label: '未入库' },
+    ],
+  },
+  {
+    id: 'seed',
+    label: '做种约束',
+    multi: false,
+    options: [
+      { id: 'all', label: '全部' },
+      { id: 'hr', label: 'H&R 保护中', tone: 'warning' },
+      { id: 'none', label: '无做种要求' },
+    ],
+  },
+  {
+    id: 'flags',
+    label: '待处理 / 质量',
+    multi: true,
+    options: [
+      { id: 'incomplete', label: '剧集不完整', tone: 'warning' },
+      { id: 'name-pending', label: '名称待确认' },
+    ],
+  },
+];
+
+function createFilterState() {
+  return { type: 'all', library: 'all', seed: 'all', flags: [] }
+}
+
+const ACTIONS = {
+  pause: {
+    title: '停止做种',
+    detail: '保留 qB 任务和全部文件',
+  },
+  retire: {
+    title: '退出做种',
+    detail: '移除 qB 任务，媒体仍保留',
+  },
+  delete: {
+    title: '完整删除',
+    detail: '移除任务、媒体和全部链接',
+  },
+};
+
+function unwrapResponse(response) {
+  if (response && Object.prototype.hasOwnProperty.call(response, 'data') && response.success !== undefined) {
+    return response.data
+  }
+  return response?.data ?? response
+}
+
+function createLatestPlanApi(api) {
+  let generation = 0;
+  let latestPlanResult = null;
+
+  return {
+    ...api,
+    get(...args) {
+      return api.get(...args)
+    },
+    post(path, body, ...args) {
+      if (!String(path || '').endsWith('/plan')) {
+        return api.post(path, body, ...args)
+      }
+
+      const requestGeneration = ++generation;
+      let rawRequest;
+      try {
+        rawRequest = Promise.resolve(api.post(path, body, ...args));
+      } catch (error) {
+        rawRequest = Promise.reject(error);
+      }
+
+      const result = (async () => {
+        try {
+          const response = await rawRequest;
+          if (requestGeneration !== generation && latestPlanResult) {
+            return await latestPlanResult
+          }
+          return response
+        } catch (error) {
+          if (requestGeneration !== generation && latestPlanResult) {
+            return await latestPlanResult
+          }
+          throw error
+        }
+      })();
+      latestPlanResult = result;
+      return result
+    },
+  }
+}
+
+function mediaType(item) {
+  const type = String(item?.type || '').trim().toLowerCase();
+  if (type === '电影' || type === 'movie') return 'movie'
+  if (type === '电视剧' || type === 'tv' || type === 'series') return 'tv'
+
+  // Keep older snapshots usable when the explicit type field is absent.
+  const edition = String(item?.edition || '').trim().toLowerCase();
+  if (edition === '电影' || edition.startsWith('电影 ·')) return 'movie'
+  return ''
+}
+
+function isIncompleteTv(item) {
+  return mediaType(item) === 'tv' && item?.episodeIncomplete === true
+}
+
+function matchesFilter(item, filter) {
+  if (filter === 'all') return true
+  if (filter === 'movie') return mediaType(item) === 'movie'
+  if (filter === 'tv') return mediaType(item) === 'tv'
+  if (filter === 'tv-incomplete') return isIncompleteTv(item)
+  if (filter === 'library') return Boolean(item.library)
+  if (filter === 'hr') return Boolean(item.hr || item.hrPending)
+  if (filter === 'review') return !item.protected && item.qbSummary === '无 qB 任务'
+  return item.metadataVerified === false
+}
+
+function matchesFlag(item, flag) {
+  if (flag === 'incomplete') return isIncompleteTv(item)
+  if (flag === 'name-pending') return item.metadataVerified === false
+  return false
+}
+
+function matchesFilterState(item, filters = createFilterState()) {
+  const state = filters || createFilterState();
+  const type = state.type || 'all';
+  const library = state.library || 'all';
+  const seed = state.seed || 'all';
+  const flags = Array.isArray(state.flags) ? state.flags : [];
+
+  if (type !== 'all' && mediaType(item) !== type) return false
+  if (library === 'imported' && !item.library) return false
+  if (library === 'not-imported' && item.library) return false
+  if (seed === 'hr' && !matchesFilter(item, 'hr')) return false
+  if (seed === 'none' && !matchesFilter(item, 'review')) return false
+  return flags.every(flag => matchesFlag(item, flag))
+}
+
+function legacyFilterState(filter) {
+  const state = createFilterState();
+  if (filter === 'movie' || filter === 'tv') state.type = filter;
+  else if (filter === 'tv-incomplete') state.flags = ['incomplete'];
+  else if (filter === 'library') state.library = 'imported';
+  else if (filter === 'hr') state.seed = 'hr';
+  else if (filter === 'review') state.seed = 'none';
+  else if (filter === 'names') state.flags = ['name-pending'];
+  return state
+}
+
+function filterOptionCount(resources, filters, groupId, optionId) {
+  const state = {
+    ...createFilterState(),
+    ...(filters || {}),
+    flags: Array.isArray(filters?.flags) ? [...filters.flags] : [],
+  };
+  if (groupId === 'type') state.type = optionId;
+  if (groupId === 'library') state.library = optionId;
+  if (groupId === 'seed') state.seed = optionId;
+  if (groupId === 'flags') {
+    state.flags = optionId === 'all'
+      ? []
+      : [...new Set([...state.flags, optionId])];
+  }
+  return (resources || []).filter(item => matchesFilterState(item, state)).length
+}
+
+function isDirectlyCleanable(item) {
+  return !item.protected && item.qbSummary === '无 qB 任务'
+}
+
+function filterResources(resources, { filter, filters, search, safeOnly, descending }) {
+  const query = String(search || '').trim().toLowerCase();
+  const state = filters || legacyFilterState(filter);
+  return [...(resources || [])]
+    .filter(item => {
+      const text = `${item.title || ''} ${item.englishTitle || ''} ${item.edition || ''} ${item.siteSummary || ''}`.toLowerCase();
+      return matchesFilterState(item, state) &&
+        (!safeOnly || isDirectlyCleanable(item)) &&
+        (!query || text.includes(query))
+    })
+    .sort((left, right) => {
+      const order = descending ? Number(right.size || 0) - Number(left.size || 0) : Number(left.size || 0) - Number(right.size || 0);
+      return order || String(left.title || '').localeCompare(String(right.title || ''), 'zh-CN')
+    })
+}
+
+function formatGiB(size) {
+  const numeric = Number(size || 0);
+  return numeric >= 1024 ? `${(numeric / 1024).toFixed(2)} TB` : `${numeric.toFixed(1)} GB`
+}
+
+function formatBytes(size) {
+  return formatGiB(Number(size || 0) / 1024 ** 3)
+}
+
+function issueKey(issue, index) {
+  return `${issue?.code || 'issue'}-${index}`
+}
+
+function refreshFeedback(elapsedSeconds) {
+  const elapsed = Math.max(0, Number(elapsedSeconds) || 0);
+  if (elapsed < 5) return '正在读取 NAS 只读快照…'
+  if (elapsed < 30) {
+    return `正在核对媒体目录、qB 与 H&R（已等待 ${elapsed} 秒）`
+  }
+  return `远端 H&R 探测可能需要数分钟（已等待 ${elapsed} 秒），请保持页面打开。`
+}
+
+const {createElementVNode:_createElementVNode,toDisplayString:_toDisplayString,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,normalizeClass:_normalizeClass,vModelText:_vModelText,withDirectives:_withDirectives,vModelCheckbox:_vModelCheckbox,createTextVNode:_createTextVNode,renderList:_renderList,Fragment:_Fragment,unref:_unref,withModifiers:_withModifiers,createVNode:_createVNode,Teleport:_Teleport,createBlock:_createBlock} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "cleanup-app" };
+const _hoisted_2 = {
+  key: 0,
+  class: "page-header"
+};
+const _hoisted_3 = { key: 0 };
+const _hoisted_4 = { class: "toolbar" };
+const _hoisted_5 = { class: "search" };
+const _hoisted_6 = { class: "safe-toggle" };
+const _hoisted_7 = ["disabled", "aria-label", "aria-busy", "title"];
+const _hoisted_8 = {
+  key: 0,
+  class: "refresh-feedback",
+  role: "status",
+  "aria-live": "polite"
+};
+const _hoisted_9 = {
+  key: 1,
+  class: "notice critical stale-notice",
+  role: "status"
+};
+const _hoisted_10 = {
+  key: 2,
+  class: "onboarding-card"
+};
+const _hoisted_11 = { key: 0 };
+const _hoisted_12 = { key: 1 };
+const _hoisted_13 = {
+  class: "filter-panel",
+  "aria-label": "资源筛选"
+};
+const _hoisted_14 = { class: "filter-label" };
+const _hoisted_15 = { class: "filter-options" };
+const _hoisted_16 = ["aria-pressed", "onClick"];
+const _hoisted_17 = { class: "filter-footer" };
+const _hoisted_18 = {
+  class: "active-filter-chips",
+  "aria-live": "polite"
+};
+const _hoisted_19 = {
+  key: 0,
+  class: "filter-caption"
+};
+const _hoisted_20 = ["onClick"];
+const _hoisted_21 = { class: "filter-result-count" };
+const _hoisted_22 = { class: "resource-card" };
+const _hoisted_23 = { class: "table-head" };
+const _hoisted_24 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_25 = ["disabled", "onClick"];
+const _hoisted_26 = { class: "resource-title" };
+const _hoisted_27 = {
+  class: "stack-cell library",
+  "data-label": "媒体库"
+};
+const _hoisted_28 = { key: 0 };
+const _hoisted_29 = {
+  class: "seed-cell",
+  "data-label": "做种与保护"
+};
+const _hoisted_30 = {
+  key: 1,
+  class: "stack-cell"
+};
+const _hoisted_31 = {
+  class: "stack-cell size",
+  "data-label": "实际占用"
+};
+const _hoisted_32 = {
+  key: 2,
+  class: "empty-state"
+};
+const _hoisted_33 = {
+  key: 0,
+  class: "action-bar"
+};
+const _hoisted_34 = { class: "selected-count" };
+const _hoisted_35 = { class: "action-buttons" };
+const _hoisted_36 = ["disabled", "title", "onClick"];
+const _hoisted_37 = {
+  class: "modal plan-modal",
+  role: "dialog",
+  "aria-modal": "true"
+};
+const _hoisted_38 = ["disabled"];
+const _hoisted_39 = { key: 0 };
+const _hoisted_40 = { key: 1 };
+const _hoisted_41 = { class: "plan-resources" };
+const _hoisted_42 = {
+  key: 0,
+  class: "plan-state"
+};
+const _hoisted_43 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_44 = {
+  key: 0,
+  class: "issues blocked"
+};
+const _hoisted_45 = {
+  key: 1,
+  class: "issues warning"
+};
+const _hoisted_46 = {
+  key: 2,
+  class: "risk-check"
+};
+const _hoisted_47 = ["checked"];
+const _hoisted_48 = {
+  key: 3,
+  class: "plan-state blocked"
+};
+const _hoisted_49 = { class: "safety-note" };
+const _hoisted_50 = {
+  key: 3,
+  class: "execution-result"
+};
+const _hoisted_51 = { key: 0 };
+const _hoisted_52 = {
+  key: 4,
+  class: "final-confirmation"
+};
+const _hoisted_53 = {
+  key: 0,
+  class: "error-text"
+};
+const _hoisted_54 = ["disabled"];
+const _hoisted_55 = ["disabled"];
+const _hoisted_56 = ["disabled"];
+const _hoisted_57 = { class: "modal compact-modal" };
+const _hoisted_58 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_59 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_60 = { class: "modal compact-modal" };
+const _hoisted_61 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_62 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_63 = ["onClick"];
+const _hoisted_64 = ["onClick"];
+const _hoisted_65 = {
+  key: 2,
+  class: "recovery-confirm"
+};
+const _hoisted_66 = ["disabled"];
+const _hoisted_67 = {
+  class: "modal settings-modal",
+  role: "dialog",
+  "aria-modal": "true",
+  "aria-labelledby": "storage-cleanup-settings-title"
+};
+
+const {computed,onMounted,onUnmounted,ref} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'AppPage',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+  hideTitle: { type: Boolean, default: false },
+},
+  setup(__props) {
+
+const props = __props;
+
+const emptySnapshot = {
+  schemaVersion: 2,
+  snapshotId: '',
+  generatedAt: '',
+  stats: {},
+  resources: [],
+};
+
+const snapshot = ref(emptySnapshot);
+const health = ref({});
+const loading = ref(true);
+const refreshing = ref(false);
+const refreshElapsed = ref(0);
+const error = ref('');
+const search = ref('');
+const filterState = ref(createFilterState());
+const safeOnly = ref(false);
+const descending = ref(true);
+const selected = ref([]);
+
+const planOpen = ref(false);
+const planMode = ref(null);
+const plan = ref(null);
+const planLoading = ref(false);
+const planError = ref('');
+const acknowledgeSiteRisk = ref(false);
+const finalConfirmation = ref(false);
+const executing = ref(false);
+const executeError = ref('');
+const executeResult = ref(null);
+
+const gapOpen = ref(false);
+const gapLoading = ref(false);
+const gaps = ref([]);
+const gapError = ref('');
+
+const recoveryOpen = ref(false);
+const recoveryLoading = ref(false);
+const recoveries = ref([]);
+const recoveryError = ref('');
+const recoveryTarget = ref(null);
+const recoveryAction = ref(null);
+const recoveryPhrase = ref('');
+const recovering = ref(false);
+const settingsOpen = ref(false);
+
+const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`);
+const resources = computed(() => snapshot.value.resources || []);
+const visible = computed(() => filterResources(resources.value, {
+  filters: filterState.value,
+  search: search.value,
+  safeOnly: safeOnly.value,
+  descending: descending.value,
+}));
+const selectedItems = computed(() => resources.value.filter(item => selected.value.includes(item.id)));
+const selectedSize = computed(() => selectedItems.value.reduce((total, item) => total + Number(item.size || 0), 0));
+const executionEnabled = computed(() => Boolean(health.value.executionEnabled));
+const inventoryCurrent = computed(() => health.value.inventoryCurrent !== false);
+const onboardingRequired = computed(() => !loading.value && (
+  !snapshot.value.snapshotId || health.value.configReady === false
+));
+const unresolvedTransactions = computed(() => Number(snapshot.value.stats?.unresolvedTransactions || 0));
+const hrGap = computed(() => Math.max(
+  0,
+  Number(
+    snapshot.value.stats?.hrMissingQbTasks ??
+    Number(snapshot.value.stats?.hrActiveTitles || 0) - Number(snapshot.value.stats?.hrMatchedQbTasks || 0),
+  ),
+));
+const hrUnassigned = computed(() => Number(
+  snapshot.value.stats?.hrMissingUnassigned ??
+  snapshot.value.stats?.hrMissingUncovered ??
+  0,
+));
+const filterGroups = computed(() => FILTER_GROUPS.map(group => ({
+  ...group,
+  options: group.options.map(option => ({
+    ...option,
+    count: filterOptionCount(resources.value, filterState.value, group.id, option.id),
+  })),
+})));
+const activeFilterChips = computed(() => {
+  const chips = [];
+  for (const group of FILTER_GROUPS) {
+    const selected = group.id === 'flags'
+      ? filterState.value.flags
+      : [filterState.value[group.id]];
+    for (const option of group.options) {
+      if (option.id !== 'all' && selected.includes(option.id)) {
+        chips.push({ group: group.id, id: option.id, label: option.label });
+      }
+    }
+  }
+  return chips
+});
+const allVisibleSelected = computed(() => {
+  const selectable = visible.value.filter(item => !item.protected);
+  return selectable.length > 0 && selectable.every(item => selected.value.includes(item.id))
+});
+const currentAction = computed(() => planMode.value ? ACTIONS[planMode.value] : null);
+const planExpired = computed(() => Boolean(plan.value && Date.parse(plan.value.expiresAt) <= Date.now()));
+const allFiltersDefault = computed(() => activeFilterChips.value.length === 0);
+const refreshMessage = computed(() => {
+  if (!refreshing.value) return ''
+  return refreshFeedback(refreshElapsed.value)
+});
+
+let refreshTimer = null;
+
+function stopRefreshTimer() {
+  if (refreshTimer !== null) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+function startRefreshTimer() {
+  stopRefreshTimer();
+  refreshElapsed.value = 0;
+  refreshTimer = setInterval(() => {
+    refreshElapsed.value += 1;
+  }, 1000);
+}
+
+function payloadError(payload, fallback) {
+  return payload?.error?.message || fallback
+}
+
+function requestErrorMessage(error, fallback) {
+  const response = error?.response || {};
+  const payload = response.data || error?.data || {};
+  const nested = payload?.error || {};
+  if (nested.code === 'inventory_stale' || response.status === 409 || error?.status === 409) {
+    health.value = { ...health.value, inventoryCurrent: false };
+    return '资源清单已过期，请点击“刷新资源清单”后再操作。浏览器重新加载不会重新核对 NAS。'
+  }
+  return nested.message || payload.message || error?.message || fallback
+}
+
+async function get(path) {
+  return unwrapResponse(await props.api.get(`${pluginBase.value}${path}`))
+}
+
+async function post(path, body) {
+  return unwrapResponse(await props.api.post(`${pluginBase.value}${path}`, body))
+}
+
+function acceptSnapshot(next) {
+  if (!next || next.schemaVersion !== 2 || !next.snapshotId || !Array.isArray(next.resources)) {
+    throw new Error('资源快照格式不受支持。')
+  }
+  snapshot.value = next;
+  const available = new Set(next.resources.map(item => item.id));
+  selected.value = selected.value.filter(id => available.has(id));
+}
+
+async function loadStatus() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const payload = await get('/status');
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '无法读取清理台状态。'))
+    health.value = payload.health || {};
+    acceptSnapshot(payload.snapshot);
+    if (health.value.inventoryCurrent === false) {
+      selected.value = [];
+    }
+  } catch (err) {
+    error.value = err?.message || '无法读取清理台状态。';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function refreshSnapshot() {
+  if (refreshing.value) return
+  refreshing.value = true;
+  startRefreshTimer();
+  error.value = '';
+  try {
+    const payload = await post('/refresh', {});
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '刷新失败。'))
+    acceptSnapshot(payload.snapshot);
+    health.value = { ...health.value, inventoryCurrent: true };
+  } catch (err) {
+    error.value = err?.message || '刷新失败，继续显示上次快照。';
+    health.value = { ...health.value, inventoryCurrent: false };
+  } finally {
+    stopRefreshTimer();
+    refreshing.value = false;
+  }
+}
+
+function toggle(item) {
+  if (item.protected) return
+  selected.value = selected.value.includes(item.id)
+    ? selected.value.filter(id => id !== item.id)
+    : [...selected.value, item.id];
+}
+
+function toggleVisible() {
+  const ids = visible.value.filter(item => !item.protected).map(item => item.id);
+  selected.value = allVisibleSelected.value
+    ? selected.value.filter(id => !ids.includes(id))
+    : [...new Set([...selected.value, ...ids])];
+}
+
+function isFilterActive(group, option) {
+  if (group.id === 'flags') return filterState.value.flags.includes(option.id)
+  return filterState.value[group.id] === option.id
+}
+
+function selectFilter(group, option) {
+  if (group.id === 'flags') {
+    filterState.value = {
+      ...filterState.value,
+      flags: filterState.value.flags.includes(option.id)
+        ? filterState.value.flags.filter(id => id !== option.id)
+        : [...filterState.value.flags, option.id],
+    };
+    return
+  }
+  filterState.value = { ...filterState.value, [group.id]: option.id };
+}
+
+function clearFilters() {
+  filterState.value = createFilterState();
+}
+
+function clearFilterChip(chip) {
+  if (chip.group === 'flags') {
+    filterState.value = {
+      ...filterState.value,
+      flags: filterState.value.flags.filter(id => id !== chip.id),
+    };
+    return
+  }
+  filterState.value = { ...filterState.value, [chip.group]: 'all' };
+}
+
+async function requestPlan(mode, acknowledged = false) {
+  planLoading.value = true;
+  planError.value = '';
+  plan.value = null;
+  finalConfirmation.value = false;
+  if (!inventoryCurrent.value) {
+    planError.value = '资源清单已过期，请点击“刷新资源清单”后再操作。浏览器重新加载不会重新核对 NAS。';
+    planLoading.value = false;
+    return
+  }
+  try {
+    const payload = await post('/plan', {
+      snapshotId: snapshot.value.snapshotId,
+      resourceIds: selected.value,
+      mode,
+      acknowledgeSiteRisk: acknowledged,
+    });
+    if (!payload?.ok || !payload.plan) throw new Error(payloadError(payload, '无法生成执行计划。'))
+    plan.value = payload.plan;
+  } catch (err) {
+    planError.value = requestErrorMessage(err, '无法生成执行计划。');
+  } finally {
+    planLoading.value = false;
+  }
+}
+
+function openPlan(mode) {
+  planMode.value = mode;
+  planOpen.value = true;
+  acknowledgeSiteRisk.value = false;
+  executeResult.value = null;
+  executeError.value = '';
+  requestPlan(mode, false);
+}
+
+function closePlan() {
+  if (executing.value) return
+  planOpen.value = false;
+  planMode.value = null;
+  plan.value = null;
+  planError.value = '';
+  finalConfirmation.value = false;
+  executeResult.value = null;
+}
+
+async function setSiteRisk(value) {
+  acknowledgeSiteRisk.value = value;
+  await requestPlan(planMode.value, value);
+}
+
+async function executePlan() {
+  if (!plan.value || planExpired.value || executing.value) return
+  executing.value = true;
+  executeError.value = '';
+  try {
+    const payload = await post('/execute', {
+      planId: plan.value.planId,
+      confirmPhrase: plan.value.confirmPhrase,
+    });
+    if (!payload?.ok || !payload.result) {
+      if (payload?.error?.plan) plan.value = payload.error.plan;
+      throw new Error(payloadError(payload, '执行失败。'))
+    }
+    executeResult.value = payload.result;
+    selected.value = [];
+    if (plan.value?.mode === 'delete') {
+      const deletedIds = new Set(plan.value.resources.map(item => item.id));
+      snapshot.value = {
+        ...snapshot.value,
+        resources: snapshot.value.resources.filter(item => !deletedIds.has(item.id)),
+      };
+    }
+    if (payload.result.snapshotRefreshPending) {
+      health.value = { ...health.value, inventoryCurrent: false };
+    } else {
+      const latest = await get('/snapshot');
+      if (latest?.snapshot) acceptSnapshot(latest.snapshot);
+    }
+  } catch (err) {
+    executeError.value = err?.message || '执行失败。';
+    finalConfirmation.value = false;
+  } finally {
+    executing.value = false;
+  }
+}
+
+async function loadGaps() {
+  gapOpen.value = true;
+  gapLoading.value = true;
+  gapError.value = '';
+  try {
+    const payload = await get('/protection-gaps');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取 H&R 缺口。'))
+    gaps.value = payload.gaps || [];
+  } catch (err) {
+    gapError.value = err?.message || '无法读取 H&R 缺口。';
+  } finally {
+    gapLoading.value = false;
+  }
+}
+
+async function loadRecoveries() {
+  recoveryOpen.value = true;
+  recoveryLoading.value = true;
+  recoveryError.value = '';
+  recoveryTarget.value = null;
+  try {
+    const payload = await get('/recovery');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取恢复状态。'))
+    recoveries.value = payload.recoveries || [];
+  } catch (err) {
+    recoveryError.value = err?.message || '无法读取恢复状态。';
+  } finally {
+    recoveryLoading.value = false;
+  }
+}
+
+function chooseRecovery(item, action) {
+  recoveryTarget.value = item;
+  recoveryAction.value = action;
+  recoveryPhrase.value = '';
+  recoveryError.value = '';
+}
+
+async function runRecovery() {
+  if (!recoveryTarget.value || !recoveryAction.value || recovering.value) return
+  recovering.value = true;
+  recoveryError.value = '';
+  try {
+    const payload = await post('/recovery', {
+      planId: recoveryTarget.value.planId,
+      action: recoveryAction.value,
+      confirmPhrase: recoveryPhrase.value,
+    });
+    if (!payload?.ok) throw new Error(payloadError(payload, '恢复操作失败。'))
+    await refreshSnapshot();
+    await loadRecoveries();
+  } catch (err) {
+    recoveryError.value = err?.message || '恢复操作失败。';
+  } finally {
+    recovering.value = false;
+  }
+}
+
+function recoveryExpectedPhrase() {
+  if (!recoveryTarget.value || !recoveryAction.value) return ''
+  return recoveryAction.value === 'rollback'
+    ? recoveryTarget.value.rollbackPhrase
+    : recoveryTarget.value.finalizePhrase
+}
+
+function openSettings() {
+  settingsOpen.value = true;
+}
+
+function closeSettings() {
+  settingsOpen.value = false;
+}
+
+onMounted(loadStatus);
+onUnmounted(stopRefreshTimer);
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("main", _hoisted_1, [
+    (!__props.hideTitle)
+      ? (_openBlock(), _createElementBlock("header", _hoisted_2, [
+          _cache[12] || (_cache[12] = _createElementVNode("div", null, [
+            _createElementVNode("p", { class: "eyebrow" }, "安全清理台"),
+            _createElementVNode("h1", null, "存储清理"),
+            _createElementVNode("span", null, "一部电影一行，一部剧一行；先看清影响，再选择清理等级。")
+          ], -1)),
+          _createElementVNode("div", {
+            class: _normalizeClass(['status-card', { danger: error.value || !inventoryCurrent.value }])
+          }, [
+            _createElementVNode("i", null, _toDisplayString(error.value || !inventoryCurrent.value ? '!' : '✓'), 1),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(error.value || (!inventoryCurrent.value ? '资源清单待刷新' : executionEnabled.value ? '执行链路已连接' : '只读模式')), 1),
+              (snapshot.value.generatedAt)
+                ? (_openBlock(), _createElementBlock("span", _hoisted_3, "更新于 " + _toDisplayString(snapshot.value.generatedAt.slice(5, 16).replace('T', ' ')), 1))
+                : _createCommentVNode("", true)
+            ])
+          ], 2)
+        ]))
+      : _createCommentVNode("", true),
+    _createElementVNode("section", _hoisted_4, [
+      _createElementVNode("label", _hoisted_5, [
+        _cache[13] || (_cache[13] = _createElementVNode("span", null, "⌕", -1)),
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((search).value = $event)),
+          "aria-label": "搜索资源",
+          placeholder: "搜索电影、剧集、季度或站点"
+        }, null, 512), [
+          [_vModelText, search.value]
+        ])
+      ]),
+      _createElementVNode("label", _hoisted_6, [
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[1] || (_cache[1] = $event => ((safeOnly).value = $event)),
+          type: "checkbox"
+        }, null, 512), [
+          [_vModelCheckbox, safeOnly.value]
+        ]),
+        _cache[14] || (_cache[14] = _createElementVNode("span", null, null, -1)),
+        _cache[15] || (_cache[15] = _createTextVNode(" 仅看无做种限制 ", -1))
+      ]),
+      _createElementVNode("button", {
+        class: "soft-button",
+        type: "button",
+        onClick: _cache[2] || (_cache[2] = $event => (descending.value = !descending.value))
+      }, " 实际占用 " + _toDisplayString(descending.value ? '↓' : '↑'), 1),
+      _createElementVNode("button", {
+        class: "soft-button settings-button",
+        type: "button",
+        "aria-label": "打开存储清理设置",
+        onClick: openSettings
+      }, " 设置 "),
+      _createElementVNode("button", {
+        class: "icon-button",
+        type: "button",
+        disabled: refreshing.value,
+        "aria-label": refreshing.value ? '正在刷新资源清单' : '刷新资源清单',
+        "aria-busy": refreshing.value,
+        title: refreshMessage.value || '刷新资源清单',
+        onClick: refreshSnapshot
+      }, _toDisplayString(refreshing.value ? '…' : '↻'), 9, _hoisted_7),
+      (refreshing.value)
+        ? (_openBlock(), _createElementBlock("p", _hoisted_8, _toDisplayString(refreshMessage.value), 1))
+        : _createCommentVNode("", true)
+    ]),
+    (!inventoryCurrent.value && !refreshing.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_9, [
+          _cache[16] || (_cache[16] = _createElementVNode("i", null, "!", -1)),
+          _cache[17] || (_cache[17] = _createElementVNode("p", null, [
+            _createElementVNode("strong", null, "资源清单待刷新"),
+            _createElementVNode("span", null, "浏览器重新加载只重载页面，不会重新核对 NAS；刷新完成前已锁定清理动作。")
+          ], -1)),
+          _createElementVNode("button", {
+            type: "button",
+            onClick: refreshSnapshot
+          }, "刷新资源清单")
+        ]))
+      : _createCommentVNode("", true),
+    (onboardingRequired.value)
+      ? (_openBlock(), _createElementBlock("section", _hoisted_10, [
+          _createElementVNode("div", null, [
+            _createElementVNode("strong", null, _toDisplayString(health.value.configReady === false ? '清理台还没有完成配置' : '还没有连接到清理后台'), 1),
+            (error.value)
+              ? (_openBlock(), _createElementBlock("span", _hoisted_11, _toDisplayString(error.value), 1))
+              : (_openBlock(), _createElementBlock("span", _hoisted_12, "请由 NAS 管理员先部署 PiNAS 清理台，并完成只读路径探测；插件不会自动登录或配置 NAS。"))
+          ]),
+          _createElementVNode("button", {
+            type: "button",
+            onClick: openSettings
+          }, "打开设置")
+        ]))
+      : _createCommentVNode("", true),
+    (unresolvedTransactions.value)
+      ? (_openBlock(), _createElementBlock("button", {
+          key: 3,
+          class: "notice critical",
+          type: "button",
+          onClick: loadRecoveries
+        }, [
+          _cache[19] || (_cache[19] = _createElementVNode("i", null, "!", -1)),
+          _createElementVNode("p", null, [
+            _createElementVNode("strong", null, _toDisplayString(unresolvedTransactions.value) + " 个未完成清理事务", 1),
+            _cache[18] || (_cache[18] = _createElementVNode("span", null, "新操作已锁定；请先核对并恢复原事务。", -1))
+          ]),
+          _cache[20] || (_cache[20] = _createElementVNode("b", null, "查看恢复状态", -1))
+        ]))
+      : (hrGap.value)
+        ? (_openBlock(), _createElementBlock("button", {
+            key: 4,
+            class: _normalizeClass(['notice', { warning: hrUnassigned.value }]),
+            type: "button",
+            onClick: loadGaps
+          }, [
+            _cache[21] || (_cache[21] = _createElementVNode("i", null, "H", -1)),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(hrGap.value) + " 个学校站 H&R 尚未恢复完成", 1),
+              _createElementVNode("span", null, _toDisplayString(hrUnassigned.value
+            ? `${hrUnassigned.value} 个未精确关联媒体；不会锁定无关资源。`
+            : '缺失任务只锁定精确关联资源，其他资源可独立清理。'), 1)
+            ]),
+            _cache[22] || (_cache[22] = _createElementVNode("b", null, "查看明细", -1))
+          ], 2))
+        : _createCommentVNode("", true),
+    _createElementVNode("nav", _hoisted_13, [
+      (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(filterGroups.value, (group) => {
+        return (_openBlock(), _createElementBlock("div", {
+          key: group.id,
+          class: "filter-row"
+        }, [
+          _createElementVNode("div", _hoisted_14, [
+            _createTextVNode(_toDisplayString(group.label) + " ", 1),
+            _createElementVNode("small", null, _toDisplayString(group.multi ? '可多选' : '单选'), 1)
+          ]),
+          _createElementVNode("div", _hoisted_15, [
+            (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(group.options, (option) => {
+              return (_openBlock(), _createElementBlock("button", {
+                key: option.id,
+                class: _normalizeClass(['filter-option', { active: isFilterActive(group, option) }, { warning: option.tone === 'warning' }]),
+                "aria-pressed": isFilterActive(group, option),
+                type: "button",
+                onClick: $event => (selectFilter(group, option))
+              }, [
+                _createTextVNode(_toDisplayString(option.label) + " ", 1),
+                _createElementVNode("span", null, _toDisplayString(option.count), 1)
+              ], 10, _hoisted_16))
+            }), 128))
+          ])
+        ]))
+      }), 128)),
+      _createElementVNode("div", _hoisted_17, [
+        _createElementVNode("div", _hoisted_18, [
+          (allFiltersDefault.value)
+            ? (_openBlock(), _createElementBlock("span", _hoisted_19, "当前筛选：全部资源"))
+            : (_openBlock(), _createElementBlock(_Fragment, { key: 1 }, [
+                _cache[23] || (_cache[23] = _createElementVNode("span", { class: "filter-caption" }, "当前筛选", -1)),
+                (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(activeFilterChips.value, (chip) => {
+                  return (_openBlock(), _createElementBlock("button", {
+                    key: `${chip.group}-${chip.id}`,
+                    class: "active-filter-chip",
+                    type: "button",
+                    onClick: $event => (clearFilterChip(chip))
+                  }, _toDisplayString(chip.label) + " × ", 9, _hoisted_20))
+                }), 128))
+              ], 64))
+        ]),
+        _createElementVNode("div", _hoisted_21, [
+          _createElementVNode("strong", null, _toDisplayString(visible.value.length), 1),
+          _cache[24] || (_cache[24] = _createTextVNode(" 条结果 ", -1)),
+          (!allFiltersDefault.value)
+            ? (_openBlock(), _createElementBlock("button", {
+                key: 0,
+                type: "button",
+                onClick: clearFilters
+              }, "清除筛选"))
+            : _createCommentVNode("", true)
+        ])
+      ]),
+      _cache[25] || (_cache[25] = _createElementVNode("p", { class: "filter-help" }, "同组条件单选；不同组条件按 AND 组合。待处理 / 质量标签可以叠加。", -1))
+    ]),
+    _createElementVNode("section", _hoisted_22, [
+      _createElementVNode("div", _hoisted_23, [
+        _createElementVNode("button", {
+          class: "select-all",
+          type: "button",
+          onClick: toggleVisible
+        }, _toDisplayString(allVisibleSelected.value ? '✓' : ''), 1),
+        _cache[26] || (_cache[26] = _createElementVNode("span", null, "资源", -1)),
+        _cache[27] || (_cache[27] = _createElementVNode("span", null, "媒体库", -1)),
+        _cache[28] || (_cache[28] = _createElementVNode("span", null, "做种与保护", -1)),
+        _cache[29] || (_cache[29] = _createElementVNode("span", null, "实际占用", -1)),
+        _cache[30] || (_cache[30] = _createElementVNode("span", null, "完整删除影响", -1))
+      ]),
+      (loading.value)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_24, "正在读取真实资源关系…"))
+        : (_openBlock(true), _createElementBlock(_Fragment, { key: 1 }, _renderList(visible.value, (item) => {
+            return (_openBlock(), _createElementBlock("article", {
+              key: item.id,
+              class: _normalizeClass(['resource-row', { selected: selected.value.includes(item.id) }])
+            }, [
+              _createElementVNode("button", {
+                class: _normalizeClass(['row-check', { locked: item.protected }]),
+                type: "button",
+                disabled: item.protected,
+                onClick: $event => (toggle(item))
+              }, _toDisplayString(item.protected ? '锁' : selected.value.includes(item.id) ? '✓' : ''), 11, _hoisted_25),
+              _createElementVNode("div", _hoisted_26, [
+                _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                _createElementVNode("b", null, _toDisplayString(item.englishTitle), 1),
+                _createElementVNode("span", null, _toDisplayString([item.type, item.year, item.edition].filter(Boolean).join(' · ')), 1)
+              ]),
+              _createElementVNode("div", _hoisted_27, [
+                _createElementVNode("strong", null, _toDisplayString(item.librarySummary), 1),
+                _createElementVNode("span", null, _toDisplayString(item.libraryDetail), 1),
+                (item.episodeStatus === 'incomplete')
+                  ? (_openBlock(), _createElementBlock("span", _hoisted_28, " 缺 " + _toDisplayString(item.episodeMissing) + " 集 · 已有 " + _toDisplayString(item.episodeActual) + " / 应有 " + _toDisplayString(item.episodeExpected), 1))
+                  : _createCommentVNode("", true)
+              ]),
+              _createElementVNode("div", _hoisted_29, [
+                (item.seedTasks?.length)
+                  ? (_openBlock(true), _createElementBlock(_Fragment, { key: 0 }, _renderList(item.seedTasks, (task, index) => {
+                      return (_openBlock(), _createElementBlock("div", {
+                        key: `${task.site}-${task.scope}-${index}`,
+                        class: _normalizeClass(['seed-task', task.tone])
+                      }, [
+                        _createElementVNode("i", null, _toDisplayString(task.status), 1),
+                        _createElementVNode("strong", null, _toDisplayString(task.site), 1),
+                        _createElementVNode("span", null, _toDisplayString(task.scope) + _toDisplayString(task.count > 1 ? ` · ${task.count} 个任务` : ''), 1)
+                      ], 2))
+                    }), 128))
+                  : (_openBlock(), _createElementBlock("div", _hoisted_30, [
+                      _createElementVNode("strong", null, _toDisplayString(item.qbSummary), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.siteSummary), 1)
+                    ]))
+              ]),
+              _createElementVNode("div", _hoisted_31, [
+                _createElementVNode("strong", null, _toDisplayString(item.sizeLabel), 1),
+                _createElementVNode("span", null, _toDisplayString(item.reclaimLabel), 1)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['impact', { danger: item.protected }]),
+                "data-label": "完整删除影响"
+              }, [
+                _createElementVNode("strong", null, _toDisplayString(item.impactTitle), 1),
+                _createElementVNode("span", null, _toDisplayString(item.impactDetail), 1)
+              ], 2)
+            ], 2))
+          }), 128)),
+      (!loading.value && !visible.value.length)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_32, " 没有符合条件的资源，请取消筛选或更换关键词。 "))
+        : _createCommentVNode("", true)
+    ]),
+    (_openBlock(), _createBlock(_Teleport, { to: "body" }, [
+      (selected.value.length)
+        ? (_openBlock(), _createElementBlock("aside", _hoisted_33, [
+            _createElementVNode("div", _hoisted_34, _toDisplayString(selected.value.length), 1),
+            _createElementVNode("p", null, [
+              _cache[31] || (_cache[31] = _createElementVNode("strong", null, "已加入清理计划", -1)),
+              _createElementVNode("span", null, "完整删除上限 " + _toDisplayString(_unref(formatGiB)(selectedSize.value)), 1)
+            ]),
+            _createElementVNode("button", {
+              class: "clear-button",
+              type: "button",
+              onClick: _cache[3] || (_cache[3] = $event => (selected.value = []))
+            }, "清空"),
+            _createElementVNode("div", _hoisted_35, [
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(ACTIONS), (action, mode) => {
+                return (_openBlock(), _createElementBlock("button", {
+                  key: mode,
+                  class: _normalizeClass(['action-level', { delete: mode === 'delete' }]),
+                  disabled: !inventoryCurrent.value || refreshing.value,
+                  title: !inventoryCurrent.value ? '请先刷新资源清单' : action.detail,
+                  type: "button",
+                  onClick: $event => (openPlan(mode))
+                }, [
+                  _createElementVNode("strong", null, _toDisplayString(action.title), 1),
+                  _createElementVNode("span", null, _toDisplayString(action.detail), 1)
+                ], 10, _hoisted_36))
+              }), 128))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (planOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 1,
+            class: "modal-backdrop",
+            onClick: _withModifiers(closePlan, ["self"])
+          }, [
+            _createElementVNode("section", _hoisted_37, [
+              _createElementVNode("header", null, [
+                _createElementVNode("div", null, [
+                  _cache[32] || (_cache[32] = _createElementVNode("span", null, "清理等级 · 真实预演", -1)),
+                  _createElementVNode("h2", null, _toDisplayString(currentAction.value?.title), 1)
+                ]),
+                _createElementVNode("button", {
+                  type: "button",
+                  disabled: executing.value,
+                  onClick: closePlan
+                }, "×", 8, _hoisted_38)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['mode-summary', planMode.value])
+              }, [
+                (plan.value && planMode.value === 'delete')
+                  ? (_openBlock(), _createElementBlock("strong", _hoisted_39, "已核算可释放 " + _toDisplayString(_unref(formatBytes)(plan.value.estimatedReclaimBytes)), 1))
+                  : (_openBlock(), _createElementBlock("strong", _hoisted_40, _toDisplayString(currentAction.value?.detail), 1)),
+                _createElementVNode("span", null, _toDisplayString(planMode.value === 'pause'
+              ? '只改变 qB 运行状态，不删除任务或文件。'
+              : planMode.value === 'retire'
+                ? '移除 qB 任务但保留文件，媒体库继续可播放。'
+                : '仅当全部路径、硬链接、H&R 与任务状态通过校验才会放行。'), 1)
+              ], 2),
+              _createElementVNode("div", _hoisted_41, [
+                (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(selectedItems.value, (item) => {
+                  return (_openBlock(), _createElementBlock("div", {
+                    key: item.id
+                  }, [
+                    _createElementVNode("p", null, [
+                      _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.englishTitle) + " · " + _toDisplayString(item.edition), 1)
+                    ]),
+                    _createElementVNode("b", null, _toDisplayString(item.sizeLabel), 1)
+                  ]))
+                }), 128))
+              ]),
+              (planLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_42, "正在刷新 NAS 状态并复核关系…"))
+                : (planError.value)
+                  ? (_openBlock(), _createElementBlock("div", _hoisted_43, [
+                      _cache[33] || (_cache[33] = _createElementVNode("strong", null, "无法生成计划", -1)),
+                      _createElementVNode("span", null, _toDisplayString(planError.value), 1)
+                    ]))
+                  : (plan.value)
+                    ? (_openBlock(), _createElementBlock(_Fragment, { key: 2 }, [
+                        _createElementVNode("div", {
+                          class: _normalizeClass(['plan-state', plan.value.canExecute ? 'passed' : 'blocked'])
+                        }, [
+                          _createElementVNode("strong", null, _toDisplayString(plan.value.canExecute ? '安全预演通过' : '计划已被安全门禁拦截'), 1),
+                          _createElementVNode("span", null, " 停止 " + _toDisplayString(plan.value.operationCounts.qbStop) + " 个任务 · 退出 " + _toDisplayString(plan.value.operationCounts.qbRemoveKeepFiles) + " 个任务 · 解除 " + _toDisplayString(plan.value.operationCounts.unlinkFiles) + " 个文件入口 ", 1)
+                        ], 2),
+                        (plan.value.blocks?.length)
+                          ? (_openBlock(), _createElementBlock("ul", _hoisted_44, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.blocks, (issue, index) => {
+                                return (_openBlock(), _createElementBlock("li", {
+                                  key: _unref(issueKey)(issue, index)
+                                }, _toDisplayString(issue.message), 1))
+                              }), 128))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (plan.value.warnings?.length)
+                          ? (_openBlock(), _createElementBlock("ul", _hoisted_45, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.warnings, (issue, index) => {
+                                return (_openBlock(), _createElementBlock("li", {
+                                  key: _unref(issueKey)(issue, index)
+                                }, _toDisplayString(issue.message), 1))
+                              }), 128))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (plan.value.requiresSiteAcknowledgement)
+                          ? (_openBlock(), _createElementBlock("label", _hoisted_46, [
+                              _createElementVNode("input", {
+                                checked: acknowledgeSiteRisk.value,
+                                type: "checkbox",
+                                onChange: _cache[4] || (_cache[4] = $event => (setSiteRisk($event.target.checked)))
+                              }, null, 40, _hoisted_47),
+                              _cache[34] || (_cache[34] = _createElementVNode("span", null, null, -1)),
+                              _cache[35] || (_cache[35] = _createTextVNode(" 我已确认会影响私有站做种，并接受站点规则风险 ", -1))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (planExpired.value)
+                          ? (_openBlock(), _createElementBlock("div", _hoisted_48, [...(_cache[36] || (_cache[36] = [
+                              _createElementVNode("strong", null, "安全预演已过期", -1),
+                              _createElementVNode("span", null, "请关闭后重新生成。", -1)
+                            ]))]))
+                          : _createCommentVNode("", true)
+                      ], 64))
+                    : _createCommentVNode("", true),
+              _createElementVNode("div", _hoisted_49, [
+                _cache[38] || (_cache[38] = _createElementVNode("i", null, "盾", -1)),
+                _createElementVNode("p", null, [
+                  _createElementVNode("strong", null, _toDisplayString(executionEnabled.value ? '执行前还需第二次确认' : '执行引擎未启用'), 1),
+                  _cache[37] || (_cache[37] = _createElementVNode("span", null, "最终执行前复核当前清单，执行器只回读所选资源的 qB、路径和硬链接。", -1))
+                ])
+              ]),
+              (executeResult.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_50, [
+                    _createElementVNode("strong", null, _toDisplayString(currentAction.value?.title) + "已完成", 1),
+                    _createElementVNode("span", null, " 停止 " + _toDisplayString(executeResult.value.qbStopped) + " · 退出 " + _toDisplayString(executeResult.value.qbRemoved) + " · 删除文件入口 " + _toDisplayString(executeResult.value.filesDeleted) + " · 清理索引 " + _toDisplayString(executeResult.value.moviepilotIndexesDeleted), 1),
+                    (executeResult.value.snapshotRefreshPending)
+                      ? (_openBlock(), _createElementBlock("span", _hoisted_51, _toDisplayString(planMode.value === 'delete' ? '已从当前列表移除，请刷新资源清单后继续操作。' : '操作已完成，请刷新资源清单后继续操作。'), 1))
+                      : _createCommentVNode("", true),
+                    _createElementVNode("button", {
+                      type: "button",
+                      onClick: closePlan
+                    }, "完成")
+                  ]))
+                : (finalConfirmation.value)
+                  ? (_openBlock(), _createElementBlock("div", _hoisted_52, [
+                      _cache[39] || (_cache[39] = _createElementVNode("strong", null, "再次确认：系统将立即执行这份计划", -1)),
+                      (executeError.value)
+                        ? (_openBlock(), _createElementBlock("span", _hoisted_53, _toDisplayString(executeError.value), 1))
+                        : _createCommentVNode("", true),
+                      _createElementVNode("div", null, [
+                        _createElementVNode("button", {
+                          type: "button",
+                          disabled: executing.value,
+                          onClick: _cache[5] || (_cache[5] = $event => (finalConfirmation.value = false))
+                        }, "返回", 8, _hoisted_54),
+                        _createElementVNode("button", {
+                          class: _normalizeClass({ danger: planMode.value === 'delete' }),
+                          type: "button",
+                          disabled: executing.value || planExpired.value,
+                          onClick: executePlan
+                        }, _toDisplayString(executing.value ? '正在定向复核…' : `确认${currentAction.value?.title}`), 11, _hoisted_55)
+                      ])
+                    ]))
+                  : (_openBlock(), _createElementBlock("button", {
+                      key: 5,
+                      class: "confirm-button",
+                      type: "button",
+                      disabled: !executionEnabled.value || !plan.value?.canExecute || planExpired.value,
+                      onClick: _cache[6] || (_cache[6] = $event => (finalConfirmation.value = true))
+                    }, " 进入最终确认 ", 8, _hoisted_56))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (gapOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 2,
+            class: "modal-backdrop",
+            onClick: _cache[8] || (_cache[8] = _withModifiers($event => (gapOpen.value = false), ["self"]))
+          }, [
+            _createElementVNode("section", _hoisted_57, [
+              _createElementVNode("header", null, [
+                _cache[40] || (_cache[40] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "学校站实时保护"),
+                  _createElementVNode("h2", null, "H&R 缺口明细")
+                ], -1)),
+                _createElementVNode("button", {
+                  onClick: _cache[7] || (_cache[7] = $event => (gapOpen.value = false))
+                }, "×")
+              ]),
+              (gapLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_58, "正在核对…"))
+                : _createCommentVNode("", true),
+              (gapError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_59, _toDisplayString(gapError.value), 1))
+                : _createCommentVNode("", true),
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(gaps.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.title,
+                  class: "gap-row"
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.linkedResourceTitle || '尚未精确关联媒体'), 1)
+                  ]),
+                  _createElementVNode("b", null, _toDisplayString(item.qbTaskPresent ? 'qB 已存在' : item.coveredByCandidate ? '候选恢复中' : '任务缺失'), 1)
+                ]))
+              }), 128))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (recoveryOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 3,
+            class: "modal-backdrop",
+            onClick: _cache[11] || (_cache[11] = _withModifiers($event => (recoveryOpen.value = false), ["self"]))
+          }, [
+            _createElementVNode("section", _hoisted_60, [
+              _createElementVNode("header", null, [
+                _cache[41] || (_cache[41] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "失败关闭"),
+                  _createElementVNode("h2", null, "恢复未完成清理")
+                ], -1)),
+                _createElementVNode("button", {
+                  onClick: _cache[9] || (_cache[9] = $event => (recoveryOpen.value = false))
+                }, "×")
+              ]),
+              (recoveryLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_61, "正在读取事务…"))
+                : _createCommentVNode("", true),
+              (recoveryError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_62, _toDisplayString(recoveryError.value), 1))
+                : _createCommentVNode("", true),
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(recoveries.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.planId,
+                  class: "recovery-row"
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.mode) + " · " + _toDisplayString(item.phase), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.planId.slice(-10)), 1)
+                  ]),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: $event => (chooseRecovery(item, 'rollback'))
+                  }, "回滚", 8, _hoisted_63),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: $event => (chooseRecovery(item, 'finalize'))
+                  }, "完成原事务", 8, _hoisted_64)
+                ]))
+              }), 128)),
+              (recoveryTarget.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_65, [
+                    _createElementVNode("label", null, [
+                      _cache[42] || (_cache[42] = _createTextVNode("输入确认短语 ", -1)),
+                      _createElementVNode("code", null, _toDisplayString(recoveryExpectedPhrase()), 1)
+                    ]),
+                    _withDirectives(_createElementVNode("input", {
+                      "onUpdate:modelValue": _cache[10] || (_cache[10] = $event => ((recoveryPhrase).value = $event)),
+                      autocomplete: "off"
+                    }, null, 512), [
+                      [_vModelText, recoveryPhrase.value]
+                    ]),
+                    _createElementVNode("button", {
+                      type: "button",
+                      disabled: recovering.value || recoveryPhrase.value !== recoveryExpectedPhrase(),
+                      onClick: runRecovery
+                    }, _toDisplayString(recovering.value ? '处理中…' : '执行恢复'), 9, _hoisted_66)
+                  ]))
+                : _createCommentVNode("", true)
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (settingsOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 4,
+            class: "modal-backdrop",
+            onClick: _withModifiers(closeSettings, ["self"])
+          }, [
+            _createElementVNode("section", _hoisted_67, [
+              _createElementVNode("header", null, [
+                _cache[43] || (_cache[43] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "清理台配置"),
+                  _createElementVNode("h2", { id: "storage-cleanup-settings-title" }, "设置")
+                ], -1)),
+                _createElementVNode("button", {
+                  type: "button",
+                  "aria-label": "关闭设置",
+                  onClick: closeSettings
+                }, "×")
+              ]),
+              _createVNode(Config, {
+                api: props.api,
+                "plugin-id": props.pluginId
+              }, null, 8, ["api", "plugin-id"])
+            ])
+          ]))
+        : _createCommentVNode("", true)
+    ]))
+  ]))
+}
+}
+
+};
+const AppPage = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-463cf7d9"]]);
+
+export { createLatestPlanApi as c, AppPage as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_expose_AppPage-Bsa0sPFe.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_expose_AppPage-Bsa0sPFe.css
@@ -1,0 +1,714 @@
+
+.cleanup-app[data-v-463cf7d9], .action-bar[data-v-463cf7d9], .modal-backdrop[data-v-463cf7d9] {
+  --ink: rgb(var(--v-theme-on-background, 30, 41, 59));
+  --muted: rgba(var(--v-theme-on-background, 30, 41, 59), .58);
+  --line: rgba(var(--v-border-color, 100, 116, 139), .18);
+  --surface: rgb(var(--v-theme-surface, 255, 255, 255));
+  --primary: rgb(var(--v-theme-primary, 59, 130, 246));
+  --primary-soft: rgba(var(--v-theme-primary, 59, 130, 246), .10);
+  --good: #16836b;
+  --warn: #b86b11;
+  --danger: #c44b47;
+}
+.cleanup-app[data-v-463cf7d9] {
+  color: var(--ink);
+  min-width: 980px;
+  padding: 18px 24px 110px;
+}
+button[data-v-463cf7d9], input[data-v-463cf7d9] { font: inherit;
+}
+button[data-v-463cf7d9] { color: inherit;
+}
+.page-header[data-v-463cf7d9] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+.eyebrow[data-v-463cf7d9] { margin: 0 0 4px; color: var(--primary); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase;
+}
+.page-header h1[data-v-463cf7d9] { margin: 0; font-size: 30px; line-height: 1.2;
+}
+.page-header > div > span[data-v-463cf7d9] { color: var(--muted); font-size: 14px;
+}
+.status-card[data-v-463cf7d9] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 220px;
+  padding: 10px 14px;
+  border: 1px solid rgba(22, 131, 107, .22);
+  border-radius: 12px;
+  background: rgba(22, 131, 107, .08);
+}
+.status-card.danger[data-v-463cf7d9] { border-color: rgba(196, 75, 71, .24); background: rgba(196, 75, 71, .08);
+}
+.status-card i[data-v-463cf7d9], .notice i[data-v-463cf7d9], .safety-note i[data-v-463cf7d9] {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  background: rgba(22, 131, 107, .12);
+  color: var(--good);
+  font-style: normal;
+  font-weight: 900;
+}
+.status-card p[data-v-463cf7d9], .notice p[data-v-463cf7d9], .safety-note p[data-v-463cf7d9], .plan-resources p[data-v-463cf7d9], .gap-row p[data-v-463cf7d9], .recovery-row p[data-v-463cf7d9] { display: grid; gap: 2px; margin: 0;
+}
+.status-card strong[data-v-463cf7d9] { font-size: 13px;
+}
+.status-card span[data-v-463cf7d9] { color: var(--muted); font-size: 12px;
+}
+.toolbar[data-v-463cf7d9] {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.search[data-v-463cf7d9] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  height: 46px;
+  padding: 0 15px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+}
+.search span[data-v-463cf7d9] { color: var(--muted); font-size: 21px;
+}
+.search input[data-v-463cf7d9] { width: 100%; border: 0; outline: 0; color: inherit; background: transparent; font-size: 15px;
+}
+.safe-toggle[data-v-463cf7d9] { display: flex; align-items: center; gap: 8px; height: 44px; white-space: nowrap; font-size: 14px; font-weight: 650;
+}
+.safe-toggle input[data-v-463cf7d9], .risk-check input[data-v-463cf7d9] { position: absolute; opacity: 0;
+}
+.safe-toggle > span[data-v-463cf7d9] {
+  width: 38px;
+  height: 22px;
+  padding: 3px;
+  border-radius: 99px;
+  background: rgba(100, 116, 139, .24);
+}
+.safe-toggle > span[data-v-463cf7d9]::after { display: block; width: 16px; height: 16px; border-radius: 50%; background: white; content: ''; transition: .2s;
+}
+.safe-toggle input:checked + span[data-v-463cf7d9] { background: var(--primary);
+}
+.safe-toggle input:checked + span[data-v-463cf7d9]::after { transform: translateX(16px);
+}
+.soft-button[data-v-463cf7d9], .icon-button[data-v-463cf7d9] {
+  height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: var(--surface);
+  cursor: pointer;
+}
+.soft-button[data-v-463cf7d9] { padding: 0 14px;
+}
+.settings-button[data-v-463cf7d9] { border-color: rgba(var(--v-theme-primary, 59, 130, 246), .35); color: var(--primary); font-weight: 750;
+}
+.onboarding-card[data-v-463cf7d9] { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 16px 18px; border: 1px solid rgba(var(--v-theme-primary, 59, 130, 246), .22); border-radius: 12px; background: var(--primary-soft);
+}
+.onboarding-card div[data-v-463cf7d9] { display: grid; gap: 4px;
+}
+.onboarding-card span[data-v-463cf7d9] { color: var(--muted); font-size: 13px; line-height: 1.5;
+}
+.onboarding-card button[data-v-463cf7d9] { flex: 0 0 auto; padding: 9px 14px; border: 1px solid rgba(var(--v-theme-primary, 59, 130, 246), .35); border-radius: 8px; background: transparent; color: var(--primary); cursor: pointer; font-weight: 700;
+}
+.icon-button[data-v-463cf7d9] { width: 42px; font-size: 20px;
+}
+.refresh-feedback[data-v-463cf7d9] {
+  flex: 0 0 100%;
+  margin: -2px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+.notice[data-v-463cf7d9] {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin: 0 0 14px;
+  padding: 12px 16px;
+  border: 1px solid rgba(184, 107, 17, .22);
+  border-radius: 12px;
+  background: rgba(184, 107, 17, .07);
+  text-align: left;
+  cursor: pointer;
+}
+.notice p[data-v-463cf7d9] { flex: 1;
+}
+.notice p span[data-v-463cf7d9] { color: var(--muted); font-size: 13px;
+}
+.notice b[data-v-463cf7d9] { color: var(--warn); font-size: 13px;
+}
+.notice.critical[data-v-463cf7d9] { border-color: rgba(196, 75, 71, .25); background: rgba(196, 75, 71, .08);
+}
+.notice.critical b[data-v-463cf7d9] { color: var(--danger);
+}
+.stale-notice[data-v-463cf7d9] { cursor: default;
+}
+.stale-notice button[data-v-463cf7d9] { flex: 0 0 auto; padding: 8px 12px; border: 1px solid rgba(196, 75, 71, .28); border-radius: 9px; background: var(--surface); color: var(--danger); font-weight: 750; cursor: pointer;
+}
+.filter-panel[data-v-463cf7d9] {
+  display: grid;
+  gap: 0;
+  margin-bottom: 12px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--surface) 88%, var(--primary-soft));
+}
+.filter-row[data-v-463cf7d9] {
+  display: grid;
+  grid-template-columns: 126px minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line);
+}
+.filter-label[data-v-463cf7d9] {
+  padding-top: 8px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+.filter-label small[data-v-463cf7d9] {
+  display: block;
+  margin-top: 3px;
+  font-size: 10px;
+  font-weight: 500;
+  opacity: .8;
+}
+.filter-options[data-v-463cf7d9] { display: flex; flex-wrap: wrap; gap: 7px;
+}
+.filter-option[data-v-463cf7d9] {
+  min-height: 34px;
+  padding: 6px 11px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  transition: .15s ease;
+}
+.filter-option[data-v-463cf7d9]:hover { border-color: var(--primary); color: var(--ink);
+}
+.filter-option.active[data-v-463cf7d9] {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+  color: var(--primary);
+  font-weight: 750;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, .04);
+}
+.filter-option.warning.active[data-v-463cf7d9] { border-color: var(--warn); color: var(--warn); background: rgba(184, 107, 17, .08);
+}
+.filter-option span[data-v-463cf7d9] {
+  display: inline-block;
+  min-width: 20px;
+  margin-left: 5px;
+  padding: 2px 6px;
+  border-radius: 99px;
+  background: rgba(100, 116, 139, .10);
+  font-size: 11px;
+  text-align: center;
+}
+.filter-option.active span[data-v-463cf7d9] { background: color-mix(in srgb, currentColor 14%, transparent);
+}
+.filter-footer[data-v-463cf7d9] { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 42px;
+}
+.active-filter-chips[data-v-463cf7d9] { display: flex; align-items: center; flex-wrap: wrap; gap: 6px;
+}
+.filter-caption[data-v-463cf7d9] { color: var(--muted); font-size: 11px;
+}
+.active-filter-chip[data-v-463cf7d9] {
+  padding: 4px 9px;
+  border: 0;
+  border-radius: 99px;
+  background: var(--primary-soft);
+  color: var(--primary);
+  font-size: 11px;
+  cursor: pointer;
+}
+.filter-result-count[data-v-463cf7d9] { color: var(--muted); font-size: 12px; white-space: nowrap;
+}
+.filter-result-count strong[data-v-463cf7d9] { color: var(--ink); font-size: 17px;
+}
+.filter-result-count button[data-v-463cf7d9] { margin-left: 8px; padding: 0; border: 0; background: transparent; color: var(--primary); font-size: 11px; cursor: pointer;
+}
+.filter-help[data-v-463cf7d9] { margin: 0; padding: 0 0 10px; color: var(--muted); font-size: 10px;
+}
+.resource-card[data-v-463cf7d9] { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--surface);
+}
+.table-head[data-v-463cf7d9], .resource-row[data-v-463cf7d9] {
+  display: grid;
+  grid-template-columns: 42px minmax(270px, 1.55fr) minmax(170px, .85fr) minmax(360px, 1.65fr) minmax(125px, .65fr) minmax(230px, 1fr);
+  align-items: center;
+}
+.table-head[data-v-463cf7d9] { min-height: 50px; padding: 0 16px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 12px; font-weight: 800;
+}
+.resource-row[data-v-463cf7d9] { min-height: 126px; padding: 0 16px; border-bottom: 1px solid var(--line);
+}
+.resource-row[data-v-463cf7d9]:last-child { border-bottom: 0;
+}
+.resource-row.selected[data-v-463cf7d9] { background: var(--primary-soft);
+}
+.select-all[data-v-463cf7d9], .row-check[data-v-463cf7d9] {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid rgba(100, 116, 139, .35);
+  border-radius: 7px;
+  background: transparent;
+  cursor: pointer;
+}
+.row-check.locked[data-v-463cf7d9] { border-color: rgba(184, 107, 17, .25); background: rgba(184, 107, 17, .08); color: var(--warn); font-size: 10px; cursor: not-allowed;
+}
+.resource-title[data-v-463cf7d9], .stack-cell[data-v-463cf7d9] { display: grid; gap: 4px; min-width: 0; padding-right: 16px;
+}
+.resource-title strong[data-v-463cf7d9] { font-size: 17px;
+}
+.resource-title b[data-v-463cf7d9] { overflow: hidden; color: var(--ink); font-size: 13px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; opacity: .78;
+}
+.resource-title span[data-v-463cf7d9], .stack-cell span[data-v-463cf7d9], .impact span[data-v-463cf7d9], .seed-task span[data-v-463cf7d9] { color: var(--muted); font-size: 12px; line-height: 1.45;
+}
+.stack-cell strong[data-v-463cf7d9] { font-size: 14px;
+}
+.stack-cell.library strong[data-v-463cf7d9] { color: var(--good);
+}
+.stack-cell.size strong[data-v-463cf7d9] { font-size: 16px;
+}
+.seed-cell[data-v-463cf7d9] { display: grid; gap: 4px; padding-right: 18px;
+}
+.seed-task[data-v-463cf7d9] {
+  display: grid;
+  grid-template-columns: 62px minmax(72px, auto) minmax(100px, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding-left: 8px;
+  border-left: 2px solid rgba(100, 116, 139, .28);
+}
+.seed-task i[data-v-463cf7d9] { padding: 4px 8px; border-radius: 99px; background: rgba(100, 116, 139, .1); font-size: 11px; font-style: normal; font-weight: 800; text-align: center; white-space: nowrap;
+}
+.seed-task strong[data-v-463cf7d9] { font-size: 13px;
+}
+.seed-task.warning[data-v-463cf7d9] { border-color: rgba(184, 107, 17, .45);
+}
+.seed-task.warning i[data-v-463cf7d9] { color: var(--warn); background: rgba(184, 107, 17, .1);
+}
+.seed-task.protected[data-v-463cf7d9] { border-color: rgba(196, 75, 71, .45);
+}
+.seed-task.protected i[data-v-463cf7d9] { color: var(--danger); background: rgba(196, 75, 71, .1);
+}
+.impact[data-v-463cf7d9] { display: grid; gap: 4px; padding-left: 10px; border-left: 2px solid rgba(22, 131, 107, .35);
+}
+.impact strong[data-v-463cf7d9] { font-size: 13px;
+}
+.impact.danger[data-v-463cf7d9] { border-color: rgba(196, 75, 71, .5);
+}
+.impact.danger strong[data-v-463cf7d9] { color: var(--danger);
+}
+.empty-state[data-v-463cf7d9] { display: grid; place-items: center; min-height: 150px; color: var(--muted);
+}
+.action-bar[data-v-463cf7d9] {
+  position: fixed;
+  z-index: 20;
+  right: 30px;
+  bottom: 22px;
+  left: calc(var(--v-layout-left, 0px) + 30px);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, .14);
+  border-radius: 16px;
+  background: #17243a;
+  color: white;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, .28);
+}
+.selected-count[data-v-463cf7d9] { display: grid; place-items: center; width: 44px; height: 44px; border-radius: 12px; background: #3f70b7; font-size: 18px; font-weight: 900;
+}
+.action-bar > p[data-v-463cf7d9] { display: grid; gap: 1px; min-width: 160px; margin: 0;
+}
+.action-bar > p span[data-v-463cf7d9], .action-level span[data-v-463cf7d9] { color: rgba(255, 255, 255, .64); font-size: 11px;
+}
+.clear-button[data-v-463cf7d9] { border: 0; background: transparent; color: rgba(255, 255, 255, .66); cursor: pointer;
+}
+.action-buttons[data-v-463cf7d9] { display: contents;
+}
+.action-level[data-v-463cf7d9] { display: grid; flex: 1; gap: 3px; padding: 10px 14px; border: 1px solid rgba(255, 255, 255, .17); border-radius: 11px; background: rgba(255, 255, 255, .06); color: white; text-align: left; cursor: pointer;
+}
+.action-level.delete[data-v-463cf7d9] { border-color: rgba(255, 142, 136, .32); background: rgba(196, 75, 71, .28);
+}
+.action-level[data-v-463cf7d9]:disabled { cursor: not-allowed; opacity: .45;
+}
+.modal-backdrop[data-v-463cf7d9] {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 28px 28px 28px calc(28px + 260px);
+  background: rgba(15, 23, 42, .55);
+  backdrop-filter: blur(6px);
+}
+.modal[data-v-463cf7d9] {
+  overflow: auto;
+  width: min(760px, 90vw);
+  max-height: 90vh;
+  padding: 24px;
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, .3);
+}
+.modal > header[data-v-463cf7d9] { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 16px;
+}
+.modal > header span[data-v-463cf7d9] { color: var(--primary); font-size: 11px; font-weight: 850; letter-spacing: .08em;
+}
+.modal h2[data-v-463cf7d9] { margin: 3px 0 0; font-size: 24px;
+}
+.modal > header button[data-v-463cf7d9] { width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 10px; background: transparent; font-size: 22px; cursor: pointer;
+}
+.mode-summary[data-v-463cf7d9], .plan-state[data-v-463cf7d9], .safety-note[data-v-463cf7d9] { display: grid; gap: 4px; margin-bottom: 12px; padding: 13px 15px; border-radius: 12px; background: var(--primary-soft);
+}
+.mode-summary span[data-v-463cf7d9], .plan-state span[data-v-463cf7d9], .safety-note span[data-v-463cf7d9] { color: var(--muted); font-size: 12px;
+}
+.mode-summary.delete[data-v-463cf7d9] { background: rgba(196, 75, 71, .08);
+}
+.plan-resources[data-v-463cf7d9] { max-height: 170px; overflow: auto; margin-bottom: 12px; border: 1px solid var(--line); border-radius: 12px;
+}
+.plan-resources > div[data-v-463cf7d9] { display: flex; justify-content: space-between; align-items: center; padding: 10px 13px; border-bottom: 1px solid var(--line);
+}
+.plan-resources > div[data-v-463cf7d9]:last-child { border-bottom: 0;
+}
+.plan-resources span[data-v-463cf7d9] { color: var(--muted); font-size: 11px;
+}
+.plan-state.passed[data-v-463cf7d9] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.plan-state.blocked[data-v-463cf7d9], .issues.blocked[data-v-463cf7d9] { color: var(--danger); background: rgba(196, 75, 71, .08);
+}
+.issues[data-v-463cf7d9] { display: grid; gap: 6px; margin: 0 0 12px; padding: 12px 16px 12px 34px; border-radius: 12px; font-size: 13px;
+}
+.issues.warning[data-v-463cf7d9] { color: var(--warn); background: rgba(184, 107, 17, .08);
+}
+.risk-check[data-v-463cf7d9] { position: relative; display: flex; align-items: center; gap: 9px; margin: 12px 0; font-size: 13px; font-weight: 700;
+}
+.risk-check > span[data-v-463cf7d9] { width: 20px; height: 20px; border: 1px solid rgba(100, 116, 139, .35); border-radius: 6px;
+}
+.risk-check input:checked + span[data-v-463cf7d9] { border-color: var(--primary); background: var(--primary); box-shadow: inset 0 0 0 4px var(--surface);
+}
+.safety-note[data-v-463cf7d9] { display: flex; align-items: center; background: rgba(100, 116, 139, .08);
+}
+.safety-note p[data-v-463cf7d9] { flex: 1;
+}
+.confirm-button[data-v-463cf7d9], .execution-result button[data-v-463cf7d9] {
+  width: 100%;
+  min-height: 46px;
+  border: 0;
+  border-radius: 11px;
+  background: var(--primary);
+  color: white;
+  font-weight: 800;
+  cursor: pointer;
+}
+.confirm-button[data-v-463cf7d9]:disabled { background: rgba(100, 116, 139, .22); color: var(--muted); cursor: not-allowed;
+}
+.final-confirmation[data-v-463cf7d9], .execution-result[data-v-463cf7d9] { display: grid; gap: 10px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.final-confirmation > div[data-v-463cf7d9] { display: flex; gap: 8px;
+}
+.final-confirmation button[data-v-463cf7d9] { flex: 1; min-height: 42px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); cursor: pointer;
+}
+.final-confirmation button.danger[data-v-463cf7d9] { border-color: transparent; background: var(--danger); color: white;
+}
+.error-text[data-v-463cf7d9] { color: var(--danger); font-size: 13px;
+}
+.execution-result[data-v-463cf7d9] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.compact-modal[data-v-463cf7d9] { width: min(650px, 90vw);
+}
+.settings-modal[data-v-463cf7d9] { width: min(980px, 94vw); max-height: calc(100dvh - 56px); padding: 20px;
+}
+.settings-modal[data-v-463cf7d9] .config-page { max-width: none; padding: 0;
+}
+.gap-row[data-v-463cf7d9], .recovery-row[data-v-463cf7d9] { display: flex; align-items: center; gap: 8px; padding: 11px 4px; border-bottom: 1px solid var(--line);
+}
+.gap-row p[data-v-463cf7d9], .recovery-row p[data-v-463cf7d9] { flex: 1;
+}
+.gap-row span[data-v-463cf7d9], .recovery-row span[data-v-463cf7d9] { color: var(--muted); font-size: 11px;
+}
+.gap-row b[data-v-463cf7d9] { font-size: 12px; color: var(--warn);
+}
+.recovery-row button[data-v-463cf7d9], .recovery-confirm button[data-v-463cf7d9] { padding: 7px 10px; border: 1px solid var(--line); border-radius: 8px; background: transparent; cursor: pointer;
+}
+.recovery-confirm[data-v-463cf7d9] { display: grid; gap: 8px; margin-top: 14px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.recovery-confirm input[data-v-463cf7d9] { height: 40px; padding: 0 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); color: inherit;
+}
+@media (max-width: 1250px) {
+.table-head[data-v-463cf7d9], .resource-row[data-v-463cf7d9] {
+    grid-template-columns: 38px minmax(240px, 1.3fr) minmax(150px, .7fr) minmax(310px, 1.35fr) 120px minmax(200px, .9fr);
+}
+}
+@media (max-width: 760px) {
+.modal-backdrop[data-v-463cf7d9] { padding: 16px;
+}
+.cleanup-app[data-v-463cf7d9] {
+    min-width: 0;
+    overflow-x: clip;
+    padding: 14px 12px 190px;
+}
+.page-header[data-v-463cf7d9] {
+    display: grid;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+.eyebrow[data-v-463cf7d9] { font-size: 10px;
+}
+.page-header h1[data-v-463cf7d9] { font-size: 27px;
+}
+.page-header > div > span[data-v-463cf7d9] {
+    display: block;
+    margin-top: 3px;
+    font-size: 12px;
+    line-height: 1.5;
+}
+.status-card[data-v-463cf7d9] {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+}
+.toolbar[data-v-463cf7d9] {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+    gap: 8px;
+}
+.search[data-v-463cf7d9] {
+    grid-column: 1 / -1;
+    height: 44px;
+    box-sizing: border-box;
+}
+.safe-toggle[data-v-463cf7d9] {
+    min-width: 0;
+    font-size: 12px;
+}
+.soft-button[data-v-463cf7d9] { padding: 0 10px; font-size: 12px;
+}
+.icon-button[data-v-463cf7d9] { width: 40px;
+}
+.notice[data-v-463cf7d9] {
+    align-items: flex-start;
+    padding: 11px 12px;
+}
+.notice p strong[data-v-463cf7d9] { font-size: 14px;
+}
+.notice p span[data-v-463cf7d9] { font-size: 11px;
+}
+.notice b[data-v-463cf7d9] { display: none;
+}
+.filter-panel[data-v-463cf7d9] {
+    width: calc(100vw - 24px);
+    padding: 0 10px;
+}
+.filter-row[data-v-463cf7d9] { display: block; padding: 10px 0;
+}
+.filter-label[data-v-463cf7d9] { padding: 0 0 7px;
+}
+.filter-options[data-v-463cf7d9] { flex-wrap: nowrap; overflow-x: auto; padding-bottom: 2px; scrollbar-width: none;
+}
+.filter-options[data-v-463cf7d9]::-webkit-scrollbar { display: none;
+}
+.filter-option[data-v-463cf7d9] { flex: 0 0 auto; white-space: nowrap;
+}
+.filter-footer[data-v-463cf7d9] { align-items: flex-start; flex-direction: column; gap: 6px; padding: 7px 0;
+}
+.filter-result-count[data-v-463cf7d9] { width: 100%;
+}
+.filter-help[data-v-463cf7d9] { line-height: 1.45;
+}
+.resource-card[data-v-463cf7d9] {
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+}
+.table-head[data-v-463cf7d9] { display: none;
+}
+.resource-row[data-v-463cf7d9] {
+    grid-template-areas:
+      "check title"
+      ". library"
+      ". seed"
+      ". size"
+      ". impact";
+    grid-template-columns: 34px minmax(0, 1fr);
+    gap: 12px 10px;
+    min-height: 0;
+    margin-bottom: 10px;
+    padding: 15px 13px;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: var(--surface);
+    box-shadow: 0 5px 18px rgba(15, 23, 42, .04);
+}
+.resource-row[data-v-463cf7d9]:last-child { border-bottom: 1px solid var(--line);
+}
+.row-check[data-v-463cf7d9] {
+    grid-area: check;
+    align-self: start;
+    width: 26px;
+    height: 26px;
+}
+.resource-title[data-v-463cf7d9] {
+    grid-area: title;
+    padding-right: 0;
+}
+.resource-title strong[data-v-463cf7d9] { font-size: 16px;
+}
+.resource-title b[data-v-463cf7d9] { font-size: 12px;
+}
+.resource-title span[data-v-463cf7d9] { white-space: normal;
+}
+.stack-cell.library[data-v-463cf7d9] { grid-area: library;
+}
+.seed-cell[data-v-463cf7d9] { grid-area: seed;
+}
+.stack-cell.size[data-v-463cf7d9] { grid-area: size;
+}
+.impact[data-v-463cf7d9] { grid-area: impact;
+}
+.stack-cell[data-v-463cf7d9], .seed-cell[data-v-463cf7d9], .impact[data-v-463cf7d9] {
+    min-width: 0;
+    padding: 10px 0 0;
+    border-top: 1px solid var(--line);
+}
+.stack-cell[data-v-463cf7d9]::before, .seed-cell[data-v-463cf7d9]::before, .impact[data-v-463cf7d9]::before {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--muted);
+    content: attr(data-label);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: .06em;
+}
+.impact[data-v-463cf7d9] {
+    padding-left: 0;
+    border-left: 0;
+}
+.impact.danger[data-v-463cf7d9] { border-left: 0;
+}
+.seed-task[data-v-463cf7d9] {
+    grid-template-columns: 58px minmax(58px, auto) minmax(0, 1fr);
+    gap: 6px;
+    padding-left: 6px;
+}
+.seed-task i[data-v-463cf7d9] { padding: 4px 6px; font-size: 10px;
+}
+.seed-task strong[data-v-463cf7d9] { font-size: 12px;
+}
+.seed-task span[data-v-463cf7d9] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.action-bar[data-v-463cf7d9] {
+    z-index: 2600;
+    right: 10px;
+    bottom: calc(78px + env(safe-area-inset-bottom, 0px));
+    left: 10px;
+    display: grid;
+    grid-template-columns: 38px minmax(0, 1fr) auto;
+    gap: 8px 10px;
+    padding: 10px;
+    border-radius: 15px;
+}
+.selected-count[data-v-463cf7d9] {
+    width: 38px;
+    height: 38px;
+    border-radius: 10px;
+    font-size: 16px;
+}
+.action-bar > p[data-v-463cf7d9] {
+    min-width: 0;
+}
+.action-bar > p strong[data-v-463cf7d9] {
+    overflow: hidden;
+    font-size: 13px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.action-bar > p span[data-v-463cf7d9] { font-size: 10px;
+}
+.clear-button[data-v-463cf7d9] {
+    padding: 0 4px;
+    font-size: 12px;
+}
+.action-buttons[data-v-463cf7d9] {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 7px;
+}
+.action-level[data-v-463cf7d9] {
+    display: block;
+    min-width: 0;
+    min-height: 42px;
+    padding: 9px 5px;
+    text-align: center;
+}
+.action-level strong[data-v-463cf7d9] {
+    display: block;
+    font-size: 13px;
+    white-space: nowrap;
+}
+.action-level span[data-v-463cf7d9] { display: none;
+}
+.modal-backdrop[data-v-463cf7d9] {
+    z-index: 3000;
+    padding:
+      max(12px, env(safe-area-inset-top, 0px))
+      12px
+      max(12px, env(safe-area-inset-bottom, 0px));
+}
+.modal[data-v-463cf7d9], .compact-modal[data-v-463cf7d9] {
+    width: calc(100vw - 24px);
+    max-height: calc(100dvh - 24px);
+    box-sizing: border-box;
+    padding: 16px;
+    border-radius: 16px;
+}
+.modal h2[data-v-463cf7d9] { font-size: 21px;
+}
+.modal > header[data-v-463cf7d9] { margin-bottom: 12px;
+}
+.mode-summary[data-v-463cf7d9], .plan-state[data-v-463cf7d9], .safety-note[data-v-463cf7d9] { padding: 11px 12px;
+}
+.plan-resources[data-v-463cf7d9] { max-height: 120px;
+}
+.plan-resources > div[data-v-463cf7d9] { gap: 8px; padding: 9px 10px;
+}
+.plan-resources p[data-v-463cf7d9] { min-width: 0;
+}
+.plan-resources p span[data-v-463cf7d9] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.issues[data-v-463cf7d9] { padding: 10px 12px 10px 28px; font-size: 12px;
+}
+.final-confirmation > div[data-v-463cf7d9] { display: grid; grid-template-columns: 1fr 1fr;
+}
+.gap-row[data-v-463cf7d9], .recovery-row[data-v-463cf7d9] {
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+.recovery-row p[data-v-463cf7d9] { flex-basis: 100%;
+}
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_expose_Config-D0d0drVp.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_expose_Config-D0d0drVp.css
@@ -1,0 +1,93 @@
+
+.config-page[data-v-b936500f] { display: grid; gap: 18px; padding: 22px; max-width: 980px;
+}
+header[data-v-b936500f] { display: grid; gap: 6px;
+}
+h2[data-v-b936500f] { margin: 0;
+}
+p[data-v-b936500f] { margin: 0; opacity: .72; line-height: 1.6;
+}
+.discovery-card[data-v-b936500f] { display: grid; gap: 12px; padding: 14px 16px; border: 1px solid rgba(var(--v-theme-primary, 59, 130, 246), .24); border-radius: 10px; background: rgba(var(--v-theme-primary, 59, 130, 246), .06);
+}
+.discovery-heading[data-v-b936500f] { display: flex; align-items: center; justify-content: space-between; gap: 16px;
+}
+.discovery-heading > div[data-v-b936500f] { display: grid; gap: 4px;
+}
+.discovery-heading span[data-v-b936500f] { opacity: .72; line-height: 1.5;
+}
+.discovery-actions[data-v-b936500f] { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end;
+}
+.discovery-heading button[data-v-b936500f], .apply-discovery[data-v-b936500f] { padding: 9px 14px; border: 1px solid rgba(var(--v-theme-primary, 59, 130, 246), .35); border-radius: 8px; cursor: pointer; background: transparent; color: inherit; font: inherit; font-weight: 700;
+}
+.discovery-actions .secondary[data-v-b936500f] { opacity: .78;
+}
+.discovery-heading button[data-v-b936500f]:disabled, .apply-discovery[data-v-b936500f]:disabled { opacity: .5; cursor: default;
+}
+.discovery-results[data-v-b936500f] { display: grid; gap: 7px;
+}
+.discovery-row[data-v-b936500f] { display: flex; justify-content: space-between; gap: 12px; padding: 7px 0; border-top: 1px solid rgba(var(--v-border-color), .16);
+}
+.discovery-row > div[data-v-b936500f] { display: grid; gap: 4px; min-width: 0;
+}
+.discovery-row small[data-v-b936500f] { opacity: .68; overflow-wrap: anywhere; line-height: 1.45;
+}
+.discovery-row b[data-v-b936500f] { font-size: .9em;
+}
+.discovery-row .found[data-v-b936500f] { color: #087443;
+}
+.discovery-row .optional[data-v-b936500f] { color: #6b7280;
+}
+.discovery-row .missing[data-v-b936500f] { color: #b86b11;
+}
+.apply-discovery[data-v-b936500f] { justify-self: start; background: rgb(var(--v-theme-primary)); color: rgb(var(--v-theme-on-primary));
+}
+.discovery-error[data-v-b936500f] { display: flex; align-items: center; justify-content: space-between; gap: 12px; color: #b42318; line-height: 1.5;
+}
+.discovery-error button[data-v-b936500f] { border: 0; padding: 0; cursor: pointer; background: transparent; color: inherit; font: inherit; font-weight: 700; text-decoration: underline;
+}
+.advanced-settings[data-v-b936500f] { display: grid; gap: 12px; padding: 2px 0;
+}
+.advanced-settings summary[data-v-b936500f] { cursor: pointer; font-weight: 700;
+}
+.advanced-settings > p[data-v-b936500f] { padding-left: 2px;
+}
+.form-grid[data-v-b936500f] { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px;
+}
+label[data-v-b936500f] { display: grid; gap: 7px; font-weight: 600;
+}
+input[data-v-b936500f], textarea[data-v-b936500f] { width: 100%; box-sizing: border-box; padding: 9px 11px; border: 1px solid rgba(var(--v-border-color), .35); border-radius: 8px; background: transparent; color: inherit; font: inherit; font-weight: 400;
+}
+textarea[data-v-b936500f] { resize: vertical; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .9em;
+}
+.wide[data-v-b936500f] { grid-column: 1 / -1;
+}
+.notice[data-v-b936500f], .error[data-v-b936500f], .success[data-v-b936500f], .probe[data-v-b936500f] { display: grid; gap: 5px; padding: 12px 14px; border-radius: 9px;
+}
+.notice[data-v-b936500f] { background: rgba(128, 128, 128, .12);
+}
+.error[data-v-b936500f] { color: #b42318; background: rgba(180, 35, 24, .1);
+}
+.success[data-v-b936500f] { color: #087443; background: rgba(8, 116, 67, .1);
+}
+.probe[data-v-b936500f] { background: rgba(32, 106, 255, .08);
+}
+.probe-details[data-v-b936500f] { display: grid; gap: 5px; margin-top: 4px;
+}
+.probe-details summary[data-v-b936500f] { cursor: pointer; font-weight: 700;
+}
+.save[data-v-b936500f] { justify-self: start; padding: 10px 18px; border: 0; border-radius: 8px; cursor: pointer; background: rgb(var(--v-theme-primary)); color: rgb(var(--v-theme-on-primary));
+}
+.save[data-v-b936500f]:disabled { opacity: .5; cursor: default;
+}
+@media (max-width: 760px) {
+.config-page[data-v-b936500f] { padding: 16px;
+}
+.form-grid[data-v-b936500f] { grid-template-columns: 1fr;
+}
+.wide[data-v-b936500f] { grid-column: auto;
+}
+.discovery-heading[data-v-b936500f] { align-items: stretch; flex-direction: column;
+}
+.discovery-actions[data-v-b936500f] { justify-content: flex-start;
+}
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_expose_Config-D6hmMvYZ.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_expose_Config-D6hmMvYZ.js
@@ -1,0 +1,426 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+
+const _export_sfc = (sfc, props) => {
+  const target = sfc.__vccOpts || sfc;
+  for (const [key, val] of props) {
+    target[key] = val;
+  }
+  return target;
+};
+
+const {createElementVNode:_createElementVNode,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,toDisplayString:_toDisplayString,renderList:_renderList,Fragment:_Fragment,normalizeClass:_normalizeClass,vModelText:_vModelText,withDirectives:_withDirectives,createTextVNode:_createTextVNode} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "config-page" };
+const _hoisted_2 = {
+  key: 0,
+  class: "notice"
+};
+const _hoisted_3 = {
+  key: 1,
+  class: "discovery-card"
+};
+const _hoisted_4 = { class: "discovery-heading" };
+const _hoisted_5 = { class: "discovery-actions" };
+const _hoisted_6 = ["disabled"];
+const _hoisted_7 = ["disabled"];
+const _hoisted_8 = {
+  key: 0,
+  class: "discovery-results"
+};
+const _hoisted_9 = { key: 0 };
+const _hoisted_10 = ["disabled"];
+const _hoisted_11 = {
+  key: 1,
+  class: "discovery-error"
+};
+const _hoisted_12 = ["disabled"];
+const _hoisted_13 = ["open"];
+const _hoisted_14 = { class: "form-grid" };
+const _hoisted_15 = { class: "wide" };
+const _hoisted_16 = { class: "wide" };
+const _hoisted_17 = ["disabled"];
+const _hoisted_18 = {
+  key: 3,
+  class: "error"
+};
+const _hoisted_19 = {
+  key: 4,
+  class: "success"
+};
+const _hoisted_20 = {
+  key: 5,
+  class: "probe"
+};
+const _hoisted_21 = { key: 0 };
+const _hoisted_22 = { key: 1 };
+const _hoisted_23 = {
+  key: 2,
+  class: "probe-details"
+};
+
+const {computed,onMounted,reactive,ref} = await importShared('vue');
+
+
+
+const _sfc_main = {
+  __name: 'Config',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+const props = __props;
+
+const form = reactive({
+  version: 1,
+  qb_url: '',
+  media_index_db: '',
+  moviepilot_db: '',
+  qb_backup: '',
+  execution_backup: '',
+  allowed_roots_text: '',
+  quarantine_roots_text: '',
+});
+const loading = ref(true);
+const saving = ref(false);
+const error = ref('');
+const message = ref('');
+const probe = ref(null);
+const discovery = ref(null);
+const discovering = ref(false);
+const discoveryError = ref('');
+const advancedOpen = ref(false);
+
+const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`);
+
+function unwrap(response) {
+  if (response && Object.prototype.hasOwnProperty.call(response, 'data')) {
+    return response.data
+  }
+  return response
+}
+
+function applyConfig(config) {
+  Object.assign(form, {
+    ...config,
+    media_index_db: config.media_index_db || config.jellyfin_db || '',
+    allowed_roots_text: (config.allowed_roots || []).join('\n'),
+    quarantine_roots_text: Object.entries(config.quarantine_roots || {})
+      .map(([volume, target]) => `${volume}=${target}`)
+      .join('\n'),
+  });
+}
+
+function parseLines(value) {
+  return String(value || '')
+    .split('\n')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+function buildConfig() {
+  const quarantine_roots = {};
+  for (const line of parseLines(form.quarantine_roots_text)) {
+    const separator = line.indexOf('=');
+    if (separator <= 0 || separator === line.length - 1) {
+      throw new Error('隔离目录格式应为：卷根目录=隔离目录。')
+    }
+    quarantine_roots[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+  }
+  return {
+    version: 1,
+    qb_url: form.qb_url,
+    media_index_db: form.media_index_db,
+    moviepilot_db: form.moviepilot_db,
+    qb_backup: form.qb_backup,
+    execution_backup: form.execution_backup,
+    allowed_roots: parseLines(form.allowed_roots_text),
+    quarantine_roots,
+  }
+}
+
+async function load() {
+  loading.value = true;
+  error.value = '';
+  try {
+    if (!props.api.get) throw new Error('MoviePilot 没有提供插件 API。')
+    const payload = unwrap(await props.api.get(`${pluginBase.value}/config`));
+    if (!payload?.ok || !payload.config) throw new Error(payload?.error?.message || '无法读取清理台配置。')
+    applyConfig(payload.config);
+    probe.value = payload.probe || null;
+    if (!probe.value?.ok) void discover();
+  } catch (err) {
+    error.value = err?.message || '无法读取清理台配置。';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function discover() {
+  if (discovering.value) return
+  discovering.value = true;
+  discoveryError.value = '';
+  try {
+    if (!props.api.get) throw new Error('MoviePilot 没有提供插件 API。')
+    const payload = unwrap(await props.api.get(`${pluginBase.value}/discover`));
+    if (!payload?.ok || !payload.config) {
+      throw new Error(payload?.error?.message || '自动发现失败。')
+    }
+    discovery.value = payload;
+    if ((payload.checks || []).some(item => item.ambiguous || (!item.found && !item.optional && !item.willCreate))) {
+      advancedOpen.value = true;
+    }
+  } catch (err) {
+    discoveryError.value = err?.message || '自动发现失败。';
+    advancedOpen.value = true;
+  } finally {
+    discovering.value = false;
+  }
+}
+
+async function applyDiscovery() {
+  if (!discovery.value?.config || !discovery.value?.ready || saving.value) return
+  saving.value = true;
+  error.value = '';
+  message.value = '';
+  try {
+    const payload = unwrap(await props.api.post(`${pluginBase.value}/config`, {
+      config: discovery.value.config,
+    }));
+    if (!payload?.ok || !payload.config) {
+      throw new Error(payload?.error?.message || '自动配置保存失败。')
+    }
+    applyConfig(payload.config);
+    probe.value = payload.probe || null;
+    message.value = probe.value?.ok
+      ? '自动识别完成，路径探测通过；请刷新资源清单。'
+      : '已应用自动识别结果，但仍有项目未就绪；清理操作保持锁定。';
+  } catch (err) {
+    const payload = err?.response?.data || err?.data;
+    probe.value = payload?.probe || probe.value;
+    error.value = err?.message || payload?.error?.message || '自动配置保存失败。';
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function save() {
+  saving.value = true;
+  error.value = '';
+  message.value = '';
+  try {
+    const config = buildConfig();
+    const payload = unwrap(await props.api.post(`${pluginBase.value}/config`, { config }));
+    if (!payload?.ok || !payload.config) throw new Error(payload?.error?.message || '配置保存失败。')
+    applyConfig(payload.config);
+    probe.value = payload.probe || null;
+    message.value = probe.value?.ok
+      ? '配置已保存，路径探测通过；请刷新资源清单。'
+      : '配置已保存，但仍有路径未就绪；清理操作保持锁定。';
+  } catch (err) {
+    const payload = err?.response?.data || err?.data;
+    probe.value = payload?.probe || probe.value;
+    error.value = err?.message || payload?.error?.message || '配置保存失败。';
+  } finally {
+    saving.value = false;
+  }
+}
+
+onMounted(load);
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("section", _hoisted_1, [
+    _cache[21] || (_cache[21] = _createElementVNode("header", null, [
+      _createElementVNode("h2", null, "存储清理设置"),
+      _createElementVNode("p", null, "一般无需填写，先点“自动识别”；识别失败再用手动配置。")
+    ], -1)),
+    (loading.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_2, "正在读取配置…"))
+      : (_openBlock(), _createElementBlock("section", _hoisted_3, [
+          _createElementVNode("div", _hoisted_4, [
+            _cache[10] || (_cache[10] = _createElementVNode("div", null, [
+              _createElementVNode("strong", null, "自动识别"),
+              _createElementVNode("span", null, "读取 MoviePilot、qB 和媒体目录；媒体库索引可留空。候选不唯一时不会自动猜。")
+            ], -1)),
+            _createElementVNode("div", _hoisted_5, [
+              _createElementVNode("button", {
+                type: "button",
+                disabled: discovering.value || saving.value,
+                onClick: discover
+              }, _toDisplayString(discovering.value ? '识别中…' : '自动识别'), 9, _hoisted_6),
+              (!advancedOpen.value)
+                ? (_openBlock(), _createElementBlock("button", {
+                    key: 0,
+                    class: "secondary",
+                    type: "button",
+                    disabled: saving.value,
+                    onClick: _cache[0] || (_cache[0] = $event => (advancedOpen.value = true))
+                  }, " 手动配置 ", 8, _hoisted_7))
+                : _createCommentVNode("", true)
+            ])
+          ]),
+          (discovery.value)
+            ? (_openBlock(), _createElementBlock("div", _hoisted_8, [
+                (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(discovery.value.checks || [], (item) => {
+                  return (_openBlock(), _createElementBlock("div", {
+                    key: item.key,
+                    class: "discovery-row"
+                  }, [
+                    _createElementVNode("div", null, [
+                      _createElementVNode("span", null, _toDisplayString(item.label), 1),
+                      (item.ambiguous)
+                        ? (_openBlock(), _createElementBlock("small", _hoisted_9, "候选：" + _toDisplayString((item.candidates || []).join('；')), 1))
+                        : _createCommentVNode("", true)
+                    ]),
+                    _createElementVNode("b", {
+                      class: _normalizeClass(item.ambiguous ? 'missing' : item.found || item.willCreate ? 'found' : item.optional ? 'optional' : 'missing')
+                    }, _toDisplayString(item.ambiguous ? '发现多个候选，需手动选择' : item.found ? '已找到' : item.willCreate ? '将自动创建' : item.optional ? '未配置（可选）' : '需管理员处理'), 3)
+                  ]))
+                }), 128)),
+                _createElementVNode("button", {
+                  class: "apply-discovery",
+                  type: "button",
+                  disabled: saving.value || !discovery.value.ready,
+                  onClick: applyDiscovery
+                }, _toDisplayString(saving.value ? '应用中…' : '应用识别结果并验证'), 9, _hoisted_10)
+              ]))
+            : _createCommentVNode("", true),
+          (discoveryError.value)
+            ? (_openBlock(), _createElementBlock("div", _hoisted_11, [
+                _createElementVNode("span", null, _toDisplayString(discoveryError.value) + " 请改用手动配置。", 1),
+                _createElementVNode("button", {
+                  type: "button",
+                  disabled: saving.value,
+                  onClick: _cache[1] || (_cache[1] = $event => (advancedOpen.value = true))
+                }, "打开手动配置", 8, _hoisted_12)
+              ]))
+            : _createCommentVNode("", true)
+        ])),
+    (!loading.value)
+      ? (_openBlock(), _createElementBlock("details", {
+          key: 2,
+          class: "advanced-settings",
+          open: advancedOpen.value,
+          onToggle: _cache[9] || (_cache[9] = $event => (advancedOpen.value = $event.target.open))
+        }, [
+          _cache[18] || (_cache[18] = _createElementVNode("summary", null, "手动配置（自动识别失败时使用）", -1)),
+          _cache[19] || (_cache[19] = _createElementVNode("p", null, "从 NAS 文件管理器复制路径；必须是清理台服务能访问到的路径。媒体库索引可以留空。", -1)),
+          _createElementVNode("div", _hoisted_14, [
+            _createElementVNode("label", null, [
+              _cache[11] || (_cache[11] = _createTextVNode("qBittorrent 地址", -1)),
+              _withDirectives(_createElementVNode("input", {
+                "onUpdate:modelValue": _cache[2] || (_cache[2] = $event => ((form.qb_url) = $event)),
+                autocomplete: "off",
+                placeholder: "例：http://127.0.0.1:8080"
+              }, null, 512), [
+                [_vModelText, form.qb_url]
+              ])
+            ]),
+            _createElementVNode("label", null, [
+              _cache[12] || (_cache[12] = _createTextVNode("MoviePilot 数据库", -1)),
+              _withDirectives(_createElementVNode("input", {
+                "onUpdate:modelValue": _cache[3] || (_cache[3] = $event => ((form.moviepilot_db) = $event)),
+                autocomplete: "off",
+                placeholder: "MoviePilot 容器内 user.db 路径"
+              }, null, 512), [
+                [_vModelText, form.moviepilot_db]
+              ])
+            ]),
+            _createElementVNode("label", null, [
+              _cache[13] || (_cache[13] = _createTextVNode("媒体库索引（可选）", -1)),
+              _withDirectives(_createElementVNode("input", {
+                "onUpdate:modelValue": _cache[4] || (_cache[4] = $event => ((form.media_index_db) = $event)),
+                autocomplete: "off",
+                placeholder: "Jellyfin / Emby 数据库路径，可留空"
+              }, null, 512), [
+                [_vModelText, form.media_index_db]
+              ])
+            ]),
+            _createElementVNode("label", null, [
+              _cache[14] || (_cache[14] = _createTextVNode("qB 种子备份目录", -1)),
+              _withDirectives(_createElementVNode("input", {
+                "onUpdate:modelValue": _cache[5] || (_cache[5] = $event => ((form.qb_backup) = $event)),
+                autocomplete: "off",
+                placeholder: "qB 备份目录"
+              }, null, 512), [
+                [_vModelText, form.qb_backup]
+              ])
+            ]),
+            _createElementVNode("label", null, [
+              _cache[15] || (_cache[15] = _createTextVNode("清理事务备份目录", -1)),
+              _withDirectives(_createElementVNode("input", {
+                "onUpdate:modelValue": _cache[6] || (_cache[6] = $event => ((form.execution_backup) = $event)),
+                autocomplete: "off",
+                placeholder: "清理台可写的备份目录"
+              }, null, 512), [
+                [_vModelText, form.execution_backup]
+              ])
+            ]),
+            _createElementVNode("label", _hoisted_15, [
+              _cache[16] || (_cache[16] = _createTextVNode("允许扫描/清理的根目录（每行一个）", -1)),
+              _withDirectives(_createElementVNode("textarea", {
+                "onUpdate:modelValue": _cache[7] || (_cache[7] = $event => ((form.allowed_roots_text) = $event)),
+                rows: "5",
+                placeholder: "下载完成目录、电影目录、电视剧目录"
+              }, null, 512), [
+                [_vModelText, form.allowed_roots_text]
+              ])
+            ]),
+            _createElementVNode("label", _hoisted_16, [
+              _cache[17] || (_cache[17] = _createTextVNode("隔离目录映射（每行：卷根目录=隔离目录）", -1)),
+              _withDirectives(_createElementVNode("textarea", {
+                "onUpdate:modelValue": _cache[8] || (_cache[8] = $event => ((form.quarantine_roots_text) = $event)),
+                rows: "3",
+                placeholder: "例如：/mnt/data=/mnt/data/.storage-cleanup-quarantine"
+              }, null, 512), [
+                [_vModelText, form.quarantine_roots_text]
+              ])
+            ])
+          ]),
+          _createElementVNode("button", {
+            class: "save",
+            disabled: loading.value || saving.value,
+            onClick: save
+          }, _toDisplayString(saving.value ? '保存中…' : '保存手动配置并探测'), 9, _hoisted_17)
+        ], 40, _hoisted_13))
+      : _createCommentVNode("", true),
+    (error.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_18, _toDisplayString(error.value), 1))
+      : _createCommentVNode("", true),
+    (message.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_19, _toDisplayString(message.value), 1))
+      : _createCommentVNode("", true),
+    (probe.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_20, [
+          _createElementVNode("strong", null, _toDisplayString(probe.value.ok ? '只读探测通过' : '只读探测未通过'), 1),
+          (probe.value.missing?.length)
+            ? (_openBlock(), _createElementBlock("span", _hoisted_21, "还有 " + _toDisplayString(probe.value.missing.length) + " 项路径未找到，请展开管理员配置查看。", 1))
+            : _createCommentVNode("", true),
+          (probe.value.problems?.length)
+            ? (_openBlock(), _createElementBlock("span", _hoisted_22, "有 " + _toDisplayString(probe.value.problems.length) + " 项安全校验未通过，请展开管理员配置查看。", 1))
+            : _createCommentVNode("", true),
+          (probe.value.missing?.length || probe.value.problems?.length)
+            ? (_openBlock(), _createElementBlock("details", _hoisted_23, [
+                _cache[20] || (_cache[20] = _createElementVNode("summary", null, "查看管理员诊断", -1)),
+                (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(probe.value.missing || [], (item) => {
+                  return (_openBlock(), _createElementBlock("span", {
+                    key: `missing-${item}`
+                  }, "未找到：" + _toDisplayString(item), 1))
+                }), 128)),
+                (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(probe.value.problems || [], (item) => {
+                  return (_openBlock(), _createElementBlock("span", { key: item }, _toDisplayString(item), 1))
+                }), 128))
+              ]))
+            : _createCommentVNode("", true)
+        ]))
+      : _createCommentVNode("", true)
+  ]))
+}
+}
+
+};
+const Config = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-b936500f"]]);
+
+export { _export_sfc as _, Config as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_expose_Page-Cn1YPvWs.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_expose_Page-Cn1YPvWs.js
@@ -1,0 +1,32 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage, { c as createLatestPlanApi } from './__federation_expose_AppPage-Bdp0MSc6.js';
+
+const {unref:_unref,openBlock:_openBlock,createBlock:_createBlock} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'Page',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+const props = __props;
+
+const guardedApi = createLatestPlanApi({
+  get: (...args) => props.api.get(...args),
+  post: (...args) => props.api.post(...args),
+});
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createBlock(AppPage, {
+    api: _unref(guardedApi),
+    "plugin-id": __props.pluginId
+  }, null, 8, ["api", "plugin-id"]))
+}
+}
+
+};
+
+export { _sfc_main as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_fn_import-JrT3xvdd.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.15/assets/__federation_fn_import-JrT3xvdd.js
@@ -1,0 +1,418 @@
+const buildIdentifier = "[0-9A-Za-z-]+";
+const build = `(?:\\+(${buildIdentifier}(?:\\.${buildIdentifier})*))`;
+const numericIdentifier = "0|[1-9]\\d*";
+const numericIdentifierLoose = "[0-9]+";
+const nonNumericIdentifier = "\\d*[a-zA-Z-][a-zA-Z0-9-]*";
+const preReleaseIdentifierLoose = `(?:${numericIdentifierLoose}|${nonNumericIdentifier})`;
+const preReleaseLoose = `(?:-?(${preReleaseIdentifierLoose}(?:\\.${preReleaseIdentifierLoose})*))`;
+const preReleaseIdentifier = `(?:${numericIdentifier}|${nonNumericIdentifier})`;
+const preRelease = `(?:-(${preReleaseIdentifier}(?:\\.${preReleaseIdentifier})*))`;
+const xRangeIdentifier = `${numericIdentifier}|x|X|\\*`;
+const xRangePlain = `[v=\\s]*(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:${preRelease})?${build}?)?)?`;
+const hyphenRange = `^\\s*(${xRangePlain})\\s+-\\s+(${xRangePlain})\\s*$`;
+const mainVersionLoose = `(${numericIdentifierLoose})\\.(${numericIdentifierLoose})\\.(${numericIdentifierLoose})`;
+const loosePlain = `[v=\\s]*${mainVersionLoose}${preReleaseLoose}?${build}?`;
+const gtlt = "((?:<|>)?=?)";
+const comparatorTrim = `(\\s*)${gtlt}\\s*(${loosePlain}|${xRangePlain})`;
+const loneTilde = "(?:~>?)";
+const tildeTrim = `(\\s*)${loneTilde}\\s+`;
+const loneCaret = "(?:\\^)";
+const caretTrim = `(\\s*)${loneCaret}\\s+`;
+const star = "(<|>)?=?\\s*\\*";
+const caret = `^${loneCaret}${xRangePlain}$`;
+const mainVersion = `(${numericIdentifier})\\.(${numericIdentifier})\\.(${numericIdentifier})`;
+const fullPlain = `v?${mainVersion}${preRelease}?${build}?`;
+const tilde = `^${loneTilde}${xRangePlain}$`;
+const xRange = `^${gtlt}\\s*${xRangePlain}$`;
+const comparator = `^${gtlt}\\s*(${fullPlain})$|^$`;
+const gte0 = "^\\s*>=\\s*0.0.0\\s*$";
+function parseRegex(source) {
+  return new RegExp(source);
+}
+function isXVersion(version) {
+  return !version || version.toLowerCase() === "x" || version === "*";
+}
+function pipe(...fns) {
+  return (x) => {
+    return fns.reduce((v, f) => f(v), x);
+  };
+}
+function extractComparator(comparatorString) {
+  return comparatorString.match(parseRegex(comparator));
+}
+function combineVersion(major, minor, patch, preRelease2) {
+  const mainVersion2 = `${major}.${minor}.${patch}`;
+  if (preRelease2) {
+    return `${mainVersion2}-${preRelease2}`;
+  }
+  return mainVersion2;
+}
+function parseHyphen(range) {
+  return range.replace(
+    parseRegex(hyphenRange),
+    (_range, from, fromMajor, fromMinor, fromPatch, _fromPreRelease, _fromBuild, to, toMajor, toMinor, toPatch, toPreRelease) => {
+      if (isXVersion(fromMajor)) {
+        from = "";
+      } else if (isXVersion(fromMinor)) {
+        from = `>=${fromMajor}.0.0`;
+      } else if (isXVersion(fromPatch)) {
+        from = `>=${fromMajor}.${fromMinor}.0`;
+      } else {
+        from = `>=${from}`;
+      }
+      if (isXVersion(toMajor)) {
+        to = "";
+      } else if (isXVersion(toMinor)) {
+        to = `<${+toMajor + 1}.0.0-0`;
+      } else if (isXVersion(toPatch)) {
+        to = `<${toMajor}.${+toMinor + 1}.0-0`;
+      } else if (toPreRelease) {
+        to = `<=${toMajor}.${toMinor}.${toPatch}-${toPreRelease}`;
+      } else {
+        to = `<=${to}`;
+      }
+      return `${from} ${to}`.trim();
+    }
+  );
+}
+function parseComparatorTrim(range) {
+  return range.replace(parseRegex(comparatorTrim), "$1$2$3");
+}
+function parseTildeTrim(range) {
+  return range.replace(parseRegex(tildeTrim), "$1~");
+}
+function parseCaretTrim(range) {
+  return range.replace(parseRegex(caretTrim), "$1^");
+}
+function parseCarets(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(caret),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          if (major === "0") {
+            return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+          } else {
+            return `>=${major}.${minor}.0 <${+major + 1}.0.0-0`;
+          }
+        } else if (preRelease2) {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+            }
+          } else {
+            return `>=${major}.${minor}.${patch}-${preRelease2} <${+major + 1}.0.0-0`;
+          }
+        } else {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+            }
+          }
+          return `>=${major}.${minor}.${patch} <${+major + 1}.0.0-0`;
+        }
+      }
+    );
+  }).join(" ");
+}
+function parseTildes(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(tilde),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+        } else if (preRelease2) {
+          return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+      }
+    );
+  }).join(" ");
+}
+function parseXRanges(range) {
+  return range.split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.trim().replace(
+      parseRegex(xRange),
+      (ret, gtlt2, major, minor, patch, preRelease2) => {
+        const isXMajor = isXVersion(major);
+        const isXMinor = isXMajor || isXVersion(minor);
+        const isXPatch = isXMinor || isXVersion(patch);
+        if (gtlt2 === "=" && isXPatch) {
+          gtlt2 = "";
+        }
+        preRelease2 = "";
+        if (isXMajor) {
+          if (gtlt2 === ">" || gtlt2 === "<") {
+            return "<0.0.0-0";
+          } else {
+            return "*";
+          }
+        } else if (gtlt2 && isXPatch) {
+          if (isXMinor) {
+            minor = 0;
+          }
+          patch = 0;
+          if (gtlt2 === ">") {
+            gtlt2 = ">=";
+            if (isXMinor) {
+              major = +major + 1;
+              minor = 0;
+              patch = 0;
+            } else {
+              minor = +minor + 1;
+              patch = 0;
+            }
+          } else if (gtlt2 === "<=") {
+            gtlt2 = "<";
+            if (isXMinor) {
+              major = +major + 1;
+            } else {
+              minor = +minor + 1;
+            }
+          }
+          if (gtlt2 === "<") {
+            preRelease2 = "-0";
+          }
+          return `${gtlt2 + major}.${minor}.${patch}${preRelease2}`;
+        } else if (isXMinor) {
+          return `>=${major}.0.0${preRelease2} <${+major + 1}.0.0-0`;
+        } else if (isXPatch) {
+          return `>=${major}.${minor}.0${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return ret;
+      }
+    );
+  }).join(" ");
+}
+function parseStar(range) {
+  return range.trim().replace(parseRegex(star), "");
+}
+function parseGTE0(comparatorString) {
+  return comparatorString.trim().replace(parseRegex(gte0), "");
+}
+function compareAtom(rangeAtom, versionAtom) {
+  rangeAtom = +rangeAtom || rangeAtom;
+  versionAtom = +versionAtom || versionAtom;
+  if (rangeAtom > versionAtom) {
+    return 1;
+  }
+  if (rangeAtom === versionAtom) {
+    return 0;
+  }
+  return -1;
+}
+function comparePreRelease(rangeAtom, versionAtom) {
+  const { preRelease: rangePreRelease } = rangeAtom;
+  const { preRelease: versionPreRelease } = versionAtom;
+  if (rangePreRelease === void 0 && !!versionPreRelease) {
+    return 1;
+  }
+  if (!!rangePreRelease && versionPreRelease === void 0) {
+    return -1;
+  }
+  if (rangePreRelease === void 0 && versionPreRelease === void 0) {
+    return 0;
+  }
+  for (let i = 0, n = rangePreRelease.length; i <= n; i++) {
+    const rangeElement = rangePreRelease[i];
+    const versionElement = versionPreRelease[i];
+    if (rangeElement === versionElement) {
+      continue;
+    }
+    if (rangeElement === void 0 && versionElement === void 0) {
+      return 0;
+    }
+    if (!rangeElement) {
+      return 1;
+    }
+    if (!versionElement) {
+      return -1;
+    }
+    return compareAtom(rangeElement, versionElement);
+  }
+  return 0;
+}
+function compareVersion(rangeAtom, versionAtom) {
+  return compareAtom(rangeAtom.major, versionAtom.major) || compareAtom(rangeAtom.minor, versionAtom.minor) || compareAtom(rangeAtom.patch, versionAtom.patch) || comparePreRelease(rangeAtom, versionAtom);
+}
+function eq(rangeAtom, versionAtom) {
+  return rangeAtom.version === versionAtom.version;
+}
+function compare(rangeAtom, versionAtom) {
+  switch (rangeAtom.operator) {
+    case "":
+    case "=":
+      return eq(rangeAtom, versionAtom);
+    case ">":
+      return compareVersion(rangeAtom, versionAtom) < 0;
+    case ">=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) < 0;
+    case "<":
+      return compareVersion(rangeAtom, versionAtom) > 0;
+    case "<=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) > 0;
+    case void 0: {
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+function parseComparatorString(range) {
+  return pipe(
+    parseCarets,
+    parseTildes,
+    parseXRanges,
+    parseStar
+  )(range);
+}
+function parseRange(range) {
+  return pipe(
+    parseHyphen,
+    parseComparatorTrim,
+    parseTildeTrim,
+    parseCaretTrim
+  )(range.trim()).split(/\s+/).join(" ");
+}
+function satisfy(version, range) {
+  if (!version) {
+    return false;
+  }
+  const parsedRange = parseRange(range);
+  const parsedComparator = parsedRange.split(" ").map((rangeVersion) => parseComparatorString(rangeVersion)).join(" ");
+  const comparators = parsedComparator.split(/\s+/).map((comparator2) => parseGTE0(comparator2));
+  const extractedVersion = extractComparator(version);
+  if (!extractedVersion) {
+    return false;
+  }
+  const [
+    ,
+    versionOperator,
+    ,
+    versionMajor,
+    versionMinor,
+    versionPatch,
+    versionPreRelease
+  ] = extractedVersion;
+  const versionAtom = {
+    version: combineVersion(
+      versionMajor,
+      versionMinor,
+      versionPatch,
+      versionPreRelease
+    ),
+    major: versionMajor,
+    minor: versionMinor,
+    patch: versionPatch,
+    preRelease: versionPreRelease == null ? void 0 : versionPreRelease.split(".")
+  };
+  for (const comparator2 of comparators) {
+    const extractedComparator = extractComparator(comparator2);
+    if (!extractedComparator) {
+      return false;
+    }
+    const [
+      ,
+      rangeOperator,
+      ,
+      rangeMajor,
+      rangeMinor,
+      rangePatch,
+      rangePreRelease
+    ] = extractedComparator;
+    const rangeAtom = {
+      operator: rangeOperator,
+      version: combineVersion(
+        rangeMajor,
+        rangeMinor,
+        rangePatch,
+        rangePreRelease
+      ),
+      major: rangeMajor,
+      minor: rangeMinor,
+      patch: rangePatch,
+      preRelease: rangePreRelease == null ? void 0 : rangePreRelease.split(".")
+    };
+    if (!compare(rangeAtom, versionAtom)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// eslint-disable-next-line no-undef
+const moduleMap = {};
+const moduleCache = Object.create(null);
+async function importShared(name, shareScope = 'default') {
+  return moduleCache[name]
+    ? new Promise((r) => r(moduleCache[name]))
+    : (await getSharedFromRuntime(name, shareScope)) || getSharedFromLocal(name)
+}
+async function getSharedFromRuntime(name, shareScope) {
+  let module = null;
+  if (globalThis?.__federation_shared__?.[shareScope]?.[name]) {
+    const versionObj = globalThis.__federation_shared__[shareScope][name];
+    const requiredVersion = moduleMap[name]?.requiredVersion;
+    const hasRequiredVersion = !!requiredVersion;
+    if (hasRequiredVersion) {
+      const versionKey = Object.keys(versionObj).find((version) =>
+        satisfy(version, requiredVersion)
+      );
+      if (versionKey) {
+        const versionValue = versionObj[versionKey];
+        module = await (await versionValue.get())();
+      } else {
+        console.log(
+          `provider support ${name}(${versionKey}) is not satisfied requiredVersion(\${moduleMap[name].requiredVersion})`
+        );
+      }
+    } else {
+      const versionKey = Object.keys(versionObj)[0];
+      const versionValue = versionObj[versionKey];
+      module = await (await versionValue.get())();
+    }
+  }
+  if (module) {
+    return flattenModule(module, name)
+  }
+}
+async function getSharedFromLocal(name) {
+  if (moduleMap[name]?.import) {
+    let module = await (await moduleMap[name].get())();
+    return flattenModule(module, name)
+  } else {
+    console.error(
+      `consumer config import=false,so cant use callback shared module`
+    );
+  }
+}
+function flattenModule(module, name) {
+  // use a shared module which export default a function will getting error 'TypeError: xxx is not a function'
+  if (typeof module.default === 'function') {
+    Object.keys(module).forEach((key) => {
+      if (key !== 'default') {
+        module.default[key] = module[key];
+      }
+    });
+    moduleCache[name] = module.default;
+    return module.default
+  }
+  if (module.default) module = Object.assign({}, module.default, module);
+  moduleCache[name] = module;
+  return module
+}
+
+export { importShared, getSharedFromLocal as importSharedLocal, getSharedFromRuntime as importSharedRuntime };

--- a/plugins.v2/storagecleanup/dist/v1.0.15/assets/index-rcPP0xjJ.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.15/assets/index-rcPP0xjJ.js
@@ -1,0 +1,44 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage from './__federation_expose_AppPage-Bdp0MSc6.js';
+
+true              &&(function polyfill() {
+  const relList = document.createElement("link").relList;
+  if (relList && relList.supports && relList.supports("modulepreload")) {
+    return;
+  }
+  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+    processPreload(link);
+  }
+  new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type !== "childList") {
+        continue;
+      }
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === "LINK" && node.rel === "modulepreload")
+          processPreload(node);
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  function getFetchOpts(link) {
+    const fetchOpts = {};
+    if (link.integrity) fetchOpts.integrity = link.integrity;
+    if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
+    if (link.crossOrigin === "use-credentials")
+      fetchOpts.credentials = "include";
+    else if (link.crossOrigin === "anonymous") fetchOpts.credentials = "omit";
+    else fetchOpts.credentials = "same-origin";
+    return fetchOpts;
+  }
+  function processPreload(link) {
+    if (link.ep)
+      return;
+    link.ep = true;
+    const fetchOpts = getFetchOpts(link);
+    fetch(link.href, fetchOpts);
+  }
+}());
+
+const {createApp} = await importShared('vue');
+
+createApp(AppPage).mount('#app');

--- a/plugins.v2/storagecleanup/dist/v1.0.15/assets/remoteEntry.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.15/assets/remoteEntry.js
@@ -2,14 +2,14 @@ const currentImports = {};
       const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
       let moduleMap = {
 "./AppPage":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './AppPage');
-      return __federation_import('./__federation_expose_AppPage-WrNLRDkU.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-Bsa0sPFe.css","__federation_expose_Config-D0d0drVp.css"], false, './AppPage');
+      return __federation_import('./__federation_expose_AppPage-Bdp0MSc6.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Page":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './Page');
-      return __federation_import('./__federation_expose_Page-DAUTopwb.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-Bsa0sPFe.css","__federation_expose_Config-D0d0drVp.css"], false, './Page');
+      return __federation_import('./__federation_expose_Page-Cn1YPvWs.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Config":()=>{
-      dynamicLoadingCss(["__federation_expose_Config-BHIxEI63.css"], false, './Config');
-      return __federation_import('./__federation_expose_Config-BlunJQWM.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
+      dynamicLoadingCss(["__federation_expose_Config-D0d0drVp.css"], false, './Config');
+      return __federation_import('./__federation_expose_Config-D6hmMvYZ.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
       const seen = {};
       const dynamicLoadingCss = (cssFilePaths, dontAppendStylesToHead, exposeItemName) => {
         const metaUrl = import.meta.url;

--- a/plugins.v2/storagecleanup/dist/v1.0.15/index.html
+++ b/plugins.v2/storagecleanup/dist/v1.0.15/index.html
@@ -1,0 +1,7 @@
+<script type="module" crossorigin src="/assets/index-rcPP0xjJ.js"></script>
+<link rel="modulepreload" crossorigin href="/assets/__federation_fn_import-JrT3xvdd.js">
+<link rel="modulepreload" crossorigin href="/assets/__federation_expose_Config-D6hmMvYZ.js">
+<link rel="modulepreload" crossorigin href="/assets/__federation_expose_AppPage-Bdp0MSc6.js">
+<link rel="stylesheet" crossorigin href="/assets/__federation_expose_Config-D0d0drVp.css">
+<link rel="stylesheet" crossorigin href="/assets/__federation_expose_AppPage-Bsa0sPFe.css">
+<div id="app"></div>

--- a/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_expose_AppPage-BKy-poVd.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_expose_AppPage-BKy-poVd.css
@@ -1,0 +1,356 @@
+
+.cleanup-app[data-v-2132403c], .action-bar[data-v-2132403c], .modal-backdrop[data-v-2132403c] {
+  --ink: rgb(var(--v-theme-on-background, 30, 41, 59));
+  --muted: rgba(var(--v-theme-on-background, 30, 41, 59), .58);
+  --line: rgba(var(--v-border-color, 100, 116, 139), .18);
+  --surface: rgb(var(--v-theme-surface, 255, 255, 255));
+  --primary: rgb(var(--v-theme-primary, 59, 130, 246));
+  --primary-soft: rgba(var(--v-theme-primary, 59, 130, 246), .10);
+  --good: #16836b;
+  --warn: #b86b11;
+  --danger: #c44b47;
+}
+.cleanup-app[data-v-2132403c] {
+  color: var(--ink);
+  min-width: 980px;
+  padding: 18px 24px 110px;
+}
+button[data-v-2132403c], input[data-v-2132403c] { font: inherit;
+}
+button[data-v-2132403c] { color: inherit;
+}
+.page-header[data-v-2132403c] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+.eyebrow[data-v-2132403c] { margin: 0 0 4px; color: var(--primary); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase;
+}
+.page-header h1[data-v-2132403c] { margin: 0; font-size: 30px; line-height: 1.2;
+}
+.page-header > div > span[data-v-2132403c] { color: var(--muted); font-size: 14px;
+}
+.status-card[data-v-2132403c] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 220px;
+  padding: 10px 14px;
+  border: 1px solid rgba(22, 131, 107, .22);
+  border-radius: 12px;
+  background: rgba(22, 131, 107, .08);
+}
+.status-card.danger[data-v-2132403c] { border-color: rgba(196, 75, 71, .24); background: rgba(196, 75, 71, .08);
+}
+.status-card i[data-v-2132403c], .notice i[data-v-2132403c], .safety-note i[data-v-2132403c] {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  background: rgba(22, 131, 107, .12);
+  color: var(--good);
+  font-style: normal;
+  font-weight: 900;
+}
+.status-card p[data-v-2132403c], .notice p[data-v-2132403c], .safety-note p[data-v-2132403c], .plan-resources p[data-v-2132403c], .gap-row p[data-v-2132403c], .recovery-row p[data-v-2132403c] { display: grid; gap: 2px; margin: 0;
+}
+.status-card strong[data-v-2132403c] { font-size: 13px;
+}
+.status-card span[data-v-2132403c] { color: var(--muted); font-size: 12px;
+}
+.toolbar[data-v-2132403c] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.search[data-v-2132403c] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  height: 46px;
+  padding: 0 15px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+}
+.search span[data-v-2132403c] { color: var(--muted); font-size: 21px;
+}
+.search input[data-v-2132403c] { width: 100%; border: 0; outline: 0; color: inherit; background: transparent; font-size: 15px;
+}
+.safe-toggle[data-v-2132403c] { display: flex; align-items: center; gap: 8px; height: 44px; white-space: nowrap; font-size: 14px; font-weight: 650;
+}
+.safe-toggle input[data-v-2132403c], .risk-check input[data-v-2132403c] { position: absolute; opacity: 0;
+}
+.safe-toggle > span[data-v-2132403c] {
+  width: 38px;
+  height: 22px;
+  padding: 3px;
+  border-radius: 99px;
+  background: rgba(100, 116, 139, .24);
+}
+.safe-toggle > span[data-v-2132403c]::after { display: block; width: 16px; height: 16px; border-radius: 50%; background: white; content: ''; transition: .2s;
+}
+.safe-toggle input:checked + span[data-v-2132403c] { background: var(--primary);
+}
+.safe-toggle input:checked + span[data-v-2132403c]::after { transform: translateX(16px);
+}
+.soft-button[data-v-2132403c], .icon-button[data-v-2132403c] {
+  height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: var(--surface);
+  cursor: pointer;
+}
+.soft-button[data-v-2132403c] { padding: 0 14px;
+}
+.icon-button[data-v-2132403c] { width: 42px; font-size: 20px;
+}
+.notice[data-v-2132403c] {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin: 0 0 14px;
+  padding: 12px 16px;
+  border: 1px solid rgba(184, 107, 17, .22);
+  border-radius: 12px;
+  background: rgba(184, 107, 17, .07);
+  text-align: left;
+  cursor: pointer;
+}
+.notice p[data-v-2132403c] { flex: 1;
+}
+.notice p span[data-v-2132403c] { color: var(--muted); font-size: 13px;
+}
+.notice b[data-v-2132403c] { color: var(--warn); font-size: 13px;
+}
+.notice.critical[data-v-2132403c] { border-color: rgba(196, 75, 71, .25); background: rgba(196, 75, 71, .08);
+}
+.notice.critical b[data-v-2132403c] { color: var(--danger);
+}
+.filters[data-v-2132403c] { display: flex; gap: 6px; margin-bottom: 12px;
+}
+.filters button[data-v-2132403c] {
+  padding: 8px 13px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.filters button.active[data-v-2132403c] { border-color: var(--line); background: var(--surface); color: var(--ink); font-weight: 750; box-shadow: 0 4px 12px rgba(15, 23, 42, .04);
+}
+.filters span[data-v-2132403c] { margin-left: 5px; padding: 2px 6px; border-radius: 99px; background: rgba(100, 116, 139, .10); font-size: 11px;
+}
+.resource-card[data-v-2132403c] { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--surface);
+}
+.table-head[data-v-2132403c], .resource-row[data-v-2132403c] {
+  display: grid;
+  grid-template-columns: 42px minmax(270px, 1.55fr) minmax(170px, .85fr) minmax(360px, 1.65fr) minmax(125px, .65fr) minmax(230px, 1fr);
+  align-items: center;
+}
+.table-head[data-v-2132403c] { min-height: 50px; padding: 0 16px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 12px; font-weight: 800;
+}
+.resource-row[data-v-2132403c] { min-height: 126px; padding: 0 16px; border-bottom: 1px solid var(--line);
+}
+.resource-row[data-v-2132403c]:last-child { border-bottom: 0;
+}
+.resource-row.selected[data-v-2132403c] { background: var(--primary-soft);
+}
+.select-all[data-v-2132403c], .row-check[data-v-2132403c] {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid rgba(100, 116, 139, .35);
+  border-radius: 7px;
+  background: transparent;
+  cursor: pointer;
+}
+.row-check.locked[data-v-2132403c] { border-color: rgba(184, 107, 17, .25); background: rgba(184, 107, 17, .08); color: var(--warn); font-size: 10px; cursor: not-allowed;
+}
+.resource-title[data-v-2132403c], .stack-cell[data-v-2132403c] { display: grid; gap: 4px; min-width: 0; padding-right: 16px;
+}
+.resource-title strong[data-v-2132403c] { font-size: 17px;
+}
+.resource-title b[data-v-2132403c] { overflow: hidden; color: var(--ink); font-size: 13px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; opacity: .78;
+}
+.resource-title span[data-v-2132403c], .stack-cell span[data-v-2132403c], .impact span[data-v-2132403c], .seed-task span[data-v-2132403c] { color: var(--muted); font-size: 12px; line-height: 1.45;
+}
+.stack-cell strong[data-v-2132403c] { font-size: 14px;
+}
+.stack-cell.library strong[data-v-2132403c] { color: var(--good);
+}
+.stack-cell.size strong[data-v-2132403c] { font-size: 16px;
+}
+.seed-cell[data-v-2132403c] { display: grid; gap: 4px; padding-right: 18px;
+}
+.seed-task[data-v-2132403c] {
+  display: grid;
+  grid-template-columns: 62px minmax(72px, auto) minmax(100px, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding-left: 8px;
+  border-left: 2px solid rgba(100, 116, 139, .28);
+}
+.seed-task i[data-v-2132403c] { padding: 4px 8px; border-radius: 99px; background: rgba(100, 116, 139, .1); font-size: 11px; font-style: normal; font-weight: 800; text-align: center; white-space: nowrap;
+}
+.seed-task strong[data-v-2132403c] { font-size: 13px;
+}
+.seed-task.warning[data-v-2132403c] { border-color: rgba(184, 107, 17, .45);
+}
+.seed-task.warning i[data-v-2132403c] { color: var(--warn); background: rgba(184, 107, 17, .1);
+}
+.seed-task.protected[data-v-2132403c] { border-color: rgba(196, 75, 71, .45);
+}
+.seed-task.protected i[data-v-2132403c] { color: var(--danger); background: rgba(196, 75, 71, .1);
+}
+.impact[data-v-2132403c] { display: grid; gap: 4px; padding-left: 10px; border-left: 2px solid rgba(22, 131, 107, .35);
+}
+.impact strong[data-v-2132403c] { font-size: 13px;
+}
+.impact.danger[data-v-2132403c] { border-color: rgba(196, 75, 71, .5);
+}
+.impact.danger strong[data-v-2132403c] { color: var(--danger);
+}
+.empty-state[data-v-2132403c] { display: grid; place-items: center; min-height: 150px; color: var(--muted);
+}
+.action-bar[data-v-2132403c] {
+  position: fixed;
+  z-index: 20;
+  right: 30px;
+  bottom: 22px;
+  left: calc(var(--v-layout-left, 0px) + 30px);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, .14);
+  border-radius: 16px;
+  background: #17243a;
+  color: white;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, .28);
+}
+.selected-count[data-v-2132403c] { display: grid; place-items: center; width: 44px; height: 44px; border-radius: 12px; background: #3f70b7; font-size: 18px; font-weight: 900;
+}
+.action-bar > p[data-v-2132403c] { display: grid; gap: 1px; min-width: 160px; margin: 0;
+}
+.action-bar > p span[data-v-2132403c], .action-level span[data-v-2132403c] { color: rgba(255, 255, 255, .64); font-size: 11px;
+}
+.clear-button[data-v-2132403c] { border: 0; background: transparent; color: rgba(255, 255, 255, .66); cursor: pointer;
+}
+.action-level[data-v-2132403c] { display: grid; flex: 1; gap: 3px; padding: 10px 14px; border: 1px solid rgba(255, 255, 255, .17); border-radius: 11px; background: rgba(255, 255, 255, .06); color: white; text-align: left; cursor: pointer;
+}
+.action-level.delete[data-v-2132403c] { border-color: rgba(255, 142, 136, .32); background: rgba(196, 75, 71, .28);
+}
+.modal-backdrop[data-v-2132403c] {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  background: rgba(15, 23, 42, .55);
+  backdrop-filter: blur(6px);
+}
+.modal[data-v-2132403c] {
+  overflow: auto;
+  width: min(760px, 90vw);
+  max-height: 90vh;
+  padding: 24px;
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, .3);
+}
+.modal > header[data-v-2132403c] { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 16px;
+}
+.modal > header span[data-v-2132403c] { color: var(--primary); font-size: 11px; font-weight: 850; letter-spacing: .08em;
+}
+.modal h2[data-v-2132403c] { margin: 3px 0 0; font-size: 24px;
+}
+.modal > header button[data-v-2132403c] { width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 10px; background: transparent; font-size: 22px; cursor: pointer;
+}
+.mode-summary[data-v-2132403c], .plan-state[data-v-2132403c], .safety-note[data-v-2132403c] { display: grid; gap: 4px; margin-bottom: 12px; padding: 13px 15px; border-radius: 12px; background: var(--primary-soft);
+}
+.mode-summary span[data-v-2132403c], .plan-state span[data-v-2132403c], .safety-note span[data-v-2132403c] { color: var(--muted); font-size: 12px;
+}
+.mode-summary.delete[data-v-2132403c] { background: rgba(196, 75, 71, .08);
+}
+.plan-resources[data-v-2132403c] { max-height: 170px; overflow: auto; margin-bottom: 12px; border: 1px solid var(--line); border-radius: 12px;
+}
+.plan-resources > div[data-v-2132403c] { display: flex; justify-content: space-between; align-items: center; padding: 10px 13px; border-bottom: 1px solid var(--line);
+}
+.plan-resources > div[data-v-2132403c]:last-child { border-bottom: 0;
+}
+.plan-resources span[data-v-2132403c] { color: var(--muted); font-size: 11px;
+}
+.plan-state.passed[data-v-2132403c] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.plan-state.blocked[data-v-2132403c], .issues.blocked[data-v-2132403c] { color: var(--danger); background: rgba(196, 75, 71, .08);
+}
+.issues[data-v-2132403c] { display: grid; gap: 6px; margin: 0 0 12px; padding: 12px 16px 12px 34px; border-radius: 12px; font-size: 13px;
+}
+.issues.warning[data-v-2132403c] { color: var(--warn); background: rgba(184, 107, 17, .08);
+}
+.risk-check[data-v-2132403c] { position: relative; display: flex; align-items: center; gap: 9px; margin: 12px 0; font-size: 13px; font-weight: 700;
+}
+.risk-check > span[data-v-2132403c] { width: 20px; height: 20px; border: 1px solid rgba(100, 116, 139, .35); border-radius: 6px;
+}
+.risk-check input:checked + span[data-v-2132403c] { border-color: var(--primary); background: var(--primary); box-shadow: inset 0 0 0 4px var(--surface);
+}
+.safety-note[data-v-2132403c] { display: flex; align-items: center; background: rgba(100, 116, 139, .08);
+}
+.safety-note p[data-v-2132403c] { flex: 1;
+}
+.confirm-button[data-v-2132403c], .execution-result button[data-v-2132403c] {
+  width: 100%;
+  min-height: 46px;
+  border: 0;
+  border-radius: 11px;
+  background: var(--primary);
+  color: white;
+  font-weight: 800;
+  cursor: pointer;
+}
+.confirm-button[data-v-2132403c]:disabled { background: rgba(100, 116, 139, .22); color: var(--muted); cursor: not-allowed;
+}
+.final-confirmation[data-v-2132403c], .execution-result[data-v-2132403c] { display: grid; gap: 10px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.final-confirmation > div[data-v-2132403c] { display: flex; gap: 8px;
+}
+.final-confirmation button[data-v-2132403c] { flex: 1; min-height: 42px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); cursor: pointer;
+}
+.final-confirmation button.danger[data-v-2132403c] { border-color: transparent; background: var(--danger); color: white;
+}
+.error-text[data-v-2132403c] { color: var(--danger); font-size: 13px;
+}
+.execution-result[data-v-2132403c] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.compact-modal[data-v-2132403c] { width: min(650px, 90vw);
+}
+.gap-row[data-v-2132403c], .recovery-row[data-v-2132403c] { display: flex; align-items: center; gap: 8px; padding: 11px 4px; border-bottom: 1px solid var(--line);
+}
+.gap-row p[data-v-2132403c], .recovery-row p[data-v-2132403c] { flex: 1;
+}
+.gap-row span[data-v-2132403c], .recovery-row span[data-v-2132403c] { color: var(--muted); font-size: 11px;
+}
+.gap-row b[data-v-2132403c] { font-size: 12px; color: var(--warn);
+}
+.recovery-row button[data-v-2132403c], .recovery-confirm button[data-v-2132403c] { padding: 7px 10px; border: 1px solid var(--line); border-radius: 8px; background: transparent; cursor: pointer;
+}
+.recovery-confirm[data-v-2132403c] { display: grid; gap: 8px; margin-top: 14px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.recovery-confirm input[data-v-2132403c] { height: 40px; padding: 0 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); color: inherit;
+}
+@media (max-width: 1250px) {
+.table-head[data-v-2132403c], .resource-row[data-v-2132403c] {
+    grid-template-columns: 38px minmax(240px, 1.3fr) minmax(150px, .7fr) minmax(310px, 1.35fr) 120px minmax(200px, .9fr);
+}
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_expose_AppPage-jF88PUVl.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_expose_AppPage-jF88PUVl.js
@@ -1,0 +1,946 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
+
+const FILTERS = [
+  { id: 'all', label: '全部资源' },
+  { id: 'library', label: '媒体库已入库' },
+  { id: 'hr', label: 'H&R 保护中' },
+  { id: 'brush', label: '刷流任务' },
+  { id: 'review', label: '无做种限制' },
+  { id: 'names', label: '名称待核' },
+];
+
+const ACTIONS = {
+  pause: {
+    title: '停止做种',
+    detail: '保留 qB 任务和全部文件',
+  },
+  retire: {
+    title: '退出做种',
+    detail: '移除 qB 任务，媒体仍保留',
+  },
+  delete: {
+    title: '完整删除',
+    detail: '移除任务、媒体和全部链接',
+  },
+};
+
+function unwrapResponse(response) {
+  if (response && Object.prototype.hasOwnProperty.call(response, 'data') && response.success !== undefined) {
+    return response.data
+  }
+  return response?.data ?? response
+}
+
+function matchesFilter(item, filter) {
+  if (filter === 'all') return true
+  if (filter === 'library') return Boolean(item.library)
+  if (filter === 'hr') return Boolean(item.hr || item.hrPending)
+  if (filter === 'brush') return Boolean(item.brush)
+  if (filter === 'review') return !item.protected && item.qbSummary === '无 qB 任务'
+  return item.metadataVerified === false
+}
+
+function isDirectlyCleanable(item) {
+  return !item.protected && item.qbSummary === '无 qB 任务'
+}
+
+function filterResources(resources, { filter, search, safeOnly, descending }) {
+  const query = String(search || '').trim().toLowerCase();
+  return [...(resources || [])]
+    .filter(item => {
+      const text = `${item.title || ''} ${item.englishTitle || ''} ${item.edition || ''} ${item.siteSummary || ''}`.toLowerCase();
+      return matchesFilter(item, filter) &&
+        (!safeOnly || isDirectlyCleanable(item)) &&
+        (!query || text.includes(query))
+    })
+    .sort((left, right) => {
+      const order = descending ? Number(right.size || 0) - Number(left.size || 0) : Number(left.size || 0) - Number(right.size || 0);
+      return order || String(left.title || '').localeCompare(String(right.title || ''), 'zh-CN')
+    })
+}
+
+function formatGiB(size) {
+  const numeric = Number(size || 0);
+  return numeric >= 1024 ? `${(numeric / 1024).toFixed(2)} TB` : `${numeric.toFixed(1)} GB`
+}
+
+function formatBytes(size) {
+  return formatGiB(Number(size || 0) / 1024 ** 3)
+}
+
+function issueKey(issue, index) {
+  return `${issue?.code || 'issue'}-${index}`
+}
+
+const {createElementVNode:_createElementVNode,toDisplayString:_toDisplayString,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,normalizeClass:_normalizeClass,vModelText:_vModelText,withDirectives:_withDirectives,vModelCheckbox:_vModelCheckbox,createTextVNode:_createTextVNode,renderList:_renderList,Fragment:_Fragment,unref:_unref,withModifiers:_withModifiers,Teleport:_Teleport,createBlock:_createBlock} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "cleanup-app" };
+const _hoisted_2 = {
+  key: 0,
+  class: "page-header"
+};
+const _hoisted_3 = { key: 0 };
+const _hoisted_4 = { class: "toolbar" };
+const _hoisted_5 = { class: "search" };
+const _hoisted_6 = { class: "safe-toggle" };
+const _hoisted_7 = ["disabled"];
+const _hoisted_8 = {
+  class: "filters",
+  "aria-label": "资源筛选"
+};
+const _hoisted_9 = ["onClick"];
+const _hoisted_10 = { class: "resource-card" };
+const _hoisted_11 = { class: "table-head" };
+const _hoisted_12 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_13 = ["disabled", "onClick"];
+const _hoisted_14 = { class: "resource-title" };
+const _hoisted_15 = { class: "stack-cell library" };
+const _hoisted_16 = { class: "seed-cell" };
+const _hoisted_17 = {
+  key: 1,
+  class: "stack-cell"
+};
+const _hoisted_18 = { class: "stack-cell size" };
+const _hoisted_19 = {
+  key: 2,
+  class: "empty-state"
+};
+const _hoisted_20 = {
+  key: 0,
+  class: "action-bar"
+};
+const _hoisted_21 = { class: "selected-count" };
+const _hoisted_22 = ["onClick"];
+const _hoisted_23 = {
+  class: "modal plan-modal",
+  role: "dialog",
+  "aria-modal": "true"
+};
+const _hoisted_24 = ["disabled"];
+const _hoisted_25 = { key: 0 };
+const _hoisted_26 = { key: 1 };
+const _hoisted_27 = { class: "plan-resources" };
+const _hoisted_28 = {
+  key: 0,
+  class: "plan-state"
+};
+const _hoisted_29 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_30 = {
+  key: 0,
+  class: "issues blocked"
+};
+const _hoisted_31 = {
+  key: 1,
+  class: "issues warning"
+};
+const _hoisted_32 = {
+  key: 2,
+  class: "risk-check"
+};
+const _hoisted_33 = ["checked"];
+const _hoisted_34 = {
+  key: 3,
+  class: "plan-state blocked"
+};
+const _hoisted_35 = { class: "safety-note" };
+const _hoisted_36 = {
+  key: 3,
+  class: "execution-result"
+};
+const _hoisted_37 = {
+  key: 4,
+  class: "final-confirmation"
+};
+const _hoisted_38 = {
+  key: 0,
+  class: "error-text"
+};
+const _hoisted_39 = ["disabled"];
+const _hoisted_40 = ["disabled"];
+const _hoisted_41 = ["disabled"];
+const _hoisted_42 = { class: "modal compact-modal" };
+const _hoisted_43 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_44 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_45 = { class: "modal compact-modal" };
+const _hoisted_46 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_47 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_48 = ["onClick"];
+const _hoisted_49 = ["onClick"];
+const _hoisted_50 = {
+  key: 2,
+  class: "recovery-confirm"
+};
+const _hoisted_51 = ["disabled"];
+
+const {computed,onMounted,ref} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'AppPage',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+  hideTitle: { type: Boolean, default: false },
+},
+  setup(__props) {
+
+const props = __props;
+
+const emptySnapshot = {
+  schemaVersion: 2,
+  snapshotId: '',
+  generatedAt: '',
+  stats: {},
+  resources: [],
+};
+
+const snapshot = ref(emptySnapshot);
+const health = ref({});
+const loading = ref(true);
+const refreshing = ref(false);
+const error = ref('');
+const search = ref('');
+const activeFilter = ref('all');
+const safeOnly = ref(false);
+const descending = ref(true);
+const selected = ref([]);
+
+const planOpen = ref(false);
+const planMode = ref(null);
+const plan = ref(null);
+const planLoading = ref(false);
+const planError = ref('');
+const acknowledgeSiteRisk = ref(false);
+const finalConfirmation = ref(false);
+const executing = ref(false);
+const executeError = ref('');
+const executeResult = ref(null);
+
+const gapOpen = ref(false);
+const gapLoading = ref(false);
+const gaps = ref([]);
+const gapError = ref('');
+
+const recoveryOpen = ref(false);
+const recoveryLoading = ref(false);
+const recoveries = ref([]);
+const recoveryError = ref('');
+const recoveryTarget = ref(null);
+const recoveryAction = ref(null);
+const recoveryPhrase = ref('');
+const recovering = ref(false);
+
+const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`);
+const resources = computed(() => snapshot.value.resources || []);
+const visible = computed(() => filterResources(resources.value, {
+  filter: activeFilter.value,
+  search: search.value,
+  safeOnly: safeOnly.value,
+  descending: descending.value,
+}));
+const selectedItems = computed(() => resources.value.filter(item => selected.value.includes(item.id)));
+const selectedSize = computed(() => selectedItems.value.reduce((total, item) => total + Number(item.size || 0), 0));
+const executionEnabled = computed(() => Boolean(health.value.executionEnabled));
+const inventoryCurrent = computed(() => health.value.inventoryCurrent !== false);
+const unresolvedTransactions = computed(() => Number(snapshot.value.stats?.unresolvedTransactions || 0));
+const hrGap = computed(() => Math.max(
+  0,
+  Number(
+    snapshot.value.stats?.hrMissingQbTasks ??
+    Number(snapshot.value.stats?.hrActiveTitles || 0) - Number(snapshot.value.stats?.hrMatchedQbTasks || 0),
+  ),
+));
+const hrUnassigned = computed(() => Number(
+  snapshot.value.stats?.hrMissingUnassigned ??
+  snapshot.value.stats?.hrMissingUncovered ??
+  0,
+));
+const filters = computed(() => FILTERS.map(filter => ({
+  ...filter,
+  count: resources.value.filter(item => {
+    if (filter.id === 'all') return true
+    return filterResources([item], {
+      filter: filter.id,
+      search: '',
+      safeOnly: false,
+      descending: true,
+    }).length === 1
+  }).length,
+})));
+const allVisibleSelected = computed(() => {
+  const selectable = visible.value.filter(item => !item.protected);
+  return selectable.length > 0 && selectable.every(item => selected.value.includes(item.id))
+});
+const currentAction = computed(() => planMode.value ? ACTIONS[planMode.value] : null);
+const planExpired = computed(() => Boolean(plan.value && Date.parse(plan.value.expiresAt) <= Date.now()));
+
+function payloadError(payload, fallback) {
+  return payload?.error?.message || fallback
+}
+
+async function get(path) {
+  return unwrapResponse(await props.api.get(`${pluginBase.value}${path}`))
+}
+
+async function post(path, body) {
+  return unwrapResponse(await props.api.post(`${pluginBase.value}${path}`, body))
+}
+
+function acceptSnapshot(next) {
+  if (!next || next.schemaVersion !== 2 || !next.snapshotId || !Array.isArray(next.resources)) {
+    throw new Error('资源快照格式不受支持。')
+  }
+  snapshot.value = next;
+  const available = new Set(next.resources.map(item => item.id));
+  selected.value = selected.value.filter(id => available.has(id));
+}
+
+async function loadStatus() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const payload = await get('/status');
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '无法读取清理台状态。'))
+    health.value = payload.health || {};
+    acceptSnapshot(payload.snapshot);
+  } catch (err) {
+    error.value = err?.message || '无法读取清理台状态。';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function refreshSnapshot() {
+  refreshing.value = true;
+  error.value = '';
+  try {
+    const payload = await post('/refresh', {});
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '刷新失败。'))
+    acceptSnapshot(payload.snapshot);
+    health.value = { ...health.value, inventoryCurrent: true };
+  } catch (err) {
+    error.value = err?.message || '刷新失败，继续显示上次快照。';
+    health.value = { ...health.value, inventoryCurrent: false };
+  } finally {
+    refreshing.value = false;
+  }
+}
+
+function toggle(item) {
+  if (item.protected) return
+  selected.value = selected.value.includes(item.id)
+    ? selected.value.filter(id => id !== item.id)
+    : [...selected.value, item.id];
+}
+
+function toggleVisible() {
+  const ids = visible.value.filter(item => !item.protected).map(item => item.id);
+  selected.value = allVisibleSelected.value
+    ? selected.value.filter(id => !ids.includes(id))
+    : [...new Set([...selected.value, ...ids])];
+}
+
+async function requestPlan(mode, acknowledged = false) {
+  planLoading.value = true;
+  planError.value = '';
+  plan.value = null;
+  finalConfirmation.value = false;
+  try {
+    const payload = await post('/plan', {
+      snapshotId: snapshot.value.snapshotId,
+      resourceIds: selected.value,
+      mode,
+      acknowledgeSiteRisk: acknowledged,
+    });
+    if (!payload?.ok || !payload.plan) throw new Error(payloadError(payload, '无法生成执行计划。'))
+    plan.value = payload.plan;
+  } catch (err) {
+    planError.value = err?.message || '无法生成执行计划。';
+  } finally {
+    planLoading.value = false;
+  }
+}
+
+function openPlan(mode) {
+  planMode.value = mode;
+  planOpen.value = true;
+  acknowledgeSiteRisk.value = false;
+  executeResult.value = null;
+  executeError.value = '';
+  requestPlan(mode, false);
+}
+
+function closePlan() {
+  if (executing.value) return
+  planOpen.value = false;
+  planMode.value = null;
+  plan.value = null;
+  planError.value = '';
+  finalConfirmation.value = false;
+  executeResult.value = null;
+}
+
+async function setSiteRisk(value) {
+  acknowledgeSiteRisk.value = value;
+  await requestPlan(planMode.value, value);
+}
+
+async function executePlan() {
+  if (!plan.value || planExpired.value || executing.value) return
+  executing.value = true;
+  executeError.value = '';
+  try {
+    const payload = await post('/execute', {
+      planId: plan.value.planId,
+      confirmPhrase: plan.value.confirmPhrase,
+    });
+    if (!payload?.ok || !payload.result) {
+      if (payload?.error?.plan) plan.value = payload.error.plan;
+      throw new Error(payloadError(payload, '执行失败。'))
+    }
+    executeResult.value = payload.result;
+    selected.value = [];
+    if (payload.result.snapshotRefreshPending) {
+      health.value = { ...health.value, inventoryCurrent: false };
+    } else {
+      const latest = await get('/snapshot');
+      if (latest?.snapshot) acceptSnapshot(latest.snapshot);
+    }
+  } catch (err) {
+    executeError.value = err?.message || '执行失败。';
+    finalConfirmation.value = false;
+  } finally {
+    executing.value = false;
+  }
+}
+
+async function loadGaps() {
+  gapOpen.value = true;
+  gapLoading.value = true;
+  gapError.value = '';
+  try {
+    const payload = await get('/protection-gaps');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取 H&R 缺口。'))
+    gaps.value = payload.gaps || [];
+  } catch (err) {
+    gapError.value = err?.message || '无法读取 H&R 缺口。';
+  } finally {
+    gapLoading.value = false;
+  }
+}
+
+async function loadRecoveries() {
+  recoveryOpen.value = true;
+  recoveryLoading.value = true;
+  recoveryError.value = '';
+  recoveryTarget.value = null;
+  try {
+    const payload = await get('/recovery');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取恢复状态。'))
+    recoveries.value = payload.recoveries || [];
+  } catch (err) {
+    recoveryError.value = err?.message || '无法读取恢复状态。';
+  } finally {
+    recoveryLoading.value = false;
+  }
+}
+
+function chooseRecovery(item, action) {
+  recoveryTarget.value = item;
+  recoveryAction.value = action;
+  recoveryPhrase.value = '';
+  recoveryError.value = '';
+}
+
+async function runRecovery() {
+  if (!recoveryTarget.value || !recoveryAction.value || recovering.value) return
+  recovering.value = true;
+  recoveryError.value = '';
+  try {
+    const payload = await post('/recovery', {
+      planId: recoveryTarget.value.planId,
+      action: recoveryAction.value,
+      confirmPhrase: recoveryPhrase.value,
+    });
+    if (!payload?.ok) throw new Error(payloadError(payload, '恢复操作失败。'))
+    await refreshSnapshot();
+    await loadRecoveries();
+  } catch (err) {
+    recoveryError.value = err?.message || '恢复操作失败。';
+  } finally {
+    recovering.value = false;
+  }
+}
+
+function recoveryExpectedPhrase() {
+  if (!recoveryTarget.value || !recoveryAction.value) return ''
+  return recoveryAction.value === 'rollback'
+    ? recoveryTarget.value.rollbackPhrase
+    : recoveryTarget.value.finalizePhrase
+}
+
+onMounted(loadStatus);
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("main", _hoisted_1, [
+    (!__props.hideTitle)
+      ? (_openBlock(), _createElementBlock("header", _hoisted_2, [
+          _cache[12] || (_cache[12] = _createElementVNode("div", null, [
+            _createElementVNode("p", { class: "eyebrow" }, "PiNAS · MoviePilot 原生页面"),
+            _createElementVNode("h1", null, "存储清理"),
+            _createElementVNode("span", null, "一部电影一行，一部剧一行；先看清影响，再选择清理等级。")
+          ], -1)),
+          _createElementVNode("div", {
+            class: _normalizeClass(['status-card', { danger: error.value || !inventoryCurrent.value }])
+          }, [
+            _createElementVNode("i", null, _toDisplayString(error.value || !inventoryCurrent.value ? '!' : '✓'), 1),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(error.value || (executionEnabled.value ? '执行链路已连接' : '只读模式')), 1),
+              (snapshot.value.generatedAt)
+                ? (_openBlock(), _createElementBlock("span", _hoisted_3, "更新于 " + _toDisplayString(snapshot.value.generatedAt.slice(5, 16).replace('T', ' ')), 1))
+                : _createCommentVNode("", true)
+            ])
+          ], 2)
+        ]))
+      : _createCommentVNode("", true),
+    _createElementVNode("section", _hoisted_4, [
+      _createElementVNode("label", _hoisted_5, [
+        _cache[13] || (_cache[13] = _createElementVNode("span", null, "⌕", -1)),
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((search).value = $event)),
+          "aria-label": "搜索资源",
+          placeholder: "搜索电影、剧集、季度或站点"
+        }, null, 512), [
+          [_vModelText, search.value]
+        ])
+      ]),
+      _createElementVNode("label", _hoisted_6, [
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[1] || (_cache[1] = $event => ((safeOnly).value = $event)),
+          type: "checkbox"
+        }, null, 512), [
+          [_vModelCheckbox, safeOnly.value]
+        ]),
+        _cache[14] || (_cache[14] = _createElementVNode("span", null, null, -1)),
+        _cache[15] || (_cache[15] = _createTextVNode(" 仅看无做种限制 ", -1))
+      ]),
+      _createElementVNode("button", {
+        class: "soft-button",
+        type: "button",
+        onClick: _cache[2] || (_cache[2] = $event => (descending.value = !descending.value))
+      }, " 实际占用 " + _toDisplayString(descending.value ? '↓' : '↑'), 1),
+      _createElementVNode("button", {
+        class: "icon-button",
+        type: "button",
+        disabled: refreshing.value,
+        onClick: refreshSnapshot
+      }, _toDisplayString(refreshing.value ? '…' : '↻'), 9, _hoisted_7)
+    ]),
+    (unresolvedTransactions.value)
+      ? (_openBlock(), _createElementBlock("button", {
+          key: 1,
+          class: "notice critical",
+          type: "button",
+          onClick: loadRecoveries
+        }, [
+          _cache[17] || (_cache[17] = _createElementVNode("i", null, "!", -1)),
+          _createElementVNode("p", null, [
+            _createElementVNode("strong", null, _toDisplayString(unresolvedTransactions.value) + " 个未完成清理事务", 1),
+            _cache[16] || (_cache[16] = _createElementVNode("span", null, "新操作已锁定；请先核对并恢复原事务。", -1))
+          ]),
+          _cache[18] || (_cache[18] = _createElementVNode("b", null, "查看恢复状态", -1))
+        ]))
+      : (hrGap.value)
+        ? (_openBlock(), _createElementBlock("button", {
+            key: 2,
+            class: _normalizeClass(['notice', { warning: hrUnassigned.value }]),
+            type: "button",
+            onClick: loadGaps
+          }, [
+            _cache[19] || (_cache[19] = _createElementVNode("i", null, "H", -1)),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(hrGap.value) + " 个学校站 H&R 尚未恢复完成", 1),
+              _createElementVNode("span", null, _toDisplayString(hrUnassigned.value
+            ? `${hrUnassigned.value} 个未精确关联媒体；不会锁定无关资源。`
+            : '缺失任务只锁定精确关联资源，其他资源可独立清理。'), 1)
+            ]),
+            _cache[20] || (_cache[20] = _createElementVNode("b", null, "查看明细", -1))
+          ], 2))
+        : _createCommentVNode("", true),
+    _createElementVNode("nav", _hoisted_8, [
+      (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(filters.value, (filter) => {
+        return (_openBlock(), _createElementBlock("button", {
+          key: filter.id,
+          class: _normalizeClass({ active: activeFilter.value === filter.id }),
+          type: "button",
+          onClick: $event => (activeFilter.value = filter.id)
+        }, [
+          _createTextVNode(_toDisplayString(filter.label) + " ", 1),
+          _createElementVNode("span", null, _toDisplayString(filter.count), 1)
+        ], 10, _hoisted_9))
+      }), 128))
+    ]),
+    _createElementVNode("section", _hoisted_10, [
+      _createElementVNode("div", _hoisted_11, [
+        _createElementVNode("button", {
+          class: "select-all",
+          type: "button",
+          onClick: toggleVisible
+        }, _toDisplayString(allVisibleSelected.value ? '✓' : ''), 1),
+        _cache[21] || (_cache[21] = _createElementVNode("span", null, "资源", -1)),
+        _cache[22] || (_cache[22] = _createElementVNode("span", null, "媒体库", -1)),
+        _cache[23] || (_cache[23] = _createElementVNode("span", null, "做种与保护", -1)),
+        _cache[24] || (_cache[24] = _createElementVNode("span", null, "实际占用", -1)),
+        _cache[25] || (_cache[25] = _createElementVNode("span", null, "完整删除影响", -1))
+      ]),
+      (loading.value)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_12, "正在读取真实资源关系…"))
+        : (_openBlock(true), _createElementBlock(_Fragment, { key: 1 }, _renderList(visible.value, (item) => {
+            return (_openBlock(), _createElementBlock("article", {
+              key: item.id,
+              class: _normalizeClass(['resource-row', { selected: selected.value.includes(item.id) }])
+            }, [
+              _createElementVNode("button", {
+                class: _normalizeClass(['row-check', { locked: item.protected }]),
+                type: "button",
+                disabled: item.protected,
+                onClick: $event => (toggle(item))
+              }, _toDisplayString(item.protected ? '锁' : selected.value.includes(item.id) ? '✓' : ''), 11, _hoisted_13),
+              _createElementVNode("div", _hoisted_14, [
+                _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                _createElementVNode("b", null, _toDisplayString(item.englishTitle), 1),
+                _createElementVNode("span", null, _toDisplayString([item.type, item.year, item.edition].filter(Boolean).join(' · ')), 1)
+              ]),
+              _createElementVNode("div", _hoisted_15, [
+                _createElementVNode("strong", null, _toDisplayString(item.librarySummary), 1),
+                _createElementVNode("span", null, _toDisplayString(item.libraryDetail), 1)
+              ]),
+              _createElementVNode("div", _hoisted_16, [
+                (item.seedTasks?.length)
+                  ? (_openBlock(true), _createElementBlock(_Fragment, { key: 0 }, _renderList(item.seedTasks, (task, index) => {
+                      return (_openBlock(), _createElementBlock("div", {
+                        key: `${task.site}-${task.scope}-${index}`,
+                        class: _normalizeClass(['seed-task', task.tone])
+                      }, [
+                        _createElementVNode("i", null, _toDisplayString(task.status), 1),
+                        _createElementVNode("strong", null, _toDisplayString(task.site), 1),
+                        _createElementVNode("span", null, _toDisplayString(task.scope) + _toDisplayString(task.count > 1 ? ` · ${task.count} 个任务` : ''), 1)
+                      ], 2))
+                    }), 128))
+                  : (_openBlock(), _createElementBlock("div", _hoisted_17, [
+                      _createElementVNode("strong", null, _toDisplayString(item.qbSummary), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.siteSummary), 1)
+                    ]))
+              ]),
+              _createElementVNode("div", _hoisted_18, [
+                _createElementVNode("strong", null, _toDisplayString(item.sizeLabel), 1),
+                _createElementVNode("span", null, _toDisplayString(item.reclaimLabel), 1)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['impact', { danger: item.protected }])
+              }, [
+                _createElementVNode("strong", null, _toDisplayString(item.impactTitle), 1),
+                _createElementVNode("span", null, _toDisplayString(item.impactDetail), 1)
+              ], 2)
+            ], 2))
+          }), 128)),
+      (!loading.value && !visible.value.length)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_19, " 没有符合条件的资源，请取消筛选或更换关键词。 "))
+        : _createCommentVNode("", true)
+    ]),
+    (_openBlock(), _createBlock(_Teleport, { to: "body" }, [
+      (selected.value.length)
+        ? (_openBlock(), _createElementBlock("aside", _hoisted_20, [
+            _createElementVNode("div", _hoisted_21, _toDisplayString(selected.value.length), 1),
+            _createElementVNode("p", null, [
+              _cache[26] || (_cache[26] = _createElementVNode("strong", null, "已加入清理计划", -1)),
+              _createElementVNode("span", null, "完整删除上限 " + _toDisplayString(_unref(formatGiB)(selectedSize.value)), 1)
+            ]),
+            _createElementVNode("button", {
+              class: "clear-button",
+              type: "button",
+              onClick: _cache[3] || (_cache[3] = $event => (selected.value = []))
+            }, "清空"),
+            (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(ACTIONS), (action, mode) => {
+              return (_openBlock(), _createElementBlock("button", {
+                key: mode,
+                class: _normalizeClass(['action-level', { delete: mode === 'delete' }]),
+                type: "button",
+                onClick: $event => (openPlan(mode))
+              }, [
+                _createElementVNode("strong", null, _toDisplayString(action.title), 1),
+                _createElementVNode("span", null, _toDisplayString(action.detail), 1)
+              ], 10, _hoisted_22))
+            }), 128))
+          ]))
+        : _createCommentVNode("", true),
+      (planOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 1,
+            class: "modal-backdrop",
+            onClick: _withModifiers(closePlan, ["self"])
+          }, [
+            _createElementVNode("section", _hoisted_23, [
+              _createElementVNode("header", null, [
+                _createElementVNode("div", null, [
+                  _cache[27] || (_cache[27] = _createElementVNode("span", null, "清理等级 · 真实预演", -1)),
+                  _createElementVNode("h2", null, _toDisplayString(currentAction.value?.title), 1)
+                ]),
+                _createElementVNode("button", {
+                  type: "button",
+                  disabled: executing.value,
+                  onClick: closePlan
+                }, "×", 8, _hoisted_24)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['mode-summary', planMode.value])
+              }, [
+                (plan.value && planMode.value === 'delete')
+                  ? (_openBlock(), _createElementBlock("strong", _hoisted_25, "已核算可释放 " + _toDisplayString(_unref(formatBytes)(plan.value.estimatedReclaimBytes)), 1))
+                  : (_openBlock(), _createElementBlock("strong", _hoisted_26, _toDisplayString(currentAction.value?.detail), 1)),
+                _createElementVNode("span", null, _toDisplayString(planMode.value === 'pause'
+              ? '只改变 qB 运行状态，不删除任务或文件。'
+              : planMode.value === 'retire'
+                ? '移除 qB 任务但保留文件，媒体库继续可播放。'
+                : '仅当全部路径、硬链接、H&R 与任务状态通过校验才会放行。'), 1)
+              ], 2),
+              _createElementVNode("div", _hoisted_27, [
+                (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(selectedItems.value, (item) => {
+                  return (_openBlock(), _createElementBlock("div", {
+                    key: item.id
+                  }, [
+                    _createElementVNode("p", null, [
+                      _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.englishTitle) + " · " + _toDisplayString(item.edition), 1)
+                    ]),
+                    _createElementVNode("b", null, _toDisplayString(item.sizeLabel), 1)
+                  ]))
+                }), 128))
+              ]),
+              (planLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_28, "正在刷新 NAS 状态并复核关系…"))
+                : (planError.value)
+                  ? (_openBlock(), _createElementBlock("div", _hoisted_29, [
+                      _cache[28] || (_cache[28] = _createElementVNode("strong", null, "无法生成计划", -1)),
+                      _createElementVNode("span", null, _toDisplayString(planError.value), 1)
+                    ]))
+                  : (plan.value)
+                    ? (_openBlock(), _createElementBlock(_Fragment, { key: 2 }, [
+                        _createElementVNode("div", {
+                          class: _normalizeClass(['plan-state', plan.value.canExecute ? 'passed' : 'blocked'])
+                        }, [
+                          _createElementVNode("strong", null, _toDisplayString(plan.value.canExecute ? '安全预演通过' : '计划已被安全门禁拦截'), 1),
+                          _createElementVNode("span", null, " 停止 " + _toDisplayString(plan.value.operationCounts.qbStop) + " 个任务 · 退出 " + _toDisplayString(plan.value.operationCounts.qbRemoveKeepFiles) + " 个任务 · 解除 " + _toDisplayString(plan.value.operationCounts.unlinkFiles) + " 个文件入口 ", 1)
+                        ], 2),
+                        (plan.value.blocks?.length)
+                          ? (_openBlock(), _createElementBlock("ul", _hoisted_30, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.blocks, (issue, index) => {
+                                return (_openBlock(), _createElementBlock("li", {
+                                  key: _unref(issueKey)(issue, index)
+                                }, _toDisplayString(issue.message), 1))
+                              }), 128))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (plan.value.warnings?.length)
+                          ? (_openBlock(), _createElementBlock("ul", _hoisted_31, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.warnings, (issue, index) => {
+                                return (_openBlock(), _createElementBlock("li", {
+                                  key: _unref(issueKey)(issue, index)
+                                }, _toDisplayString(issue.message), 1))
+                              }), 128))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (plan.value.requiresSiteAcknowledgement)
+                          ? (_openBlock(), _createElementBlock("label", _hoisted_32, [
+                              _createElementVNode("input", {
+                                checked: acknowledgeSiteRisk.value,
+                                type: "checkbox",
+                                onChange: _cache[4] || (_cache[4] = $event => (setSiteRisk($event.target.checked)))
+                              }, null, 40, _hoisted_33),
+                              _cache[29] || (_cache[29] = _createElementVNode("span", null, null, -1)),
+                              _cache[30] || (_cache[30] = _createTextVNode(" 我已确认会影响私有站做种，并接受站点规则风险 ", -1))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (planExpired.value)
+                          ? (_openBlock(), _createElementBlock("div", _hoisted_34, [...(_cache[31] || (_cache[31] = [
+                              _createElementVNode("strong", null, "安全预演已过期", -1),
+                              _createElementVNode("span", null, "请关闭后重新生成。", -1)
+                            ]))]))
+                          : _createCommentVNode("", true)
+                      ], 64))
+                    : _createCommentVNode("", true),
+              _createElementVNode("div", _hoisted_35, [
+                _cache[33] || (_cache[33] = _createElementVNode("i", null, "盾", -1)),
+                _createElementVNode("p", null, [
+                  _createElementVNode("strong", null, _toDisplayString(executionEnabled.value ? '执行前还需第二次确认' : '执行引擎未启用'), 1),
+                  _cache[32] || (_cache[32] = _createElementVNode("span", null, "最终执行前会重新读取 qB、路径、硬链接和保护状态。", -1))
+                ])
+              ]),
+              (executeResult.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_36, [
+                    _createElementVNode("strong", null, _toDisplayString(currentAction.value?.title) + "已完成", 1),
+                    _createElementVNode("span", null, " 停止 " + _toDisplayString(executeResult.value.qbStopped) + " · 退出 " + _toDisplayString(executeResult.value.qbRemoved) + " · 删除文件入口 " + _toDisplayString(executeResult.value.filesDeleted) + " · 清理索引 " + _toDisplayString(executeResult.value.moviepilotIndexesDeleted), 1),
+                    _createElementVNode("button", {
+                      type: "button",
+                      onClick: closePlan
+                    }, "完成")
+                  ]))
+                : (finalConfirmation.value)
+                  ? (_openBlock(), _createElementBlock("div", _hoisted_37, [
+                      _cache[34] || (_cache[34] = _createElementVNode("strong", null, "再次确认：系统将立即执行这份计划", -1)),
+                      (executeError.value)
+                        ? (_openBlock(), _createElementBlock("span", _hoisted_38, _toDisplayString(executeError.value), 1))
+                        : _createCommentVNode("", true),
+                      _createElementVNode("div", null, [
+                        _createElementVNode("button", {
+                          type: "button",
+                          disabled: executing.value,
+                          onClick: _cache[5] || (_cache[5] = $event => (finalConfirmation.value = false))
+                        }, "返回", 8, _hoisted_39),
+                        _createElementVNode("button", {
+                          class: _normalizeClass({ danger: planMode.value === 'delete' }),
+                          type: "button",
+                          disabled: executing.value || planExpired.value,
+                          onClick: executePlan
+                        }, _toDisplayString(executing.value ? '正在二次复核…' : `确认${currentAction.value?.title}`), 11, _hoisted_40)
+                      ])
+                    ]))
+                  : (_openBlock(), _createElementBlock("button", {
+                      key: 5,
+                      class: "confirm-button",
+                      type: "button",
+                      disabled: !executionEnabled.value || !plan.value?.canExecute || planExpired.value,
+                      onClick: _cache[6] || (_cache[6] = $event => (finalConfirmation.value = true))
+                    }, " 进入最终确认 ", 8, _hoisted_41))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (gapOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 2,
+            class: "modal-backdrop",
+            onClick: _cache[8] || (_cache[8] = _withModifiers($event => (gapOpen.value = false), ["self"]))
+          }, [
+            _createElementVNode("section", _hoisted_42, [
+              _createElementVNode("header", null, [
+                _cache[35] || (_cache[35] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "学校站实时保护"),
+                  _createElementVNode("h2", null, "H&R 缺口明细")
+                ], -1)),
+                _createElementVNode("button", {
+                  onClick: _cache[7] || (_cache[7] = $event => (gapOpen.value = false))
+                }, "×")
+              ]),
+              (gapLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_43, "正在核对…"))
+                : _createCommentVNode("", true),
+              (gapError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_44, _toDisplayString(gapError.value), 1))
+                : _createCommentVNode("", true),
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(gaps.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.title,
+                  class: "gap-row"
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.linkedResourceTitle || '尚未精确关联媒体'), 1)
+                  ]),
+                  _createElementVNode("b", null, _toDisplayString(item.qbTaskPresent ? 'qB 已存在' : item.coveredByCandidate ? '候选恢复中' : '任务缺失'), 1)
+                ]))
+              }), 128))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (recoveryOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 3,
+            class: "modal-backdrop",
+            onClick: _cache[11] || (_cache[11] = _withModifiers($event => (recoveryOpen.value = false), ["self"]))
+          }, [
+            _createElementVNode("section", _hoisted_45, [
+              _createElementVNode("header", null, [
+                _cache[36] || (_cache[36] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "失败关闭"),
+                  _createElementVNode("h2", null, "恢复未完成清理")
+                ], -1)),
+                _createElementVNode("button", {
+                  onClick: _cache[9] || (_cache[9] = $event => (recoveryOpen.value = false))
+                }, "×")
+              ]),
+              (recoveryLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_46, "正在读取事务…"))
+                : _createCommentVNode("", true),
+              (recoveryError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_47, _toDisplayString(recoveryError.value), 1))
+                : _createCommentVNode("", true),
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(recoveries.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.planId,
+                  class: "recovery-row"
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.mode) + " · " + _toDisplayString(item.phase), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.planId.slice(-10)), 1)
+                  ]),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: $event => (chooseRecovery(item, 'rollback'))
+                  }, "回滚", 8, _hoisted_48),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: $event => (chooseRecovery(item, 'finalize'))
+                  }, "完成原事务", 8, _hoisted_49)
+                ]))
+              }), 128)),
+              (recoveryTarget.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_50, [
+                    _createElementVNode("label", null, [
+                      _cache[37] || (_cache[37] = _createTextVNode("输入确认短语 ", -1)),
+                      _createElementVNode("code", null, _toDisplayString(recoveryExpectedPhrase()), 1)
+                    ]),
+                    _withDirectives(_createElementVNode("input", {
+                      "onUpdate:modelValue": _cache[10] || (_cache[10] = $event => ((recoveryPhrase).value = $event)),
+                      autocomplete: "off"
+                    }, null, 512), [
+                      [_vModelText, recoveryPhrase.value]
+                    ]),
+                    _createElementVNode("button", {
+                      type: "button",
+                      disabled: recovering.value || recoveryPhrase.value !== recoveryExpectedPhrase(),
+                      onClick: runRecovery
+                    }, _toDisplayString(recovering.value ? '处理中…' : '执行恢复'), 9, _hoisted_51)
+                  ]))
+                : _createCommentVNode("", true)
+            ])
+          ]))
+        : _createCommentVNode("", true)
+    ]))
+  ]))
+}
+}
+
+};
+const AppPage = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-2132403c"]]);
+
+export { AppPage as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_expose_Config-SYLmVfvj.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_expose_Config-SYLmVfvj.css
@@ -1,0 +1,10 @@
+
+.config-note[data-v-ed9f201d] {
+  display: grid;
+  gap: 6px;
+  padding: 20px;
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+  border-radius: 12px;
+}
+.config-note span[data-v-ed9f201d] { opacity: .7;
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_expose_Config-jwIyjrQZ.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_expose_Config-jwIyjrQZ.js
@@ -1,0 +1,30 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
+
+const {createElementVNode:_createElementVNode,openBlock:_openBlock,createElementBlock:_createElementBlock} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "config-note" };
+
+
+const _sfc_main = {
+  __name: 'Config',
+  props: {
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("div", _hoisted_1, [...(_cache[0] || (_cache[0] = [
+    _createElementVNode("strong", null, "存储清理已接入 MoviePilot", -1),
+    _createElementVNode("span", null, "请从左侧“存储清理”进入完整页面。3000 端口页面继续保留。", -1)
+  ]))]))
+}
+}
+
+};
+const Config = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-ed9f201d"]]);
+
+export { Config as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_expose_Page-D7goqImm.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_expose_Page-D7goqImm.js
@@ -1,0 +1,27 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage from './__federation_expose_AppPage-jF88PUVl.js';
+
+const {openBlock:_openBlock,createBlock:_createBlock} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'Page',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createBlock(AppPage, {
+    api: __props.api,
+    "plugin-id": __props.pluginId
+  }, null, 8, ["api", "plugin-id"]))
+}
+}
+
+};
+
+export { _sfc_main as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_fn_import-JrT3xvdd.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.2/assets/__federation_fn_import-JrT3xvdd.js
@@ -1,0 +1,418 @@
+const buildIdentifier = "[0-9A-Za-z-]+";
+const build = `(?:\\+(${buildIdentifier}(?:\\.${buildIdentifier})*))`;
+const numericIdentifier = "0|[1-9]\\d*";
+const numericIdentifierLoose = "[0-9]+";
+const nonNumericIdentifier = "\\d*[a-zA-Z-][a-zA-Z0-9-]*";
+const preReleaseIdentifierLoose = `(?:${numericIdentifierLoose}|${nonNumericIdentifier})`;
+const preReleaseLoose = `(?:-?(${preReleaseIdentifierLoose}(?:\\.${preReleaseIdentifierLoose})*))`;
+const preReleaseIdentifier = `(?:${numericIdentifier}|${nonNumericIdentifier})`;
+const preRelease = `(?:-(${preReleaseIdentifier}(?:\\.${preReleaseIdentifier})*))`;
+const xRangeIdentifier = `${numericIdentifier}|x|X|\\*`;
+const xRangePlain = `[v=\\s]*(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:${preRelease})?${build}?)?)?`;
+const hyphenRange = `^\\s*(${xRangePlain})\\s+-\\s+(${xRangePlain})\\s*$`;
+const mainVersionLoose = `(${numericIdentifierLoose})\\.(${numericIdentifierLoose})\\.(${numericIdentifierLoose})`;
+const loosePlain = `[v=\\s]*${mainVersionLoose}${preReleaseLoose}?${build}?`;
+const gtlt = "((?:<|>)?=?)";
+const comparatorTrim = `(\\s*)${gtlt}\\s*(${loosePlain}|${xRangePlain})`;
+const loneTilde = "(?:~>?)";
+const tildeTrim = `(\\s*)${loneTilde}\\s+`;
+const loneCaret = "(?:\\^)";
+const caretTrim = `(\\s*)${loneCaret}\\s+`;
+const star = "(<|>)?=?\\s*\\*";
+const caret = `^${loneCaret}${xRangePlain}$`;
+const mainVersion = `(${numericIdentifier})\\.(${numericIdentifier})\\.(${numericIdentifier})`;
+const fullPlain = `v?${mainVersion}${preRelease}?${build}?`;
+const tilde = `^${loneTilde}${xRangePlain}$`;
+const xRange = `^${gtlt}\\s*${xRangePlain}$`;
+const comparator = `^${gtlt}\\s*(${fullPlain})$|^$`;
+const gte0 = "^\\s*>=\\s*0.0.0\\s*$";
+function parseRegex(source) {
+  return new RegExp(source);
+}
+function isXVersion(version) {
+  return !version || version.toLowerCase() === "x" || version === "*";
+}
+function pipe(...fns) {
+  return (x) => {
+    return fns.reduce((v, f) => f(v), x);
+  };
+}
+function extractComparator(comparatorString) {
+  return comparatorString.match(parseRegex(comparator));
+}
+function combineVersion(major, minor, patch, preRelease2) {
+  const mainVersion2 = `${major}.${minor}.${patch}`;
+  if (preRelease2) {
+    return `${mainVersion2}-${preRelease2}`;
+  }
+  return mainVersion2;
+}
+function parseHyphen(range) {
+  return range.replace(
+    parseRegex(hyphenRange),
+    (_range, from, fromMajor, fromMinor, fromPatch, _fromPreRelease, _fromBuild, to, toMajor, toMinor, toPatch, toPreRelease) => {
+      if (isXVersion(fromMajor)) {
+        from = "";
+      } else if (isXVersion(fromMinor)) {
+        from = `>=${fromMajor}.0.0`;
+      } else if (isXVersion(fromPatch)) {
+        from = `>=${fromMajor}.${fromMinor}.0`;
+      } else {
+        from = `>=${from}`;
+      }
+      if (isXVersion(toMajor)) {
+        to = "";
+      } else if (isXVersion(toMinor)) {
+        to = `<${+toMajor + 1}.0.0-0`;
+      } else if (isXVersion(toPatch)) {
+        to = `<${toMajor}.${+toMinor + 1}.0-0`;
+      } else if (toPreRelease) {
+        to = `<=${toMajor}.${toMinor}.${toPatch}-${toPreRelease}`;
+      } else {
+        to = `<=${to}`;
+      }
+      return `${from} ${to}`.trim();
+    }
+  );
+}
+function parseComparatorTrim(range) {
+  return range.replace(parseRegex(comparatorTrim), "$1$2$3");
+}
+function parseTildeTrim(range) {
+  return range.replace(parseRegex(tildeTrim), "$1~");
+}
+function parseCaretTrim(range) {
+  return range.replace(parseRegex(caretTrim), "$1^");
+}
+function parseCarets(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(caret),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          if (major === "0") {
+            return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+          } else {
+            return `>=${major}.${minor}.0 <${+major + 1}.0.0-0`;
+          }
+        } else if (preRelease2) {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+            }
+          } else {
+            return `>=${major}.${minor}.${patch}-${preRelease2} <${+major + 1}.0.0-0`;
+          }
+        } else {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+            }
+          }
+          return `>=${major}.${minor}.${patch} <${+major + 1}.0.0-0`;
+        }
+      }
+    );
+  }).join(" ");
+}
+function parseTildes(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(tilde),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+        } else if (preRelease2) {
+          return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+      }
+    );
+  }).join(" ");
+}
+function parseXRanges(range) {
+  return range.split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.trim().replace(
+      parseRegex(xRange),
+      (ret, gtlt2, major, minor, patch, preRelease2) => {
+        const isXMajor = isXVersion(major);
+        const isXMinor = isXMajor || isXVersion(minor);
+        const isXPatch = isXMinor || isXVersion(patch);
+        if (gtlt2 === "=" && isXPatch) {
+          gtlt2 = "";
+        }
+        preRelease2 = "";
+        if (isXMajor) {
+          if (gtlt2 === ">" || gtlt2 === "<") {
+            return "<0.0.0-0";
+          } else {
+            return "*";
+          }
+        } else if (gtlt2 && isXPatch) {
+          if (isXMinor) {
+            minor = 0;
+          }
+          patch = 0;
+          if (gtlt2 === ">") {
+            gtlt2 = ">=";
+            if (isXMinor) {
+              major = +major + 1;
+              minor = 0;
+              patch = 0;
+            } else {
+              minor = +minor + 1;
+              patch = 0;
+            }
+          } else if (gtlt2 === "<=") {
+            gtlt2 = "<";
+            if (isXMinor) {
+              major = +major + 1;
+            } else {
+              minor = +minor + 1;
+            }
+          }
+          if (gtlt2 === "<") {
+            preRelease2 = "-0";
+          }
+          return `${gtlt2 + major}.${minor}.${patch}${preRelease2}`;
+        } else if (isXMinor) {
+          return `>=${major}.0.0${preRelease2} <${+major + 1}.0.0-0`;
+        } else if (isXPatch) {
+          return `>=${major}.${minor}.0${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return ret;
+      }
+    );
+  }).join(" ");
+}
+function parseStar(range) {
+  return range.trim().replace(parseRegex(star), "");
+}
+function parseGTE0(comparatorString) {
+  return comparatorString.trim().replace(parseRegex(gte0), "");
+}
+function compareAtom(rangeAtom, versionAtom) {
+  rangeAtom = +rangeAtom || rangeAtom;
+  versionAtom = +versionAtom || versionAtom;
+  if (rangeAtom > versionAtom) {
+    return 1;
+  }
+  if (rangeAtom === versionAtom) {
+    return 0;
+  }
+  return -1;
+}
+function comparePreRelease(rangeAtom, versionAtom) {
+  const { preRelease: rangePreRelease } = rangeAtom;
+  const { preRelease: versionPreRelease } = versionAtom;
+  if (rangePreRelease === void 0 && !!versionPreRelease) {
+    return 1;
+  }
+  if (!!rangePreRelease && versionPreRelease === void 0) {
+    return -1;
+  }
+  if (rangePreRelease === void 0 && versionPreRelease === void 0) {
+    return 0;
+  }
+  for (let i = 0, n = rangePreRelease.length; i <= n; i++) {
+    const rangeElement = rangePreRelease[i];
+    const versionElement = versionPreRelease[i];
+    if (rangeElement === versionElement) {
+      continue;
+    }
+    if (rangeElement === void 0 && versionElement === void 0) {
+      return 0;
+    }
+    if (!rangeElement) {
+      return 1;
+    }
+    if (!versionElement) {
+      return -1;
+    }
+    return compareAtom(rangeElement, versionElement);
+  }
+  return 0;
+}
+function compareVersion(rangeAtom, versionAtom) {
+  return compareAtom(rangeAtom.major, versionAtom.major) || compareAtom(rangeAtom.minor, versionAtom.minor) || compareAtom(rangeAtom.patch, versionAtom.patch) || comparePreRelease(rangeAtom, versionAtom);
+}
+function eq(rangeAtom, versionAtom) {
+  return rangeAtom.version === versionAtom.version;
+}
+function compare(rangeAtom, versionAtom) {
+  switch (rangeAtom.operator) {
+    case "":
+    case "=":
+      return eq(rangeAtom, versionAtom);
+    case ">":
+      return compareVersion(rangeAtom, versionAtom) < 0;
+    case ">=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) < 0;
+    case "<":
+      return compareVersion(rangeAtom, versionAtom) > 0;
+    case "<=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) > 0;
+    case void 0: {
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+function parseComparatorString(range) {
+  return pipe(
+    parseCarets,
+    parseTildes,
+    parseXRanges,
+    parseStar
+  )(range);
+}
+function parseRange(range) {
+  return pipe(
+    parseHyphen,
+    parseComparatorTrim,
+    parseTildeTrim,
+    parseCaretTrim
+  )(range.trim()).split(/\s+/).join(" ");
+}
+function satisfy(version, range) {
+  if (!version) {
+    return false;
+  }
+  const parsedRange = parseRange(range);
+  const parsedComparator = parsedRange.split(" ").map((rangeVersion) => parseComparatorString(rangeVersion)).join(" ");
+  const comparators = parsedComparator.split(/\s+/).map((comparator2) => parseGTE0(comparator2));
+  const extractedVersion = extractComparator(version);
+  if (!extractedVersion) {
+    return false;
+  }
+  const [
+    ,
+    versionOperator,
+    ,
+    versionMajor,
+    versionMinor,
+    versionPatch,
+    versionPreRelease
+  ] = extractedVersion;
+  const versionAtom = {
+    version: combineVersion(
+      versionMajor,
+      versionMinor,
+      versionPatch,
+      versionPreRelease
+    ),
+    major: versionMajor,
+    minor: versionMinor,
+    patch: versionPatch,
+    preRelease: versionPreRelease == null ? void 0 : versionPreRelease.split(".")
+  };
+  for (const comparator2 of comparators) {
+    const extractedComparator = extractComparator(comparator2);
+    if (!extractedComparator) {
+      return false;
+    }
+    const [
+      ,
+      rangeOperator,
+      ,
+      rangeMajor,
+      rangeMinor,
+      rangePatch,
+      rangePreRelease
+    ] = extractedComparator;
+    const rangeAtom = {
+      operator: rangeOperator,
+      version: combineVersion(
+        rangeMajor,
+        rangeMinor,
+        rangePatch,
+        rangePreRelease
+      ),
+      major: rangeMajor,
+      minor: rangeMinor,
+      patch: rangePatch,
+      preRelease: rangePreRelease == null ? void 0 : rangePreRelease.split(".")
+    };
+    if (!compare(rangeAtom, versionAtom)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// eslint-disable-next-line no-undef
+const moduleMap = {};
+const moduleCache = Object.create(null);
+async function importShared(name, shareScope = 'default') {
+  return moduleCache[name]
+    ? new Promise((r) => r(moduleCache[name]))
+    : (await getSharedFromRuntime(name, shareScope)) || getSharedFromLocal(name)
+}
+async function getSharedFromRuntime(name, shareScope) {
+  let module = null;
+  if (globalThis?.__federation_shared__?.[shareScope]?.[name]) {
+    const versionObj = globalThis.__federation_shared__[shareScope][name];
+    const requiredVersion = moduleMap[name]?.requiredVersion;
+    const hasRequiredVersion = !!requiredVersion;
+    if (hasRequiredVersion) {
+      const versionKey = Object.keys(versionObj).find((version) =>
+        satisfy(version, requiredVersion)
+      );
+      if (versionKey) {
+        const versionValue = versionObj[versionKey];
+        module = await (await versionValue.get())();
+      } else {
+        console.log(
+          `provider support ${name}(${versionKey}) is not satisfied requiredVersion(\${moduleMap[name].requiredVersion})`
+        );
+      }
+    } else {
+      const versionKey = Object.keys(versionObj)[0];
+      const versionValue = versionObj[versionKey];
+      module = await (await versionValue.get())();
+    }
+  }
+  if (module) {
+    return flattenModule(module, name)
+  }
+}
+async function getSharedFromLocal(name) {
+  if (moduleMap[name]?.import) {
+    let module = await (await moduleMap[name].get())();
+    return flattenModule(module, name)
+  } else {
+    console.error(
+      `consumer config import=false,so cant use callback shared module`
+    );
+  }
+}
+function flattenModule(module, name) {
+  // use a shared module which export default a function will getting error 'TypeError: xxx is not a function'
+  if (typeof module.default === 'function') {
+    Object.keys(module).forEach((key) => {
+      if (key !== 'default') {
+        module.default[key] = module[key];
+      }
+    });
+    moduleCache[name] = module.default;
+    return module.default
+  }
+  if (module.default) module = Object.assign({}, module.default, module);
+  moduleCache[name] = module;
+  return module
+}
+
+export { importShared, getSharedFromLocal as importSharedLocal, getSharedFromRuntime as importSharedRuntime };

--- a/plugins.v2/storagecleanup/dist/v1.0.2/assets/_plugin-vue_export-helper-pcqpp-6-.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.2/assets/_plugin-vue_export-helper-pcqpp-6-.js
@@ -1,0 +1,9 @@
+const _export_sfc = (sfc, props) => {
+  const target = sfc.__vccOpts || sfc;
+  for (const [key, val] of props) {
+    target[key] = val;
+  }
+  return target;
+};
+
+export { _export_sfc as _ };

--- a/plugins.v2/storagecleanup/dist/v1.0.2/assets/index-CWyMuSES.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.2/assets/index-CWyMuSES.js
@@ -1,0 +1,44 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage from './__federation_expose_AppPage-jF88PUVl.js';
+
+true              &&(function polyfill() {
+  const relList = document.createElement("link").relList;
+  if (relList && relList.supports && relList.supports("modulepreload")) {
+    return;
+  }
+  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+    processPreload(link);
+  }
+  new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type !== "childList") {
+        continue;
+      }
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === "LINK" && node.rel === "modulepreload")
+          processPreload(node);
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  function getFetchOpts(link) {
+    const fetchOpts = {};
+    if (link.integrity) fetchOpts.integrity = link.integrity;
+    if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
+    if (link.crossOrigin === "use-credentials")
+      fetchOpts.credentials = "include";
+    else if (link.crossOrigin === "anonymous") fetchOpts.credentials = "omit";
+    else fetchOpts.credentials = "same-origin";
+    return fetchOpts;
+  }
+  function processPreload(link) {
+    if (link.ep)
+      return;
+    link.ep = true;
+    const fetchOpts = getFetchOpts(link);
+    fetch(link.href, fetchOpts);
+  }
+}());
+
+const {createApp} = await importShared('vue');
+
+createApp(AppPage).mount('#app');

--- a/plugins.v2/storagecleanup/dist/v1.0.2/assets/remoteEntry.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.2/assets/remoteEntry.js
@@ -2,14 +2,14 @@ const currentImports = {};
       const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
       let moduleMap = {
 "./AppPage":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './AppPage');
-      return __federation_import('./__federation_expose_AppPage-WrNLRDkU.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-BKy-poVd.css"], false, './AppPage');
+      return __federation_import('./__federation_expose_AppPage-jF88PUVl.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Page":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './Page');
-      return __federation_import('./__federation_expose_Page-DAUTopwb.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-BKy-poVd.css"], false, './Page');
+      return __federation_import('./__federation_expose_Page-D7goqImm.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Config":()=>{
-      dynamicLoadingCss(["__federation_expose_Config-BHIxEI63.css"], false, './Config');
-      return __federation_import('./__federation_expose_Config-BlunJQWM.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
+      dynamicLoadingCss(["__federation_expose_Config-SYLmVfvj.css"], false, './Config');
+      return __federation_import('./__federation_expose_Config-jwIyjrQZ.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
       const seen = {};
       const dynamicLoadingCss = (cssFilePaths, dontAppendStylesToHead, exposeItemName) => {
         const metaUrl = import.meta.url;
@@ -48,7 +48,7 @@ const currentImports = {};
          } else {
            href = cssPath;
          }
-         
+
           if (dontAppendStylesToHead) {
             const key = 'css__StorageCleanup__' + exposeItemName;
             window[key] = window[key] || [];

--- a/plugins.v2/storagecleanup/dist/v1.0.2/index.html
+++ b/plugins.v2/storagecleanup/dist/v1.0.2/index.html
@@ -1,0 +1,6 @@
+<script type="module" crossorigin src="/assets/index-CWyMuSES.js"></script>
+<link rel="modulepreload" crossorigin href="/assets/__federation_fn_import-JrT3xvdd.js">
+<link rel="modulepreload" crossorigin href="/assets/_plugin-vue_export-helper-pcqpp-6-.js">
+<link rel="modulepreload" crossorigin href="/assets/__federation_expose_AppPage-jF88PUVl.js">
+<link rel="stylesheet" crossorigin href="/assets/__federation_expose_AppPage-BKy-poVd.css">
+<div id="app"></div>

--- a/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_expose_AppPage-B6tAG2vu.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_expose_AppPage-B6tAG2vu.css
@@ -1,0 +1,604 @@
+
+.cleanup-app[data-v-55ee4f66], .action-bar[data-v-55ee4f66], .modal-backdrop[data-v-55ee4f66] {
+  --ink: rgb(var(--v-theme-on-background, 30, 41, 59));
+  --muted: rgba(var(--v-theme-on-background, 30, 41, 59), .58);
+  --line: rgba(var(--v-border-color, 100, 116, 139), .18);
+  --surface: rgb(var(--v-theme-surface, 255, 255, 255));
+  --primary: rgb(var(--v-theme-primary, 59, 130, 246));
+  --primary-soft: rgba(var(--v-theme-primary, 59, 130, 246), .10);
+  --good: #16836b;
+  --warn: #b86b11;
+  --danger: #c44b47;
+}
+.cleanup-app[data-v-55ee4f66] {
+  color: var(--ink);
+  min-width: 980px;
+  padding: 18px 24px 110px;
+}
+button[data-v-55ee4f66], input[data-v-55ee4f66] { font: inherit;
+}
+button[data-v-55ee4f66] { color: inherit;
+}
+.page-header[data-v-55ee4f66] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+.eyebrow[data-v-55ee4f66] { margin: 0 0 4px; color: var(--primary); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase;
+}
+.page-header h1[data-v-55ee4f66] { margin: 0; font-size: 30px; line-height: 1.2;
+}
+.page-header > div > span[data-v-55ee4f66] { color: var(--muted); font-size: 14px;
+}
+.status-card[data-v-55ee4f66] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 220px;
+  padding: 10px 14px;
+  border: 1px solid rgba(22, 131, 107, .22);
+  border-radius: 12px;
+  background: rgba(22, 131, 107, .08);
+}
+.status-card.danger[data-v-55ee4f66] { border-color: rgba(196, 75, 71, .24); background: rgba(196, 75, 71, .08);
+}
+.status-card i[data-v-55ee4f66], .notice i[data-v-55ee4f66], .safety-note i[data-v-55ee4f66] {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  background: rgba(22, 131, 107, .12);
+  color: var(--good);
+  font-style: normal;
+  font-weight: 900;
+}
+.status-card p[data-v-55ee4f66], .notice p[data-v-55ee4f66], .safety-note p[data-v-55ee4f66], .plan-resources p[data-v-55ee4f66], .gap-row p[data-v-55ee4f66], .recovery-row p[data-v-55ee4f66] { display: grid; gap: 2px; margin: 0;
+}
+.status-card strong[data-v-55ee4f66] { font-size: 13px;
+}
+.status-card span[data-v-55ee4f66] { color: var(--muted); font-size: 12px;
+}
+.toolbar[data-v-55ee4f66] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.search[data-v-55ee4f66] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  height: 46px;
+  padding: 0 15px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+}
+.search span[data-v-55ee4f66] { color: var(--muted); font-size: 21px;
+}
+.search input[data-v-55ee4f66] { width: 100%; border: 0; outline: 0; color: inherit; background: transparent; font-size: 15px;
+}
+.safe-toggle[data-v-55ee4f66] { display: flex; align-items: center; gap: 8px; height: 44px; white-space: nowrap; font-size: 14px; font-weight: 650;
+}
+.safe-toggle input[data-v-55ee4f66], .risk-check input[data-v-55ee4f66] { position: absolute; opacity: 0;
+}
+.safe-toggle > span[data-v-55ee4f66] {
+  width: 38px;
+  height: 22px;
+  padding: 3px;
+  border-radius: 99px;
+  background: rgba(100, 116, 139, .24);
+}
+.safe-toggle > span[data-v-55ee4f66]::after { display: block; width: 16px; height: 16px; border-radius: 50%; background: white; content: ''; transition: .2s;
+}
+.safe-toggle input:checked + span[data-v-55ee4f66] { background: var(--primary);
+}
+.safe-toggle input:checked + span[data-v-55ee4f66]::after { transform: translateX(16px);
+}
+.soft-button[data-v-55ee4f66], .icon-button[data-v-55ee4f66] {
+  height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: var(--surface);
+  cursor: pointer;
+}
+.soft-button[data-v-55ee4f66] { padding: 0 14px;
+}
+.icon-button[data-v-55ee4f66] { width: 42px; font-size: 20px;
+}
+.notice[data-v-55ee4f66] {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin: 0 0 14px;
+  padding: 12px 16px;
+  border: 1px solid rgba(184, 107, 17, .22);
+  border-radius: 12px;
+  background: rgba(184, 107, 17, .07);
+  text-align: left;
+  cursor: pointer;
+}
+.notice p[data-v-55ee4f66] { flex: 1;
+}
+.notice p span[data-v-55ee4f66] { color: var(--muted); font-size: 13px;
+}
+.notice b[data-v-55ee4f66] { color: var(--warn); font-size: 13px;
+}
+.notice.critical[data-v-55ee4f66] { border-color: rgba(196, 75, 71, .25); background: rgba(196, 75, 71, .08);
+}
+.notice.critical b[data-v-55ee4f66] { color: var(--danger);
+}
+.filters[data-v-55ee4f66] { display: flex; gap: 6px; margin-bottom: 12px;
+}
+.filters button[data-v-55ee4f66] {
+  padding: 8px 13px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.filters button.active[data-v-55ee4f66] { border-color: var(--line); background: var(--surface); color: var(--ink); font-weight: 750; box-shadow: 0 4px 12px rgba(15, 23, 42, .04);
+}
+.filters span[data-v-55ee4f66] { margin-left: 5px; padding: 2px 6px; border-radius: 99px; background: rgba(100, 116, 139, .10); font-size: 11px;
+}
+.resource-card[data-v-55ee4f66] { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--surface);
+}
+.table-head[data-v-55ee4f66], .resource-row[data-v-55ee4f66] {
+  display: grid;
+  grid-template-columns: 42px minmax(270px, 1.55fr) minmax(170px, .85fr) minmax(360px, 1.65fr) minmax(125px, .65fr) minmax(230px, 1fr);
+  align-items: center;
+}
+.table-head[data-v-55ee4f66] { min-height: 50px; padding: 0 16px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 12px; font-weight: 800;
+}
+.resource-row[data-v-55ee4f66] { min-height: 126px; padding: 0 16px; border-bottom: 1px solid var(--line);
+}
+.resource-row[data-v-55ee4f66]:last-child { border-bottom: 0;
+}
+.resource-row.selected[data-v-55ee4f66] { background: var(--primary-soft);
+}
+.select-all[data-v-55ee4f66], .row-check[data-v-55ee4f66] {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid rgba(100, 116, 139, .35);
+  border-radius: 7px;
+  background: transparent;
+  cursor: pointer;
+}
+.row-check.locked[data-v-55ee4f66] { border-color: rgba(184, 107, 17, .25); background: rgba(184, 107, 17, .08); color: var(--warn); font-size: 10px; cursor: not-allowed;
+}
+.resource-title[data-v-55ee4f66], .stack-cell[data-v-55ee4f66] { display: grid; gap: 4px; min-width: 0; padding-right: 16px;
+}
+.resource-title strong[data-v-55ee4f66] { font-size: 17px;
+}
+.resource-title b[data-v-55ee4f66] { overflow: hidden; color: var(--ink); font-size: 13px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; opacity: .78;
+}
+.resource-title span[data-v-55ee4f66], .stack-cell span[data-v-55ee4f66], .impact span[data-v-55ee4f66], .seed-task span[data-v-55ee4f66] { color: var(--muted); font-size: 12px; line-height: 1.45;
+}
+.stack-cell strong[data-v-55ee4f66] { font-size: 14px;
+}
+.stack-cell.library strong[data-v-55ee4f66] { color: var(--good);
+}
+.stack-cell.size strong[data-v-55ee4f66] { font-size: 16px;
+}
+.seed-cell[data-v-55ee4f66] { display: grid; gap: 4px; padding-right: 18px;
+}
+.seed-task[data-v-55ee4f66] {
+  display: grid;
+  grid-template-columns: 62px minmax(72px, auto) minmax(100px, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding-left: 8px;
+  border-left: 2px solid rgba(100, 116, 139, .28);
+}
+.seed-task i[data-v-55ee4f66] { padding: 4px 8px; border-radius: 99px; background: rgba(100, 116, 139, .1); font-size: 11px; font-style: normal; font-weight: 800; text-align: center; white-space: nowrap;
+}
+.seed-task strong[data-v-55ee4f66] { font-size: 13px;
+}
+.seed-task.warning[data-v-55ee4f66] { border-color: rgba(184, 107, 17, .45);
+}
+.seed-task.warning i[data-v-55ee4f66] { color: var(--warn); background: rgba(184, 107, 17, .1);
+}
+.seed-task.protected[data-v-55ee4f66] { border-color: rgba(196, 75, 71, .45);
+}
+.seed-task.protected i[data-v-55ee4f66] { color: var(--danger); background: rgba(196, 75, 71, .1);
+}
+.impact[data-v-55ee4f66] { display: grid; gap: 4px; padding-left: 10px; border-left: 2px solid rgba(22, 131, 107, .35);
+}
+.impact strong[data-v-55ee4f66] { font-size: 13px;
+}
+.impact.danger[data-v-55ee4f66] { border-color: rgba(196, 75, 71, .5);
+}
+.impact.danger strong[data-v-55ee4f66] { color: var(--danger);
+}
+.empty-state[data-v-55ee4f66] { display: grid; place-items: center; min-height: 150px; color: var(--muted);
+}
+.action-bar[data-v-55ee4f66] {
+  position: fixed;
+  z-index: 20;
+  right: 30px;
+  bottom: 22px;
+  left: calc(var(--v-layout-left, 0px) + 30px);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, .14);
+  border-radius: 16px;
+  background: #17243a;
+  color: white;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, .28);
+}
+.selected-count[data-v-55ee4f66] { display: grid; place-items: center; width: 44px; height: 44px; border-radius: 12px; background: #3f70b7; font-size: 18px; font-weight: 900;
+}
+.action-bar > p[data-v-55ee4f66] { display: grid; gap: 1px; min-width: 160px; margin: 0;
+}
+.action-bar > p span[data-v-55ee4f66], .action-level span[data-v-55ee4f66] { color: rgba(255, 255, 255, .64); font-size: 11px;
+}
+.clear-button[data-v-55ee4f66] { border: 0; background: transparent; color: rgba(255, 255, 255, .66); cursor: pointer;
+}
+.action-buttons[data-v-55ee4f66] { display: contents;
+}
+.action-level[data-v-55ee4f66] { display: grid; flex: 1; gap: 3px; padding: 10px 14px; border: 1px solid rgba(255, 255, 255, .17); border-radius: 11px; background: rgba(255, 255, 255, .06); color: white; text-align: left; cursor: pointer;
+}
+.action-level.delete[data-v-55ee4f66] { border-color: rgba(255, 142, 136, .32); background: rgba(196, 75, 71, .28);
+}
+.modal-backdrop[data-v-55ee4f66] {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  background: rgba(15, 23, 42, .55);
+  backdrop-filter: blur(6px);
+}
+.modal[data-v-55ee4f66] {
+  overflow: auto;
+  width: min(760px, 90vw);
+  max-height: 90vh;
+  padding: 24px;
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, .3);
+}
+.modal > header[data-v-55ee4f66] { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 16px;
+}
+.modal > header span[data-v-55ee4f66] { color: var(--primary); font-size: 11px; font-weight: 850; letter-spacing: .08em;
+}
+.modal h2[data-v-55ee4f66] { margin: 3px 0 0; font-size: 24px;
+}
+.modal > header button[data-v-55ee4f66] { width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 10px; background: transparent; font-size: 22px; cursor: pointer;
+}
+.mode-summary[data-v-55ee4f66], .plan-state[data-v-55ee4f66], .safety-note[data-v-55ee4f66] { display: grid; gap: 4px; margin-bottom: 12px; padding: 13px 15px; border-radius: 12px; background: var(--primary-soft);
+}
+.mode-summary span[data-v-55ee4f66], .plan-state span[data-v-55ee4f66], .safety-note span[data-v-55ee4f66] { color: var(--muted); font-size: 12px;
+}
+.mode-summary.delete[data-v-55ee4f66] { background: rgba(196, 75, 71, .08);
+}
+.plan-resources[data-v-55ee4f66] { max-height: 170px; overflow: auto; margin-bottom: 12px; border: 1px solid var(--line); border-radius: 12px;
+}
+.plan-resources > div[data-v-55ee4f66] { display: flex; justify-content: space-between; align-items: center; padding: 10px 13px; border-bottom: 1px solid var(--line);
+}
+.plan-resources > div[data-v-55ee4f66]:last-child { border-bottom: 0;
+}
+.plan-resources span[data-v-55ee4f66] { color: var(--muted); font-size: 11px;
+}
+.plan-state.passed[data-v-55ee4f66] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.plan-state.blocked[data-v-55ee4f66], .issues.blocked[data-v-55ee4f66] { color: var(--danger); background: rgba(196, 75, 71, .08);
+}
+.issues[data-v-55ee4f66] { display: grid; gap: 6px; margin: 0 0 12px; padding: 12px 16px 12px 34px; border-radius: 12px; font-size: 13px;
+}
+.issues.warning[data-v-55ee4f66] { color: var(--warn); background: rgba(184, 107, 17, .08);
+}
+.risk-check[data-v-55ee4f66] { position: relative; display: flex; align-items: center; gap: 9px; margin: 12px 0; font-size: 13px; font-weight: 700;
+}
+.risk-check > span[data-v-55ee4f66] { width: 20px; height: 20px; border: 1px solid rgba(100, 116, 139, .35); border-radius: 6px;
+}
+.risk-check input:checked + span[data-v-55ee4f66] { border-color: var(--primary); background: var(--primary); box-shadow: inset 0 0 0 4px var(--surface);
+}
+.safety-note[data-v-55ee4f66] { display: flex; align-items: center; background: rgba(100, 116, 139, .08);
+}
+.safety-note p[data-v-55ee4f66] { flex: 1;
+}
+.confirm-button[data-v-55ee4f66], .execution-result button[data-v-55ee4f66] {
+  width: 100%;
+  min-height: 46px;
+  border: 0;
+  border-radius: 11px;
+  background: var(--primary);
+  color: white;
+  font-weight: 800;
+  cursor: pointer;
+}
+.confirm-button[data-v-55ee4f66]:disabled { background: rgba(100, 116, 139, .22); color: var(--muted); cursor: not-allowed;
+}
+.final-confirmation[data-v-55ee4f66], .execution-result[data-v-55ee4f66] { display: grid; gap: 10px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.final-confirmation > div[data-v-55ee4f66] { display: flex; gap: 8px;
+}
+.final-confirmation button[data-v-55ee4f66] { flex: 1; min-height: 42px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); cursor: pointer;
+}
+.final-confirmation button.danger[data-v-55ee4f66] { border-color: transparent; background: var(--danger); color: white;
+}
+.error-text[data-v-55ee4f66] { color: var(--danger); font-size: 13px;
+}
+.execution-result[data-v-55ee4f66] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.compact-modal[data-v-55ee4f66] { width: min(650px, 90vw);
+}
+.gap-row[data-v-55ee4f66], .recovery-row[data-v-55ee4f66] { display: flex; align-items: center; gap: 8px; padding: 11px 4px; border-bottom: 1px solid var(--line);
+}
+.gap-row p[data-v-55ee4f66], .recovery-row p[data-v-55ee4f66] { flex: 1;
+}
+.gap-row span[data-v-55ee4f66], .recovery-row span[data-v-55ee4f66] { color: var(--muted); font-size: 11px;
+}
+.gap-row b[data-v-55ee4f66] { font-size: 12px; color: var(--warn);
+}
+.recovery-row button[data-v-55ee4f66], .recovery-confirm button[data-v-55ee4f66] { padding: 7px 10px; border: 1px solid var(--line); border-radius: 8px; background: transparent; cursor: pointer;
+}
+.recovery-confirm[data-v-55ee4f66] { display: grid; gap: 8px; margin-top: 14px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.recovery-confirm input[data-v-55ee4f66] { height: 40px; padding: 0 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); color: inherit;
+}
+@media (max-width: 1250px) {
+.table-head[data-v-55ee4f66], .resource-row[data-v-55ee4f66] {
+    grid-template-columns: 38px minmax(240px, 1.3fr) minmax(150px, .7fr) minmax(310px, 1.35fr) 120px minmax(200px, .9fr);
+}
+}
+@media (max-width: 760px) {
+.cleanup-app[data-v-55ee4f66] {
+    min-width: 0;
+    overflow-x: clip;
+    padding: 14px 12px 190px;
+}
+.page-header[data-v-55ee4f66] {
+    display: grid;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+.eyebrow[data-v-55ee4f66] { font-size: 10px;
+}
+.page-header h1[data-v-55ee4f66] { font-size: 27px;
+}
+.page-header > div > span[data-v-55ee4f66] {
+    display: block;
+    margin-top: 3px;
+    font-size: 12px;
+    line-height: 1.5;
+}
+.status-card[data-v-55ee4f66] {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+}
+.toolbar[data-v-55ee4f66] {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 8px;
+}
+.search[data-v-55ee4f66] {
+    grid-column: 1 / -1;
+    height: 44px;
+    box-sizing: border-box;
+}
+.safe-toggle[data-v-55ee4f66] {
+    min-width: 0;
+    font-size: 12px;
+}
+.soft-button[data-v-55ee4f66] { padding: 0 10px; font-size: 12px;
+}
+.icon-button[data-v-55ee4f66] { width: 40px;
+}
+.notice[data-v-55ee4f66] {
+    align-items: flex-start;
+    padding: 11px 12px;
+}
+.notice p strong[data-v-55ee4f66] { font-size: 14px;
+}
+.notice p span[data-v-55ee4f66] { font-size: 11px;
+}
+.notice b[data-v-55ee4f66] { display: none;
+}
+.filters[data-v-55ee4f66] {
+    overflow-x: auto;
+    width: calc(100vw - 24px);
+    padding: 0 0 4px;
+    scrollbar-width: none;
+}
+.filters[data-v-55ee4f66]::-webkit-scrollbar { display: none;
+}
+.filters button[data-v-55ee4f66] {
+    flex: 0 0 auto;
+    padding: 8px 11px;
+    white-space: nowrap;
+}
+.resource-card[data-v-55ee4f66] {
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+}
+.table-head[data-v-55ee4f66] { display: none;
+}
+.resource-row[data-v-55ee4f66] {
+    grid-template-areas:
+      "check title"
+      ". library"
+      ". seed"
+      ". size"
+      ". impact";
+    grid-template-columns: 34px minmax(0, 1fr);
+    gap: 12px 10px;
+    min-height: 0;
+    margin-bottom: 10px;
+    padding: 15px 13px;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: var(--surface);
+    box-shadow: 0 5px 18px rgba(15, 23, 42, .04);
+}
+.resource-row[data-v-55ee4f66]:last-child { border-bottom: 1px solid var(--line);
+}
+.row-check[data-v-55ee4f66] {
+    grid-area: check;
+    align-self: start;
+    width: 26px;
+    height: 26px;
+}
+.resource-title[data-v-55ee4f66] {
+    grid-area: title;
+    padding-right: 0;
+}
+.resource-title strong[data-v-55ee4f66] { font-size: 16px;
+}
+.resource-title b[data-v-55ee4f66] { font-size: 12px;
+}
+.resource-title span[data-v-55ee4f66] { white-space: normal;
+}
+.stack-cell.library[data-v-55ee4f66] { grid-area: library;
+}
+.seed-cell[data-v-55ee4f66] { grid-area: seed;
+}
+.stack-cell.size[data-v-55ee4f66] { grid-area: size;
+}
+.impact[data-v-55ee4f66] { grid-area: impact;
+}
+.stack-cell[data-v-55ee4f66], .seed-cell[data-v-55ee4f66], .impact[data-v-55ee4f66] {
+    min-width: 0;
+    padding: 10px 0 0;
+    border-top: 1px solid var(--line);
+}
+.stack-cell[data-v-55ee4f66]::before, .seed-cell[data-v-55ee4f66]::before, .impact[data-v-55ee4f66]::before {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--muted);
+    content: attr(data-label);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: .06em;
+}
+.impact[data-v-55ee4f66] {
+    padding-left: 0;
+    border-left: 0;
+}
+.impact.danger[data-v-55ee4f66] { border-left: 0;
+}
+.seed-task[data-v-55ee4f66] {
+    grid-template-columns: 58px minmax(58px, auto) minmax(0, 1fr);
+    gap: 6px;
+    padding-left: 6px;
+}
+.seed-task i[data-v-55ee4f66] { padding: 4px 6px; font-size: 10px;
+}
+.seed-task strong[data-v-55ee4f66] { font-size: 12px;
+}
+.seed-task span[data-v-55ee4f66] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.action-bar[data-v-55ee4f66] {
+    z-index: 2600;
+    right: 10px;
+    bottom: calc(78px + env(safe-area-inset-bottom, 0px));
+    left: 10px;
+    display: grid;
+    grid-template-columns: 38px minmax(0, 1fr) auto;
+    gap: 8px 10px;
+    padding: 10px;
+    border-radius: 15px;
+}
+.selected-count[data-v-55ee4f66] {
+    width: 38px;
+    height: 38px;
+    border-radius: 10px;
+    font-size: 16px;
+}
+.action-bar > p[data-v-55ee4f66] {
+    min-width: 0;
+}
+.action-bar > p strong[data-v-55ee4f66] {
+    overflow: hidden;
+    font-size: 13px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.action-bar > p span[data-v-55ee4f66] { font-size: 10px;
+}
+.clear-button[data-v-55ee4f66] {
+    padding: 0 4px;
+    font-size: 12px;
+}
+.action-buttons[data-v-55ee4f66] {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 7px;
+}
+.action-level[data-v-55ee4f66] {
+    display: block;
+    min-width: 0;
+    min-height: 42px;
+    padding: 9px 5px;
+    text-align: center;
+}
+.action-level strong[data-v-55ee4f66] {
+    display: block;
+    font-size: 13px;
+    white-space: nowrap;
+}
+.action-level span[data-v-55ee4f66] { display: none;
+}
+.modal-backdrop[data-v-55ee4f66] {
+    z-index: 3000;
+    padding:
+      max(12px, env(safe-area-inset-top, 0px))
+      12px
+      max(12px, env(safe-area-inset-bottom, 0px));
+}
+.modal[data-v-55ee4f66], .compact-modal[data-v-55ee4f66] {
+    width: calc(100vw - 24px);
+    max-height: calc(100dvh - 24px);
+    box-sizing: border-box;
+    padding: 16px;
+    border-radius: 16px;
+}
+.modal h2[data-v-55ee4f66] { font-size: 21px;
+}
+.modal > header[data-v-55ee4f66] { margin-bottom: 12px;
+}
+.mode-summary[data-v-55ee4f66], .plan-state[data-v-55ee4f66], .safety-note[data-v-55ee4f66] { padding: 11px 12px;
+}
+.plan-resources[data-v-55ee4f66] { max-height: 120px;
+}
+.plan-resources > div[data-v-55ee4f66] { gap: 8px; padding: 9px 10px;
+}
+.plan-resources p[data-v-55ee4f66] { min-width: 0;
+}
+.plan-resources p span[data-v-55ee4f66] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.issues[data-v-55ee4f66] { padding: 10px 12px 10px 28px; font-size: 12px;
+}
+.final-confirmation > div[data-v-55ee4f66] { display: grid; grid-template-columns: 1fr 1fr;
+}
+.gap-row[data-v-55ee4f66], .recovery-row[data-v-55ee4f66] {
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+.recovery-row p[data-v-55ee4f66] { flex-basis: 100%;
+}
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_expose_AppPage-mb1zO2qt.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_expose_AppPage-mb1zO2qt.js
@@ -1,0 +1,959 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
+
+const FILTERS = [
+  { id: 'all', label: '全部资源' },
+  { id: 'library', label: '媒体库已入库' },
+  { id: 'hr', label: 'H&R 保护中' },
+  { id: 'brush', label: '刷流任务' },
+  { id: 'review', label: '无做种限制' },
+  { id: 'names', label: '名称待核' },
+];
+
+const ACTIONS = {
+  pause: {
+    title: '停止做种',
+    detail: '保留 qB 任务和全部文件',
+  },
+  retire: {
+    title: '退出做种',
+    detail: '移除 qB 任务，媒体仍保留',
+  },
+  delete: {
+    title: '完整删除',
+    detail: '移除任务、媒体和全部链接',
+  },
+};
+
+function unwrapResponse(response) {
+  if (response && Object.prototype.hasOwnProperty.call(response, 'data') && response.success !== undefined) {
+    return response.data
+  }
+  return response?.data ?? response
+}
+
+function matchesFilter(item, filter) {
+  if (filter === 'all') return true
+  if (filter === 'library') return Boolean(item.library)
+  if (filter === 'hr') return Boolean(item.hr || item.hrPending)
+  if (filter === 'brush') return Boolean(item.brush)
+  if (filter === 'review') return !item.protected && item.qbSummary === '无 qB 任务'
+  return item.metadataVerified === false
+}
+
+function isDirectlyCleanable(item) {
+  return !item.protected && item.qbSummary === '无 qB 任务'
+}
+
+function filterResources(resources, { filter, search, safeOnly, descending }) {
+  const query = String(search || '').trim().toLowerCase();
+  return [...(resources || [])]
+    .filter(item => {
+      const text = `${item.title || ''} ${item.englishTitle || ''} ${item.edition || ''} ${item.siteSummary || ''}`.toLowerCase();
+      return matchesFilter(item, filter) &&
+        (!safeOnly || isDirectlyCleanable(item)) &&
+        (!query || text.includes(query))
+    })
+    .sort((left, right) => {
+      const order = descending ? Number(right.size || 0) - Number(left.size || 0) : Number(left.size || 0) - Number(right.size || 0);
+      return order || String(left.title || '').localeCompare(String(right.title || ''), 'zh-CN')
+    })
+}
+
+function formatGiB(size) {
+  const numeric = Number(size || 0);
+  return numeric >= 1024 ? `${(numeric / 1024).toFixed(2)} TB` : `${numeric.toFixed(1)} GB`
+}
+
+function formatBytes(size) {
+  return formatGiB(Number(size || 0) / 1024 ** 3)
+}
+
+function issueKey(issue, index) {
+  return `${issue?.code || 'issue'}-${index}`
+}
+
+const {createElementVNode:_createElementVNode,toDisplayString:_toDisplayString,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,normalizeClass:_normalizeClass,vModelText:_vModelText,withDirectives:_withDirectives,vModelCheckbox:_vModelCheckbox,createTextVNode:_createTextVNode,renderList:_renderList,Fragment:_Fragment,unref:_unref,withModifiers:_withModifiers,Teleport:_Teleport,createBlock:_createBlock} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "cleanup-app" };
+const _hoisted_2 = {
+  key: 0,
+  class: "page-header"
+};
+const _hoisted_3 = { key: 0 };
+const _hoisted_4 = { class: "toolbar" };
+const _hoisted_5 = { class: "search" };
+const _hoisted_6 = { class: "safe-toggle" };
+const _hoisted_7 = ["disabled"];
+const _hoisted_8 = {
+  class: "filters",
+  "aria-label": "资源筛选"
+};
+const _hoisted_9 = ["onClick"];
+const _hoisted_10 = { class: "resource-card" };
+const _hoisted_11 = { class: "table-head" };
+const _hoisted_12 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_13 = ["disabled", "onClick"];
+const _hoisted_14 = { class: "resource-title" };
+const _hoisted_15 = {
+  class: "stack-cell library",
+  "data-label": "媒体库"
+};
+const _hoisted_16 = {
+  class: "seed-cell",
+  "data-label": "做种与保护"
+};
+const _hoisted_17 = {
+  key: 1,
+  class: "stack-cell"
+};
+const _hoisted_18 = {
+  class: "stack-cell size",
+  "data-label": "实际占用"
+};
+const _hoisted_19 = {
+  key: 2,
+  class: "empty-state"
+};
+const _hoisted_20 = {
+  key: 0,
+  class: "action-bar"
+};
+const _hoisted_21 = { class: "selected-count" };
+const _hoisted_22 = { class: "action-buttons" };
+const _hoisted_23 = ["onClick"];
+const _hoisted_24 = {
+  class: "modal plan-modal",
+  role: "dialog",
+  "aria-modal": "true"
+};
+const _hoisted_25 = ["disabled"];
+const _hoisted_26 = { key: 0 };
+const _hoisted_27 = { key: 1 };
+const _hoisted_28 = { class: "plan-resources" };
+const _hoisted_29 = {
+  key: 0,
+  class: "plan-state"
+};
+const _hoisted_30 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_31 = {
+  key: 0,
+  class: "issues blocked"
+};
+const _hoisted_32 = {
+  key: 1,
+  class: "issues warning"
+};
+const _hoisted_33 = {
+  key: 2,
+  class: "risk-check"
+};
+const _hoisted_34 = ["checked"];
+const _hoisted_35 = {
+  key: 3,
+  class: "plan-state blocked"
+};
+const _hoisted_36 = { class: "safety-note" };
+const _hoisted_37 = {
+  key: 3,
+  class: "execution-result"
+};
+const _hoisted_38 = {
+  key: 4,
+  class: "final-confirmation"
+};
+const _hoisted_39 = {
+  key: 0,
+  class: "error-text"
+};
+const _hoisted_40 = ["disabled"];
+const _hoisted_41 = ["disabled"];
+const _hoisted_42 = ["disabled"];
+const _hoisted_43 = { class: "modal compact-modal" };
+const _hoisted_44 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_45 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_46 = { class: "modal compact-modal" };
+const _hoisted_47 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_48 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_49 = ["onClick"];
+const _hoisted_50 = ["onClick"];
+const _hoisted_51 = {
+  key: 2,
+  class: "recovery-confirm"
+};
+const _hoisted_52 = ["disabled"];
+
+const {computed,onMounted,ref} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'AppPage',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+  hideTitle: { type: Boolean, default: false },
+},
+  setup(__props) {
+
+const props = __props;
+
+const emptySnapshot = {
+  schemaVersion: 2,
+  snapshotId: '',
+  generatedAt: '',
+  stats: {},
+  resources: [],
+};
+
+const snapshot = ref(emptySnapshot);
+const health = ref({});
+const loading = ref(true);
+const refreshing = ref(false);
+const error = ref('');
+const search = ref('');
+const activeFilter = ref('all');
+const safeOnly = ref(false);
+const descending = ref(true);
+const selected = ref([]);
+
+const planOpen = ref(false);
+const planMode = ref(null);
+const plan = ref(null);
+const planLoading = ref(false);
+const planError = ref('');
+const acknowledgeSiteRisk = ref(false);
+const finalConfirmation = ref(false);
+const executing = ref(false);
+const executeError = ref('');
+const executeResult = ref(null);
+
+const gapOpen = ref(false);
+const gapLoading = ref(false);
+const gaps = ref([]);
+const gapError = ref('');
+
+const recoveryOpen = ref(false);
+const recoveryLoading = ref(false);
+const recoveries = ref([]);
+const recoveryError = ref('');
+const recoveryTarget = ref(null);
+const recoveryAction = ref(null);
+const recoveryPhrase = ref('');
+const recovering = ref(false);
+
+const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`);
+const resources = computed(() => snapshot.value.resources || []);
+const visible = computed(() => filterResources(resources.value, {
+  filter: activeFilter.value,
+  search: search.value,
+  safeOnly: safeOnly.value,
+  descending: descending.value,
+}));
+const selectedItems = computed(() => resources.value.filter(item => selected.value.includes(item.id)));
+const selectedSize = computed(() => selectedItems.value.reduce((total, item) => total + Number(item.size || 0), 0));
+const executionEnabled = computed(() => Boolean(health.value.executionEnabled));
+const inventoryCurrent = computed(() => health.value.inventoryCurrent !== false);
+const unresolvedTransactions = computed(() => Number(snapshot.value.stats?.unresolvedTransactions || 0));
+const hrGap = computed(() => Math.max(
+  0,
+  Number(
+    snapshot.value.stats?.hrMissingQbTasks ??
+    Number(snapshot.value.stats?.hrActiveTitles || 0) - Number(snapshot.value.stats?.hrMatchedQbTasks || 0),
+  ),
+));
+const hrUnassigned = computed(() => Number(
+  snapshot.value.stats?.hrMissingUnassigned ??
+  snapshot.value.stats?.hrMissingUncovered ??
+  0,
+));
+const filters = computed(() => FILTERS.map(filter => ({
+  ...filter,
+  count: resources.value.filter(item => {
+    if (filter.id === 'all') return true
+    return filterResources([item], {
+      filter: filter.id,
+      search: '',
+      safeOnly: false,
+      descending: true,
+    }).length === 1
+  }).length,
+})));
+const allVisibleSelected = computed(() => {
+  const selectable = visible.value.filter(item => !item.protected);
+  return selectable.length > 0 && selectable.every(item => selected.value.includes(item.id))
+});
+const currentAction = computed(() => planMode.value ? ACTIONS[planMode.value] : null);
+const planExpired = computed(() => Boolean(plan.value && Date.parse(plan.value.expiresAt) <= Date.now()));
+
+function payloadError(payload, fallback) {
+  return payload?.error?.message || fallback
+}
+
+async function get(path) {
+  return unwrapResponse(await props.api.get(`${pluginBase.value}${path}`))
+}
+
+async function post(path, body) {
+  return unwrapResponse(await props.api.post(`${pluginBase.value}${path}`, body))
+}
+
+function acceptSnapshot(next) {
+  if (!next || next.schemaVersion !== 2 || !next.snapshotId || !Array.isArray(next.resources)) {
+    throw new Error('资源快照格式不受支持。')
+  }
+  snapshot.value = next;
+  const available = new Set(next.resources.map(item => item.id));
+  selected.value = selected.value.filter(id => available.has(id));
+}
+
+async function loadStatus() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const payload = await get('/status');
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '无法读取清理台状态。'))
+    health.value = payload.health || {};
+    acceptSnapshot(payload.snapshot);
+  } catch (err) {
+    error.value = err?.message || '无法读取清理台状态。';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function refreshSnapshot() {
+  refreshing.value = true;
+  error.value = '';
+  try {
+    const payload = await post('/refresh', {});
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '刷新失败。'))
+    acceptSnapshot(payload.snapshot);
+    health.value = { ...health.value, inventoryCurrent: true };
+  } catch (err) {
+    error.value = err?.message || '刷新失败，继续显示上次快照。';
+    health.value = { ...health.value, inventoryCurrent: false };
+  } finally {
+    refreshing.value = false;
+  }
+}
+
+function toggle(item) {
+  if (item.protected) return
+  selected.value = selected.value.includes(item.id)
+    ? selected.value.filter(id => id !== item.id)
+    : [...selected.value, item.id];
+}
+
+function toggleVisible() {
+  const ids = visible.value.filter(item => !item.protected).map(item => item.id);
+  selected.value = allVisibleSelected.value
+    ? selected.value.filter(id => !ids.includes(id))
+    : [...new Set([...selected.value, ...ids])];
+}
+
+async function requestPlan(mode, acknowledged = false) {
+  planLoading.value = true;
+  planError.value = '';
+  plan.value = null;
+  finalConfirmation.value = false;
+  try {
+    const payload = await post('/plan', {
+      snapshotId: snapshot.value.snapshotId,
+      resourceIds: selected.value,
+      mode,
+      acknowledgeSiteRisk: acknowledged,
+    });
+    if (!payload?.ok || !payload.plan) throw new Error(payloadError(payload, '无法生成执行计划。'))
+    plan.value = payload.plan;
+  } catch (err) {
+    planError.value = err?.message || '无法生成执行计划。';
+  } finally {
+    planLoading.value = false;
+  }
+}
+
+function openPlan(mode) {
+  planMode.value = mode;
+  planOpen.value = true;
+  acknowledgeSiteRisk.value = false;
+  executeResult.value = null;
+  executeError.value = '';
+  requestPlan(mode, false);
+}
+
+function closePlan() {
+  if (executing.value) return
+  planOpen.value = false;
+  planMode.value = null;
+  plan.value = null;
+  planError.value = '';
+  finalConfirmation.value = false;
+  executeResult.value = null;
+}
+
+async function setSiteRisk(value) {
+  acknowledgeSiteRisk.value = value;
+  await requestPlan(planMode.value, value);
+}
+
+async function executePlan() {
+  if (!plan.value || planExpired.value || executing.value) return
+  executing.value = true;
+  executeError.value = '';
+  try {
+    const payload = await post('/execute', {
+      planId: plan.value.planId,
+      confirmPhrase: plan.value.confirmPhrase,
+    });
+    if (!payload?.ok || !payload.result) {
+      if (payload?.error?.plan) plan.value = payload.error.plan;
+      throw new Error(payloadError(payload, '执行失败。'))
+    }
+    executeResult.value = payload.result;
+    selected.value = [];
+    if (payload.result.snapshotRefreshPending) {
+      health.value = { ...health.value, inventoryCurrent: false };
+    } else {
+      const latest = await get('/snapshot');
+      if (latest?.snapshot) acceptSnapshot(latest.snapshot);
+    }
+  } catch (err) {
+    executeError.value = err?.message || '执行失败。';
+    finalConfirmation.value = false;
+  } finally {
+    executing.value = false;
+  }
+}
+
+async function loadGaps() {
+  gapOpen.value = true;
+  gapLoading.value = true;
+  gapError.value = '';
+  try {
+    const payload = await get('/protection-gaps');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取 H&R 缺口。'))
+    gaps.value = payload.gaps || [];
+  } catch (err) {
+    gapError.value = err?.message || '无法读取 H&R 缺口。';
+  } finally {
+    gapLoading.value = false;
+  }
+}
+
+async function loadRecoveries() {
+  recoveryOpen.value = true;
+  recoveryLoading.value = true;
+  recoveryError.value = '';
+  recoveryTarget.value = null;
+  try {
+    const payload = await get('/recovery');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取恢复状态。'))
+    recoveries.value = payload.recoveries || [];
+  } catch (err) {
+    recoveryError.value = err?.message || '无法读取恢复状态。';
+  } finally {
+    recoveryLoading.value = false;
+  }
+}
+
+function chooseRecovery(item, action) {
+  recoveryTarget.value = item;
+  recoveryAction.value = action;
+  recoveryPhrase.value = '';
+  recoveryError.value = '';
+}
+
+async function runRecovery() {
+  if (!recoveryTarget.value || !recoveryAction.value || recovering.value) return
+  recovering.value = true;
+  recoveryError.value = '';
+  try {
+    const payload = await post('/recovery', {
+      planId: recoveryTarget.value.planId,
+      action: recoveryAction.value,
+      confirmPhrase: recoveryPhrase.value,
+    });
+    if (!payload?.ok) throw new Error(payloadError(payload, '恢复操作失败。'))
+    await refreshSnapshot();
+    await loadRecoveries();
+  } catch (err) {
+    recoveryError.value = err?.message || '恢复操作失败。';
+  } finally {
+    recovering.value = false;
+  }
+}
+
+function recoveryExpectedPhrase() {
+  if (!recoveryTarget.value || !recoveryAction.value) return ''
+  return recoveryAction.value === 'rollback'
+    ? recoveryTarget.value.rollbackPhrase
+    : recoveryTarget.value.finalizePhrase
+}
+
+onMounted(loadStatus);
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("main", _hoisted_1, [
+    (!__props.hideTitle)
+      ? (_openBlock(), _createElementBlock("header", _hoisted_2, [
+          _cache[12] || (_cache[12] = _createElementVNode("div", null, [
+            _createElementVNode("p", { class: "eyebrow" }, "PiNAS · MoviePilot 原生页面"),
+            _createElementVNode("h1", null, "存储清理"),
+            _createElementVNode("span", null, "一部电影一行，一部剧一行；先看清影响，再选择清理等级。")
+          ], -1)),
+          _createElementVNode("div", {
+            class: _normalizeClass(['status-card', { danger: error.value || !inventoryCurrent.value }])
+          }, [
+            _createElementVNode("i", null, _toDisplayString(error.value || !inventoryCurrent.value ? '!' : '✓'), 1),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(error.value || (executionEnabled.value ? '执行链路已连接' : '只读模式')), 1),
+              (snapshot.value.generatedAt)
+                ? (_openBlock(), _createElementBlock("span", _hoisted_3, "更新于 " + _toDisplayString(snapshot.value.generatedAt.slice(5, 16).replace('T', ' ')), 1))
+                : _createCommentVNode("", true)
+            ])
+          ], 2)
+        ]))
+      : _createCommentVNode("", true),
+    _createElementVNode("section", _hoisted_4, [
+      _createElementVNode("label", _hoisted_5, [
+        _cache[13] || (_cache[13] = _createElementVNode("span", null, "⌕", -1)),
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((search).value = $event)),
+          "aria-label": "搜索资源",
+          placeholder: "搜索电影、剧集、季度或站点"
+        }, null, 512), [
+          [_vModelText, search.value]
+        ])
+      ]),
+      _createElementVNode("label", _hoisted_6, [
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[1] || (_cache[1] = $event => ((safeOnly).value = $event)),
+          type: "checkbox"
+        }, null, 512), [
+          [_vModelCheckbox, safeOnly.value]
+        ]),
+        _cache[14] || (_cache[14] = _createElementVNode("span", null, null, -1)),
+        _cache[15] || (_cache[15] = _createTextVNode(" 仅看无做种限制 ", -1))
+      ]),
+      _createElementVNode("button", {
+        class: "soft-button",
+        type: "button",
+        onClick: _cache[2] || (_cache[2] = $event => (descending.value = !descending.value))
+      }, " 实际占用 " + _toDisplayString(descending.value ? '↓' : '↑'), 1),
+      _createElementVNode("button", {
+        class: "icon-button",
+        type: "button",
+        disabled: refreshing.value,
+        onClick: refreshSnapshot
+      }, _toDisplayString(refreshing.value ? '…' : '↻'), 9, _hoisted_7)
+    ]),
+    (unresolvedTransactions.value)
+      ? (_openBlock(), _createElementBlock("button", {
+          key: 1,
+          class: "notice critical",
+          type: "button",
+          onClick: loadRecoveries
+        }, [
+          _cache[17] || (_cache[17] = _createElementVNode("i", null, "!", -1)),
+          _createElementVNode("p", null, [
+            _createElementVNode("strong", null, _toDisplayString(unresolvedTransactions.value) + " 个未完成清理事务", 1),
+            _cache[16] || (_cache[16] = _createElementVNode("span", null, "新操作已锁定；请先核对并恢复原事务。", -1))
+          ]),
+          _cache[18] || (_cache[18] = _createElementVNode("b", null, "查看恢复状态", -1))
+        ]))
+      : (hrGap.value)
+        ? (_openBlock(), _createElementBlock("button", {
+            key: 2,
+            class: _normalizeClass(['notice', { warning: hrUnassigned.value }]),
+            type: "button",
+            onClick: loadGaps
+          }, [
+            _cache[19] || (_cache[19] = _createElementVNode("i", null, "H", -1)),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(hrGap.value) + " 个学校站 H&R 尚未恢复完成", 1),
+              _createElementVNode("span", null, _toDisplayString(hrUnassigned.value
+            ? `${hrUnassigned.value} 个未精确关联媒体；不会锁定无关资源。`
+            : '缺失任务只锁定精确关联资源，其他资源可独立清理。'), 1)
+            ]),
+            _cache[20] || (_cache[20] = _createElementVNode("b", null, "查看明细", -1))
+          ], 2))
+        : _createCommentVNode("", true),
+    _createElementVNode("nav", _hoisted_8, [
+      (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(filters.value, (filter) => {
+        return (_openBlock(), _createElementBlock("button", {
+          key: filter.id,
+          class: _normalizeClass({ active: activeFilter.value === filter.id }),
+          type: "button",
+          onClick: $event => (activeFilter.value = filter.id)
+        }, [
+          _createTextVNode(_toDisplayString(filter.label) + " ", 1),
+          _createElementVNode("span", null, _toDisplayString(filter.count), 1)
+        ], 10, _hoisted_9))
+      }), 128))
+    ]),
+    _createElementVNode("section", _hoisted_10, [
+      _createElementVNode("div", _hoisted_11, [
+        _createElementVNode("button", {
+          class: "select-all",
+          type: "button",
+          onClick: toggleVisible
+        }, _toDisplayString(allVisibleSelected.value ? '✓' : ''), 1),
+        _cache[21] || (_cache[21] = _createElementVNode("span", null, "资源", -1)),
+        _cache[22] || (_cache[22] = _createElementVNode("span", null, "媒体库", -1)),
+        _cache[23] || (_cache[23] = _createElementVNode("span", null, "做种与保护", -1)),
+        _cache[24] || (_cache[24] = _createElementVNode("span", null, "实际占用", -1)),
+        _cache[25] || (_cache[25] = _createElementVNode("span", null, "完整删除影响", -1))
+      ]),
+      (loading.value)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_12, "正在读取真实资源关系…"))
+        : (_openBlock(true), _createElementBlock(_Fragment, { key: 1 }, _renderList(visible.value, (item) => {
+            return (_openBlock(), _createElementBlock("article", {
+              key: item.id,
+              class: _normalizeClass(['resource-row', { selected: selected.value.includes(item.id) }])
+            }, [
+              _createElementVNode("button", {
+                class: _normalizeClass(['row-check', { locked: item.protected }]),
+                type: "button",
+                disabled: item.protected,
+                onClick: $event => (toggle(item))
+              }, _toDisplayString(item.protected ? '锁' : selected.value.includes(item.id) ? '✓' : ''), 11, _hoisted_13),
+              _createElementVNode("div", _hoisted_14, [
+                _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                _createElementVNode("b", null, _toDisplayString(item.englishTitle), 1),
+                _createElementVNode("span", null, _toDisplayString([item.type, item.year, item.edition].filter(Boolean).join(' · ')), 1)
+              ]),
+              _createElementVNode("div", _hoisted_15, [
+                _createElementVNode("strong", null, _toDisplayString(item.librarySummary), 1),
+                _createElementVNode("span", null, _toDisplayString(item.libraryDetail), 1)
+              ]),
+              _createElementVNode("div", _hoisted_16, [
+                (item.seedTasks?.length)
+                  ? (_openBlock(true), _createElementBlock(_Fragment, { key: 0 }, _renderList(item.seedTasks, (task, index) => {
+                      return (_openBlock(), _createElementBlock("div", {
+                        key: `${task.site}-${task.scope}-${index}`,
+                        class: _normalizeClass(['seed-task', task.tone])
+                      }, [
+                        _createElementVNode("i", null, _toDisplayString(task.status), 1),
+                        _createElementVNode("strong", null, _toDisplayString(task.site), 1),
+                        _createElementVNode("span", null, _toDisplayString(task.scope) + _toDisplayString(task.count > 1 ? ` · ${task.count} 个任务` : ''), 1)
+                      ], 2))
+                    }), 128))
+                  : (_openBlock(), _createElementBlock("div", _hoisted_17, [
+                      _createElementVNode("strong", null, _toDisplayString(item.qbSummary), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.siteSummary), 1)
+                    ]))
+              ]),
+              _createElementVNode("div", _hoisted_18, [
+                _createElementVNode("strong", null, _toDisplayString(item.sizeLabel), 1),
+                _createElementVNode("span", null, _toDisplayString(item.reclaimLabel), 1)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['impact', { danger: item.protected }]),
+                "data-label": "完整删除影响"
+              }, [
+                _createElementVNode("strong", null, _toDisplayString(item.impactTitle), 1),
+                _createElementVNode("span", null, _toDisplayString(item.impactDetail), 1)
+              ], 2)
+            ], 2))
+          }), 128)),
+      (!loading.value && !visible.value.length)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_19, " 没有符合条件的资源，请取消筛选或更换关键词。 "))
+        : _createCommentVNode("", true)
+    ]),
+    (_openBlock(), _createBlock(_Teleport, { to: "body" }, [
+      (selected.value.length)
+        ? (_openBlock(), _createElementBlock("aside", _hoisted_20, [
+            _createElementVNode("div", _hoisted_21, _toDisplayString(selected.value.length), 1),
+            _createElementVNode("p", null, [
+              _cache[26] || (_cache[26] = _createElementVNode("strong", null, "已加入清理计划", -1)),
+              _createElementVNode("span", null, "完整删除上限 " + _toDisplayString(_unref(formatGiB)(selectedSize.value)), 1)
+            ]),
+            _createElementVNode("button", {
+              class: "clear-button",
+              type: "button",
+              onClick: _cache[3] || (_cache[3] = $event => (selected.value = []))
+            }, "清空"),
+            _createElementVNode("div", _hoisted_22, [
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(ACTIONS), (action, mode) => {
+                return (_openBlock(), _createElementBlock("button", {
+                  key: mode,
+                  class: _normalizeClass(['action-level', { delete: mode === 'delete' }]),
+                  type: "button",
+                  onClick: $event => (openPlan(mode))
+                }, [
+                  _createElementVNode("strong", null, _toDisplayString(action.title), 1),
+                  _createElementVNode("span", null, _toDisplayString(action.detail), 1)
+                ], 10, _hoisted_23))
+              }), 128))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (planOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 1,
+            class: "modal-backdrop",
+            onClick: _withModifiers(closePlan, ["self"])
+          }, [
+            _createElementVNode("section", _hoisted_24, [
+              _createElementVNode("header", null, [
+                _createElementVNode("div", null, [
+                  _cache[27] || (_cache[27] = _createElementVNode("span", null, "清理等级 · 真实预演", -1)),
+                  _createElementVNode("h2", null, _toDisplayString(currentAction.value?.title), 1)
+                ]),
+                _createElementVNode("button", {
+                  type: "button",
+                  disabled: executing.value,
+                  onClick: closePlan
+                }, "×", 8, _hoisted_25)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['mode-summary', planMode.value])
+              }, [
+                (plan.value && planMode.value === 'delete')
+                  ? (_openBlock(), _createElementBlock("strong", _hoisted_26, "已核算可释放 " + _toDisplayString(_unref(formatBytes)(plan.value.estimatedReclaimBytes)), 1))
+                  : (_openBlock(), _createElementBlock("strong", _hoisted_27, _toDisplayString(currentAction.value?.detail), 1)),
+                _createElementVNode("span", null, _toDisplayString(planMode.value === 'pause'
+              ? '只改变 qB 运行状态，不删除任务或文件。'
+              : planMode.value === 'retire'
+                ? '移除 qB 任务但保留文件，媒体库继续可播放。'
+                : '仅当全部路径、硬链接、H&R 与任务状态通过校验才会放行。'), 1)
+              ], 2),
+              _createElementVNode("div", _hoisted_28, [
+                (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(selectedItems.value, (item) => {
+                  return (_openBlock(), _createElementBlock("div", {
+                    key: item.id
+                  }, [
+                    _createElementVNode("p", null, [
+                      _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.englishTitle) + " · " + _toDisplayString(item.edition), 1)
+                    ]),
+                    _createElementVNode("b", null, _toDisplayString(item.sizeLabel), 1)
+                  ]))
+                }), 128))
+              ]),
+              (planLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_29, "正在刷新 NAS 状态并复核关系…"))
+                : (planError.value)
+                  ? (_openBlock(), _createElementBlock("div", _hoisted_30, [
+                      _cache[28] || (_cache[28] = _createElementVNode("strong", null, "无法生成计划", -1)),
+                      _createElementVNode("span", null, _toDisplayString(planError.value), 1)
+                    ]))
+                  : (plan.value)
+                    ? (_openBlock(), _createElementBlock(_Fragment, { key: 2 }, [
+                        _createElementVNode("div", {
+                          class: _normalizeClass(['plan-state', plan.value.canExecute ? 'passed' : 'blocked'])
+                        }, [
+                          _createElementVNode("strong", null, _toDisplayString(plan.value.canExecute ? '安全预演通过' : '计划已被安全门禁拦截'), 1),
+                          _createElementVNode("span", null, " 停止 " + _toDisplayString(plan.value.operationCounts.qbStop) + " 个任务 · 退出 " + _toDisplayString(plan.value.operationCounts.qbRemoveKeepFiles) + " 个任务 · 解除 " + _toDisplayString(plan.value.operationCounts.unlinkFiles) + " 个文件入口 ", 1)
+                        ], 2),
+                        (plan.value.blocks?.length)
+                          ? (_openBlock(), _createElementBlock("ul", _hoisted_31, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.blocks, (issue, index) => {
+                                return (_openBlock(), _createElementBlock("li", {
+                                  key: _unref(issueKey)(issue, index)
+                                }, _toDisplayString(issue.message), 1))
+                              }), 128))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (plan.value.warnings?.length)
+                          ? (_openBlock(), _createElementBlock("ul", _hoisted_32, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.warnings, (issue, index) => {
+                                return (_openBlock(), _createElementBlock("li", {
+                                  key: _unref(issueKey)(issue, index)
+                                }, _toDisplayString(issue.message), 1))
+                              }), 128))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (plan.value.requiresSiteAcknowledgement)
+                          ? (_openBlock(), _createElementBlock("label", _hoisted_33, [
+                              _createElementVNode("input", {
+                                checked: acknowledgeSiteRisk.value,
+                                type: "checkbox",
+                                onChange: _cache[4] || (_cache[4] = $event => (setSiteRisk($event.target.checked)))
+                              }, null, 40, _hoisted_34),
+                              _cache[29] || (_cache[29] = _createElementVNode("span", null, null, -1)),
+                              _cache[30] || (_cache[30] = _createTextVNode(" 我已确认会影响私有站做种，并接受站点规则风险 ", -1))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (planExpired.value)
+                          ? (_openBlock(), _createElementBlock("div", _hoisted_35, [...(_cache[31] || (_cache[31] = [
+                              _createElementVNode("strong", null, "安全预演已过期", -1),
+                              _createElementVNode("span", null, "请关闭后重新生成。", -1)
+                            ]))]))
+                          : _createCommentVNode("", true)
+                      ], 64))
+                    : _createCommentVNode("", true),
+              _createElementVNode("div", _hoisted_36, [
+                _cache[33] || (_cache[33] = _createElementVNode("i", null, "盾", -1)),
+                _createElementVNode("p", null, [
+                  _createElementVNode("strong", null, _toDisplayString(executionEnabled.value ? '执行前还需第二次确认' : '执行引擎未启用'), 1),
+                  _cache[32] || (_cache[32] = _createElementVNode("span", null, "最终执行前会重新读取 qB、路径、硬链接和保护状态。", -1))
+                ])
+              ]),
+              (executeResult.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_37, [
+                    _createElementVNode("strong", null, _toDisplayString(currentAction.value?.title) + "已完成", 1),
+                    _createElementVNode("span", null, " 停止 " + _toDisplayString(executeResult.value.qbStopped) + " · 退出 " + _toDisplayString(executeResult.value.qbRemoved) + " · 删除文件入口 " + _toDisplayString(executeResult.value.filesDeleted) + " · 清理索引 " + _toDisplayString(executeResult.value.moviepilotIndexesDeleted), 1),
+                    _createElementVNode("button", {
+                      type: "button",
+                      onClick: closePlan
+                    }, "完成")
+                  ]))
+                : (finalConfirmation.value)
+                  ? (_openBlock(), _createElementBlock("div", _hoisted_38, [
+                      _cache[34] || (_cache[34] = _createElementVNode("strong", null, "再次确认：系统将立即执行这份计划", -1)),
+                      (executeError.value)
+                        ? (_openBlock(), _createElementBlock("span", _hoisted_39, _toDisplayString(executeError.value), 1))
+                        : _createCommentVNode("", true),
+                      _createElementVNode("div", null, [
+                        _createElementVNode("button", {
+                          type: "button",
+                          disabled: executing.value,
+                          onClick: _cache[5] || (_cache[5] = $event => (finalConfirmation.value = false))
+                        }, "返回", 8, _hoisted_40),
+                        _createElementVNode("button", {
+                          class: _normalizeClass({ danger: planMode.value === 'delete' }),
+                          type: "button",
+                          disabled: executing.value || planExpired.value,
+                          onClick: executePlan
+                        }, _toDisplayString(executing.value ? '正在二次复核…' : `确认${currentAction.value?.title}`), 11, _hoisted_41)
+                      ])
+                    ]))
+                  : (_openBlock(), _createElementBlock("button", {
+                      key: 5,
+                      class: "confirm-button",
+                      type: "button",
+                      disabled: !executionEnabled.value || !plan.value?.canExecute || planExpired.value,
+                      onClick: _cache[6] || (_cache[6] = $event => (finalConfirmation.value = true))
+                    }, " 进入最终确认 ", 8, _hoisted_42))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (gapOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 2,
+            class: "modal-backdrop",
+            onClick: _cache[8] || (_cache[8] = _withModifiers($event => (gapOpen.value = false), ["self"]))
+          }, [
+            _createElementVNode("section", _hoisted_43, [
+              _createElementVNode("header", null, [
+                _cache[35] || (_cache[35] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "学校站实时保护"),
+                  _createElementVNode("h2", null, "H&R 缺口明细")
+                ], -1)),
+                _createElementVNode("button", {
+                  onClick: _cache[7] || (_cache[7] = $event => (gapOpen.value = false))
+                }, "×")
+              ]),
+              (gapLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_44, "正在核对…"))
+                : _createCommentVNode("", true),
+              (gapError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_45, _toDisplayString(gapError.value), 1))
+                : _createCommentVNode("", true),
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(gaps.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.title,
+                  class: "gap-row"
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.linkedResourceTitle || '尚未精确关联媒体'), 1)
+                  ]),
+                  _createElementVNode("b", null, _toDisplayString(item.qbTaskPresent ? 'qB 已存在' : item.coveredByCandidate ? '候选恢复中' : '任务缺失'), 1)
+                ]))
+              }), 128))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (recoveryOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 3,
+            class: "modal-backdrop",
+            onClick: _cache[11] || (_cache[11] = _withModifiers($event => (recoveryOpen.value = false), ["self"]))
+          }, [
+            _createElementVNode("section", _hoisted_46, [
+              _createElementVNode("header", null, [
+                _cache[36] || (_cache[36] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "失败关闭"),
+                  _createElementVNode("h2", null, "恢复未完成清理")
+                ], -1)),
+                _createElementVNode("button", {
+                  onClick: _cache[9] || (_cache[9] = $event => (recoveryOpen.value = false))
+                }, "×")
+              ]),
+              (recoveryLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_47, "正在读取事务…"))
+                : _createCommentVNode("", true),
+              (recoveryError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_48, _toDisplayString(recoveryError.value), 1))
+                : _createCommentVNode("", true),
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(recoveries.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.planId,
+                  class: "recovery-row"
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.mode) + " · " + _toDisplayString(item.phase), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.planId.slice(-10)), 1)
+                  ]),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: $event => (chooseRecovery(item, 'rollback'))
+                  }, "回滚", 8, _hoisted_49),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: $event => (chooseRecovery(item, 'finalize'))
+                  }, "完成原事务", 8, _hoisted_50)
+                ]))
+              }), 128)),
+              (recoveryTarget.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_51, [
+                    _createElementVNode("label", null, [
+                      _cache[37] || (_cache[37] = _createTextVNode("输入确认短语 ", -1)),
+                      _createElementVNode("code", null, _toDisplayString(recoveryExpectedPhrase()), 1)
+                    ]),
+                    _withDirectives(_createElementVNode("input", {
+                      "onUpdate:modelValue": _cache[10] || (_cache[10] = $event => ((recoveryPhrase).value = $event)),
+                      autocomplete: "off"
+                    }, null, 512), [
+                      [_vModelText, recoveryPhrase.value]
+                    ]),
+                    _createElementVNode("button", {
+                      type: "button",
+                      disabled: recovering.value || recoveryPhrase.value !== recoveryExpectedPhrase(),
+                      onClick: runRecovery
+                    }, _toDisplayString(recovering.value ? '处理中…' : '执行恢复'), 9, _hoisted_52)
+                  ]))
+                : _createCommentVNode("", true)
+            ])
+          ]))
+        : _createCommentVNode("", true)
+    ]))
+  ]))
+}
+}
+
+};
+const AppPage = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-55ee4f66"]]);
+
+export { AppPage as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_expose_Config-SYLmVfvj.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_expose_Config-SYLmVfvj.css
@@ -1,0 +1,10 @@
+
+.config-note[data-v-ed9f201d] {
+  display: grid;
+  gap: 6px;
+  padding: 20px;
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+  border-radius: 12px;
+}
+.config-note span[data-v-ed9f201d] { opacity: .7;
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_expose_Config-jwIyjrQZ.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_expose_Config-jwIyjrQZ.js
@@ -1,0 +1,30 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
+
+const {createElementVNode:_createElementVNode,openBlock:_openBlock,createElementBlock:_createElementBlock} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "config-note" };
+
+
+const _sfc_main = {
+  __name: 'Config',
+  props: {
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("div", _hoisted_1, [...(_cache[0] || (_cache[0] = [
+    _createElementVNode("strong", null, "存储清理已接入 MoviePilot", -1),
+    _createElementVNode("span", null, "请从左侧“存储清理”进入完整页面。3000 端口页面继续保留。", -1)
+  ]))]))
+}
+}
+
+};
+const Config = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-ed9f201d"]]);
+
+export { Config as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_expose_Page-DWMp4Ts5.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_expose_Page-DWMp4Ts5.js
@@ -1,0 +1,27 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage from './__federation_expose_AppPage-mb1zO2qt.js';
+
+const {openBlock:_openBlock,createBlock:_createBlock} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'Page',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createBlock(AppPage, {
+    api: __props.api,
+    "plugin-id": __props.pluginId
+  }, null, 8, ["api", "plugin-id"]))
+}
+}
+
+};
+
+export { _sfc_main as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_fn_import-JrT3xvdd.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.3/assets/__federation_fn_import-JrT3xvdd.js
@@ -1,0 +1,418 @@
+const buildIdentifier = "[0-9A-Za-z-]+";
+const build = `(?:\\+(${buildIdentifier}(?:\\.${buildIdentifier})*))`;
+const numericIdentifier = "0|[1-9]\\d*";
+const numericIdentifierLoose = "[0-9]+";
+const nonNumericIdentifier = "\\d*[a-zA-Z-][a-zA-Z0-9-]*";
+const preReleaseIdentifierLoose = `(?:${numericIdentifierLoose}|${nonNumericIdentifier})`;
+const preReleaseLoose = `(?:-?(${preReleaseIdentifierLoose}(?:\\.${preReleaseIdentifierLoose})*))`;
+const preReleaseIdentifier = `(?:${numericIdentifier}|${nonNumericIdentifier})`;
+const preRelease = `(?:-(${preReleaseIdentifier}(?:\\.${preReleaseIdentifier})*))`;
+const xRangeIdentifier = `${numericIdentifier}|x|X|\\*`;
+const xRangePlain = `[v=\\s]*(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:${preRelease})?${build}?)?)?`;
+const hyphenRange = `^\\s*(${xRangePlain})\\s+-\\s+(${xRangePlain})\\s*$`;
+const mainVersionLoose = `(${numericIdentifierLoose})\\.(${numericIdentifierLoose})\\.(${numericIdentifierLoose})`;
+const loosePlain = `[v=\\s]*${mainVersionLoose}${preReleaseLoose}?${build}?`;
+const gtlt = "((?:<|>)?=?)";
+const comparatorTrim = `(\\s*)${gtlt}\\s*(${loosePlain}|${xRangePlain})`;
+const loneTilde = "(?:~>?)";
+const tildeTrim = `(\\s*)${loneTilde}\\s+`;
+const loneCaret = "(?:\\^)";
+const caretTrim = `(\\s*)${loneCaret}\\s+`;
+const star = "(<|>)?=?\\s*\\*";
+const caret = `^${loneCaret}${xRangePlain}$`;
+const mainVersion = `(${numericIdentifier})\\.(${numericIdentifier})\\.(${numericIdentifier})`;
+const fullPlain = `v?${mainVersion}${preRelease}?${build}?`;
+const tilde = `^${loneTilde}${xRangePlain}$`;
+const xRange = `^${gtlt}\\s*${xRangePlain}$`;
+const comparator = `^${gtlt}\\s*(${fullPlain})$|^$`;
+const gte0 = "^\\s*>=\\s*0.0.0\\s*$";
+function parseRegex(source) {
+  return new RegExp(source);
+}
+function isXVersion(version) {
+  return !version || version.toLowerCase() === "x" || version === "*";
+}
+function pipe(...fns) {
+  return (x) => {
+    return fns.reduce((v, f) => f(v), x);
+  };
+}
+function extractComparator(comparatorString) {
+  return comparatorString.match(parseRegex(comparator));
+}
+function combineVersion(major, minor, patch, preRelease2) {
+  const mainVersion2 = `${major}.${minor}.${patch}`;
+  if (preRelease2) {
+    return `${mainVersion2}-${preRelease2}`;
+  }
+  return mainVersion2;
+}
+function parseHyphen(range) {
+  return range.replace(
+    parseRegex(hyphenRange),
+    (_range, from, fromMajor, fromMinor, fromPatch, _fromPreRelease, _fromBuild, to, toMajor, toMinor, toPatch, toPreRelease) => {
+      if (isXVersion(fromMajor)) {
+        from = "";
+      } else if (isXVersion(fromMinor)) {
+        from = `>=${fromMajor}.0.0`;
+      } else if (isXVersion(fromPatch)) {
+        from = `>=${fromMajor}.${fromMinor}.0`;
+      } else {
+        from = `>=${from}`;
+      }
+      if (isXVersion(toMajor)) {
+        to = "";
+      } else if (isXVersion(toMinor)) {
+        to = `<${+toMajor + 1}.0.0-0`;
+      } else if (isXVersion(toPatch)) {
+        to = `<${toMajor}.${+toMinor + 1}.0-0`;
+      } else if (toPreRelease) {
+        to = `<=${toMajor}.${toMinor}.${toPatch}-${toPreRelease}`;
+      } else {
+        to = `<=${to}`;
+      }
+      return `${from} ${to}`.trim();
+    }
+  );
+}
+function parseComparatorTrim(range) {
+  return range.replace(parseRegex(comparatorTrim), "$1$2$3");
+}
+function parseTildeTrim(range) {
+  return range.replace(parseRegex(tildeTrim), "$1~");
+}
+function parseCaretTrim(range) {
+  return range.replace(parseRegex(caretTrim), "$1^");
+}
+function parseCarets(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(caret),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          if (major === "0") {
+            return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+          } else {
+            return `>=${major}.${minor}.0 <${+major + 1}.0.0-0`;
+          }
+        } else if (preRelease2) {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+            }
+          } else {
+            return `>=${major}.${minor}.${patch}-${preRelease2} <${+major + 1}.0.0-0`;
+          }
+        } else {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+            }
+          }
+          return `>=${major}.${minor}.${patch} <${+major + 1}.0.0-0`;
+        }
+      }
+    );
+  }).join(" ");
+}
+function parseTildes(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(tilde),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+        } else if (preRelease2) {
+          return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+      }
+    );
+  }).join(" ");
+}
+function parseXRanges(range) {
+  return range.split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.trim().replace(
+      parseRegex(xRange),
+      (ret, gtlt2, major, minor, patch, preRelease2) => {
+        const isXMajor = isXVersion(major);
+        const isXMinor = isXMajor || isXVersion(minor);
+        const isXPatch = isXMinor || isXVersion(patch);
+        if (gtlt2 === "=" && isXPatch) {
+          gtlt2 = "";
+        }
+        preRelease2 = "";
+        if (isXMajor) {
+          if (gtlt2 === ">" || gtlt2 === "<") {
+            return "<0.0.0-0";
+          } else {
+            return "*";
+          }
+        } else if (gtlt2 && isXPatch) {
+          if (isXMinor) {
+            minor = 0;
+          }
+          patch = 0;
+          if (gtlt2 === ">") {
+            gtlt2 = ">=";
+            if (isXMinor) {
+              major = +major + 1;
+              minor = 0;
+              patch = 0;
+            } else {
+              minor = +minor + 1;
+              patch = 0;
+            }
+          } else if (gtlt2 === "<=") {
+            gtlt2 = "<";
+            if (isXMinor) {
+              major = +major + 1;
+            } else {
+              minor = +minor + 1;
+            }
+          }
+          if (gtlt2 === "<") {
+            preRelease2 = "-0";
+          }
+          return `${gtlt2 + major}.${minor}.${patch}${preRelease2}`;
+        } else if (isXMinor) {
+          return `>=${major}.0.0${preRelease2} <${+major + 1}.0.0-0`;
+        } else if (isXPatch) {
+          return `>=${major}.${minor}.0${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return ret;
+      }
+    );
+  }).join(" ");
+}
+function parseStar(range) {
+  return range.trim().replace(parseRegex(star), "");
+}
+function parseGTE0(comparatorString) {
+  return comparatorString.trim().replace(parseRegex(gte0), "");
+}
+function compareAtom(rangeAtom, versionAtom) {
+  rangeAtom = +rangeAtom || rangeAtom;
+  versionAtom = +versionAtom || versionAtom;
+  if (rangeAtom > versionAtom) {
+    return 1;
+  }
+  if (rangeAtom === versionAtom) {
+    return 0;
+  }
+  return -1;
+}
+function comparePreRelease(rangeAtom, versionAtom) {
+  const { preRelease: rangePreRelease } = rangeAtom;
+  const { preRelease: versionPreRelease } = versionAtom;
+  if (rangePreRelease === void 0 && !!versionPreRelease) {
+    return 1;
+  }
+  if (!!rangePreRelease && versionPreRelease === void 0) {
+    return -1;
+  }
+  if (rangePreRelease === void 0 && versionPreRelease === void 0) {
+    return 0;
+  }
+  for (let i = 0, n = rangePreRelease.length; i <= n; i++) {
+    const rangeElement = rangePreRelease[i];
+    const versionElement = versionPreRelease[i];
+    if (rangeElement === versionElement) {
+      continue;
+    }
+    if (rangeElement === void 0 && versionElement === void 0) {
+      return 0;
+    }
+    if (!rangeElement) {
+      return 1;
+    }
+    if (!versionElement) {
+      return -1;
+    }
+    return compareAtom(rangeElement, versionElement);
+  }
+  return 0;
+}
+function compareVersion(rangeAtom, versionAtom) {
+  return compareAtom(rangeAtom.major, versionAtom.major) || compareAtom(rangeAtom.minor, versionAtom.minor) || compareAtom(rangeAtom.patch, versionAtom.patch) || comparePreRelease(rangeAtom, versionAtom);
+}
+function eq(rangeAtom, versionAtom) {
+  return rangeAtom.version === versionAtom.version;
+}
+function compare(rangeAtom, versionAtom) {
+  switch (rangeAtom.operator) {
+    case "":
+    case "=":
+      return eq(rangeAtom, versionAtom);
+    case ">":
+      return compareVersion(rangeAtom, versionAtom) < 0;
+    case ">=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) < 0;
+    case "<":
+      return compareVersion(rangeAtom, versionAtom) > 0;
+    case "<=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) > 0;
+    case void 0: {
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+function parseComparatorString(range) {
+  return pipe(
+    parseCarets,
+    parseTildes,
+    parseXRanges,
+    parseStar
+  )(range);
+}
+function parseRange(range) {
+  return pipe(
+    parseHyphen,
+    parseComparatorTrim,
+    parseTildeTrim,
+    parseCaretTrim
+  )(range.trim()).split(/\s+/).join(" ");
+}
+function satisfy(version, range) {
+  if (!version) {
+    return false;
+  }
+  const parsedRange = parseRange(range);
+  const parsedComparator = parsedRange.split(" ").map((rangeVersion) => parseComparatorString(rangeVersion)).join(" ");
+  const comparators = parsedComparator.split(/\s+/).map((comparator2) => parseGTE0(comparator2));
+  const extractedVersion = extractComparator(version);
+  if (!extractedVersion) {
+    return false;
+  }
+  const [
+    ,
+    versionOperator,
+    ,
+    versionMajor,
+    versionMinor,
+    versionPatch,
+    versionPreRelease
+  ] = extractedVersion;
+  const versionAtom = {
+    version: combineVersion(
+      versionMajor,
+      versionMinor,
+      versionPatch,
+      versionPreRelease
+    ),
+    major: versionMajor,
+    minor: versionMinor,
+    patch: versionPatch,
+    preRelease: versionPreRelease == null ? void 0 : versionPreRelease.split(".")
+  };
+  for (const comparator2 of comparators) {
+    const extractedComparator = extractComparator(comparator2);
+    if (!extractedComparator) {
+      return false;
+    }
+    const [
+      ,
+      rangeOperator,
+      ,
+      rangeMajor,
+      rangeMinor,
+      rangePatch,
+      rangePreRelease
+    ] = extractedComparator;
+    const rangeAtom = {
+      operator: rangeOperator,
+      version: combineVersion(
+        rangeMajor,
+        rangeMinor,
+        rangePatch,
+        rangePreRelease
+      ),
+      major: rangeMajor,
+      minor: rangeMinor,
+      patch: rangePatch,
+      preRelease: rangePreRelease == null ? void 0 : rangePreRelease.split(".")
+    };
+    if (!compare(rangeAtom, versionAtom)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// eslint-disable-next-line no-undef
+const moduleMap = {};
+const moduleCache = Object.create(null);
+async function importShared(name, shareScope = 'default') {
+  return moduleCache[name]
+    ? new Promise((r) => r(moduleCache[name]))
+    : (await getSharedFromRuntime(name, shareScope)) || getSharedFromLocal(name)
+}
+async function getSharedFromRuntime(name, shareScope) {
+  let module = null;
+  if (globalThis?.__federation_shared__?.[shareScope]?.[name]) {
+    const versionObj = globalThis.__federation_shared__[shareScope][name];
+    const requiredVersion = moduleMap[name]?.requiredVersion;
+    const hasRequiredVersion = !!requiredVersion;
+    if (hasRequiredVersion) {
+      const versionKey = Object.keys(versionObj).find((version) =>
+        satisfy(version, requiredVersion)
+      );
+      if (versionKey) {
+        const versionValue = versionObj[versionKey];
+        module = await (await versionValue.get())();
+      } else {
+        console.log(
+          `provider support ${name}(${versionKey}) is not satisfied requiredVersion(\${moduleMap[name].requiredVersion})`
+        );
+      }
+    } else {
+      const versionKey = Object.keys(versionObj)[0];
+      const versionValue = versionObj[versionKey];
+      module = await (await versionValue.get())();
+    }
+  }
+  if (module) {
+    return flattenModule(module, name)
+  }
+}
+async function getSharedFromLocal(name) {
+  if (moduleMap[name]?.import) {
+    let module = await (await moduleMap[name].get())();
+    return flattenModule(module, name)
+  } else {
+    console.error(
+      `consumer config import=false,so cant use callback shared module`
+    );
+  }
+}
+function flattenModule(module, name) {
+  // use a shared module which export default a function will getting error 'TypeError: xxx is not a function'
+  if (typeof module.default === 'function') {
+    Object.keys(module).forEach((key) => {
+      if (key !== 'default') {
+        module.default[key] = module[key];
+      }
+    });
+    moduleCache[name] = module.default;
+    return module.default
+  }
+  if (module.default) module = Object.assign({}, module.default, module);
+  moduleCache[name] = module;
+  return module
+}
+
+export { importShared, getSharedFromLocal as importSharedLocal, getSharedFromRuntime as importSharedRuntime };

--- a/plugins.v2/storagecleanup/dist/v1.0.3/assets/_plugin-vue_export-helper-pcqpp-6-.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.3/assets/_plugin-vue_export-helper-pcqpp-6-.js
@@ -1,0 +1,9 @@
+const _export_sfc = (sfc, props) => {
+  const target = sfc.__vccOpts || sfc;
+  for (const [key, val] of props) {
+    target[key] = val;
+  }
+  return target;
+};
+
+export { _export_sfc as _ };

--- a/plugins.v2/storagecleanup/dist/v1.0.3/assets/index-DA5a61hf.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.3/assets/index-DA5a61hf.js
@@ -1,0 +1,44 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage from './__federation_expose_AppPage-mb1zO2qt.js';
+
+true              &&(function polyfill() {
+  const relList = document.createElement("link").relList;
+  if (relList && relList.supports && relList.supports("modulepreload")) {
+    return;
+  }
+  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+    processPreload(link);
+  }
+  new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type !== "childList") {
+        continue;
+      }
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === "LINK" && node.rel === "modulepreload")
+          processPreload(node);
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  function getFetchOpts(link) {
+    const fetchOpts = {};
+    if (link.integrity) fetchOpts.integrity = link.integrity;
+    if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
+    if (link.crossOrigin === "use-credentials")
+      fetchOpts.credentials = "include";
+    else if (link.crossOrigin === "anonymous") fetchOpts.credentials = "omit";
+    else fetchOpts.credentials = "same-origin";
+    return fetchOpts;
+  }
+  function processPreload(link) {
+    if (link.ep)
+      return;
+    link.ep = true;
+    const fetchOpts = getFetchOpts(link);
+    fetch(link.href, fetchOpts);
+  }
+}());
+
+const {createApp} = await importShared('vue');
+
+createApp(AppPage).mount('#app');

--- a/plugins.v2/storagecleanup/dist/v1.0.3/assets/remoteEntry.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.3/assets/remoteEntry.js
@@ -2,14 +2,14 @@ const currentImports = {};
       const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
       let moduleMap = {
 "./AppPage":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './AppPage');
-      return __federation_import('./__federation_expose_AppPage-WrNLRDkU.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-B6tAG2vu.css"], false, './AppPage');
+      return __federation_import('./__federation_expose_AppPage-mb1zO2qt.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Page":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './Page');
-      return __federation_import('./__federation_expose_Page-DAUTopwb.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-B6tAG2vu.css"], false, './Page');
+      return __federation_import('./__federation_expose_Page-DWMp4Ts5.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Config":()=>{
-      dynamicLoadingCss(["__federation_expose_Config-BHIxEI63.css"], false, './Config');
-      return __federation_import('./__federation_expose_Config-BlunJQWM.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
+      dynamicLoadingCss(["__federation_expose_Config-SYLmVfvj.css"], false, './Config');
+      return __federation_import('./__federation_expose_Config-jwIyjrQZ.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
       const seen = {};
       const dynamicLoadingCss = (cssFilePaths, dontAppendStylesToHead, exposeItemName) => {
         const metaUrl = import.meta.url;
@@ -48,7 +48,7 @@ const currentImports = {};
          } else {
            href = cssPath;
          }
-         
+
           if (dontAppendStylesToHead) {
             const key = 'css__StorageCleanup__' + exposeItemName;
             window[key] = window[key] || [];

--- a/plugins.v2/storagecleanup/dist/v1.0.3/index.html
+++ b/plugins.v2/storagecleanup/dist/v1.0.3/index.html
@@ -1,0 +1,6 @@
+<script type="module" crossorigin src="/assets/index-DA5a61hf.js"></script>
+<link rel="modulepreload" crossorigin href="/assets/__federation_fn_import-JrT3xvdd.js">
+<link rel="modulepreload" crossorigin href="/assets/_plugin-vue_export-helper-pcqpp-6-.js">
+<link rel="modulepreload" crossorigin href="/assets/__federation_expose_AppPage-mb1zO2qt.js">
+<link rel="stylesheet" crossorigin href="/assets/__federation_expose_AppPage-B6tAG2vu.css">
+<div id="app"></div>

--- a/plugins.v2/storagecleanup/dist/v1.0.4/assets/__federation_expose_Page-PlanGuard.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.4/assets/__federation_expose_Page-PlanGuard.js
@@ -1,0 +1,69 @@
+import { importShared } from '../../v1.0.3/assets/__federation_fn_import-JrT3xvdd.js';
+import AppPage from '../../v1.0.3/assets/__federation_expose_AppPage-mb1zO2qt.js';
+
+const {openBlock:_openBlock,createBlock:_createBlock} = await importShared('vue');
+
+function createLatestPlanApi(api) {
+  let generation = 0;
+  let latestPlanResult = null;
+
+  return {
+    ...api,
+    get(...args) {
+      return api.get(...args);
+    },
+    post(path, body, ...args) {
+      if (!String(path || '').endsWith('/plan')) {
+        return api.post(path, body, ...args);
+      }
+
+      const requestGeneration = ++generation;
+      let rawRequest;
+      try {
+        rawRequest = Promise.resolve(api.post(path, body, ...args));
+      } catch (error) {
+        rawRequest = Promise.reject(error);
+      }
+
+      const result = (async () => {
+        try {
+          const response = await rawRequest;
+          if (requestGeneration !== generation && latestPlanResult) {
+            return await latestPlanResult;
+          }
+          return response;
+        } catch (error) {
+          if (requestGeneration !== generation && latestPlanResult) {
+            return await latestPlanResult;
+          }
+          throw error;
+        }
+      })();
+      latestPlanResult = result;
+      return result;
+    },
+  };
+}
+
+const _sfc_main = {
+  __name: 'Page',
+  props: {
+    api: { type: Object, default: () => ({}) },
+    pluginId: { type: String, default: 'StorageCleanup' },
+  },
+  setup(__props) {
+    const guardedApi = createLatestPlanApi({
+      get: (...args) => __props.api.get(...args),
+      post: (...args) => __props.api.post(...args),
+    });
+
+    return (_ctx, _cache) => {
+      return (_openBlock(), _createBlock(AppPage, {
+        api: guardedApi,
+        "plugin-id": __props.pluginId
+      }, null, 8, ["plugin-id"]));
+    };
+  }
+};
+
+export { _sfc_main as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.4/assets/remoteEntry.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.4/assets/remoteEntry.js
@@ -2,14 +2,14 @@ const currentImports = {};
       const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
       let moduleMap = {
 "./AppPage":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './AppPage');
-      return __federation_import('./__federation_expose_AppPage-WrNLRDkU.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["../../v1.0.3/assets/__federation_expose_AppPage-B6tAG2vu.css"], false, './AppPage');
+      return __federation_import('../../v1.0.3/assets/__federation_expose_AppPage-mb1zO2qt.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Page":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './Page');
-      return __federation_import('./__federation_expose_Page-DAUTopwb.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["../../v1.0.3/assets/__federation_expose_AppPage-B6tAG2vu.css"], false, './Page');
+      return __federation_import('./__federation_expose_Page-PlanGuard.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Config":()=>{
-      dynamicLoadingCss(["__federation_expose_Config-BHIxEI63.css"], false, './Config');
-      return __federation_import('./__federation_expose_Config-BlunJQWM.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
+      dynamicLoadingCss(["../../v1.0.3/assets/__federation_expose_Config-SYLmVfvj.css"], false, './Config');
+      return __federation_import('../../v1.0.3/assets/__federation_expose_Config-jwIyjrQZ.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
       const seen = {};
       const dynamicLoadingCss = (cssFilePaths, dontAppendStylesToHead, exposeItemName) => {
         const metaUrl = import.meta.url;
@@ -48,7 +48,7 @@ const currentImports = {};
          } else {
            href = cssPath;
          }
-         
+
           if (dontAppendStylesToHead) {
             const key = 'css__StorageCleanup__' + exposeItemName;
             window[key] = window[key] || [];
@@ -78,7 +78,7 @@ const currentImports = {};
           for (const [versionKey, versionValue] of Object.entries(value)) {
             const scope = versionValue.scope || 'default';
             globalThis.__federation_shared__[scope] = globalThis.__federation_shared__[scope] || {};
-            const shared= globalThis.__federation_shared__[scope];
+            const shared=globalThis.__federation_shared__[scope];
             (shared[key] = shared[key]||{})[versionKey] = versionValue;
           }
         });

--- a/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_expose_AppPage-B6tAG2vu.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_expose_AppPage-B6tAG2vu.css
@@ -1,0 +1,604 @@
+
+.cleanup-app[data-v-55ee4f66], .action-bar[data-v-55ee4f66], .modal-backdrop[data-v-55ee4f66] {
+  --ink: rgb(var(--v-theme-on-background, 30, 41, 59));
+  --muted: rgba(var(--v-theme-on-background, 30, 41, 59), .58);
+  --line: rgba(var(--v-border-color, 100, 116, 139), .18);
+  --surface: rgb(var(--v-theme-surface, 255, 255, 255));
+  --primary: rgb(var(--v-theme-primary, 59, 130, 246));
+  --primary-soft: rgba(var(--v-theme-primary, 59, 130, 246), .10);
+  --good: #16836b;
+  --warn: #b86b11;
+  --danger: #c44b47;
+}
+.cleanup-app[data-v-55ee4f66] {
+  color: var(--ink);
+  min-width: 980px;
+  padding: 18px 24px 110px;
+}
+button[data-v-55ee4f66], input[data-v-55ee4f66] { font: inherit;
+}
+button[data-v-55ee4f66] { color: inherit;
+}
+.page-header[data-v-55ee4f66] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+.eyebrow[data-v-55ee4f66] { margin: 0 0 4px; color: var(--primary); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase;
+}
+.page-header h1[data-v-55ee4f66] { margin: 0; font-size: 30px; line-height: 1.2;
+}
+.page-header > div > span[data-v-55ee4f66] { color: var(--muted); font-size: 14px;
+}
+.status-card[data-v-55ee4f66] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 220px;
+  padding: 10px 14px;
+  border: 1px solid rgba(22, 131, 107, .22);
+  border-radius: 12px;
+  background: rgba(22, 131, 107, .08);
+}
+.status-card.danger[data-v-55ee4f66] { border-color: rgba(196, 75, 71, .24); background: rgba(196, 75, 71, .08);
+}
+.status-card i[data-v-55ee4f66], .notice i[data-v-55ee4f66], .safety-note i[data-v-55ee4f66] {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  background: rgba(22, 131, 107, .12);
+  color: var(--good);
+  font-style: normal;
+  font-weight: 900;
+}
+.status-card p[data-v-55ee4f66], .notice p[data-v-55ee4f66], .safety-note p[data-v-55ee4f66], .plan-resources p[data-v-55ee4f66], .gap-row p[data-v-55ee4f66], .recovery-row p[data-v-55ee4f66] { display: grid; gap: 2px; margin: 0;
+}
+.status-card strong[data-v-55ee4f66] { font-size: 13px;
+}
+.status-card span[data-v-55ee4f66] { color: var(--muted); font-size: 12px;
+}
+.toolbar[data-v-55ee4f66] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.search[data-v-55ee4f66] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  height: 46px;
+  padding: 0 15px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+}
+.search span[data-v-55ee4f66] { color: var(--muted); font-size: 21px;
+}
+.search input[data-v-55ee4f66] { width: 100%; border: 0; outline: 0; color: inherit; background: transparent; font-size: 15px;
+}
+.safe-toggle[data-v-55ee4f66] { display: flex; align-items: center; gap: 8px; height: 44px; white-space: nowrap; font-size: 14px; font-weight: 650;
+}
+.safe-toggle input[data-v-55ee4f66], .risk-check input[data-v-55ee4f66] { position: absolute; opacity: 0;
+}
+.safe-toggle > span[data-v-55ee4f66] {
+  width: 38px;
+  height: 22px;
+  padding: 3px;
+  border-radius: 99px;
+  background: rgba(100, 116, 139, .24);
+}
+.safe-toggle > span[data-v-55ee4f66]::after { display: block; width: 16px; height: 16px; border-radius: 50%; background: white; content: ''; transition: .2s;
+}
+.safe-toggle input:checked + span[data-v-55ee4f66] { background: var(--primary);
+}
+.safe-toggle input:checked + span[data-v-55ee4f66]::after { transform: translateX(16px);
+}
+.soft-button[data-v-55ee4f66], .icon-button[data-v-55ee4f66] {
+  height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: var(--surface);
+  cursor: pointer;
+}
+.soft-button[data-v-55ee4f66] { padding: 0 14px;
+}
+.icon-button[data-v-55ee4f66] { width: 42px; font-size: 20px;
+}
+.notice[data-v-55ee4f66] {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin: 0 0 14px;
+  padding: 12px 16px;
+  border: 1px solid rgba(184, 107, 17, .22);
+  border-radius: 12px;
+  background: rgba(184, 107, 17, .07);
+  text-align: left;
+  cursor: pointer;
+}
+.notice p[data-v-55ee4f66] { flex: 1;
+}
+.notice p span[data-v-55ee4f66] { color: var(--muted); font-size: 13px;
+}
+.notice b[data-v-55ee4f66] { color: var(--warn); font-size: 13px;
+}
+.notice.critical[data-v-55ee4f66] { border-color: rgba(196, 75, 71, .25); background: rgba(196, 75, 71, .08);
+}
+.notice.critical b[data-v-55ee4f66] { color: var(--danger);
+}
+.filters[data-v-55ee4f66] { display: flex; gap: 6px; margin-bottom: 12px;
+}
+.filters button[data-v-55ee4f66] {
+  padding: 8px 13px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.filters button.active[data-v-55ee4f66] { border-color: var(--line); background: var(--surface); color: var(--ink); font-weight: 750; box-shadow: 0 4px 12px rgba(15, 23, 42, .04);
+}
+.filters span[data-v-55ee4f66] { margin-left: 5px; padding: 2px 6px; border-radius: 99px; background: rgba(100, 116, 139, .10); font-size: 11px;
+}
+.resource-card[data-v-55ee4f66] { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--surface);
+}
+.table-head[data-v-55ee4f66], .resource-row[data-v-55ee4f66] {
+  display: grid;
+  grid-template-columns: 42px minmax(270px, 1.55fr) minmax(170px, .85fr) minmax(360px, 1.65fr) minmax(125px, .65fr) minmax(230px, 1fr);
+  align-items: center;
+}
+.table-head[data-v-55ee4f66] { min-height: 50px; padding: 0 16px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 12px; font-weight: 800;
+}
+.resource-row[data-v-55ee4f66] { min-height: 126px; padding: 0 16px; border-bottom: 1px solid var(--line);
+}
+.resource-row[data-v-55ee4f66]:last-child { border-bottom: 0;
+}
+.resource-row.selected[data-v-55ee4f66] { background: var(--primary-soft);
+}
+.select-all[data-v-55ee4f66], .row-check[data-v-55ee4f66] {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid rgba(100, 116, 139, .35);
+  border-radius: 7px;
+  background: transparent;
+  cursor: pointer;
+}
+.row-check.locked[data-v-55ee4f66] { border-color: rgba(184, 107, 17, .25); background: rgba(184, 107, 17, .08); color: var(--warn); font-size: 10px; cursor: not-allowed;
+}
+.resource-title[data-v-55ee4f66], .stack-cell[data-v-55ee4f66] { display: grid; gap: 4px; min-width: 0; padding-right: 16px;
+}
+.resource-title strong[data-v-55ee4f66] { font-size: 17px;
+}
+.resource-title b[data-v-55ee4f66] { overflow: hidden; color: var(--ink); font-size: 13px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; opacity: .78;
+}
+.resource-title span[data-v-55ee4f66], .stack-cell span[data-v-55ee4f66], .impact span[data-v-55ee4f66], .seed-task span[data-v-55ee4f66] { color: var(--muted); font-size: 12px; line-height: 1.45;
+}
+.stack-cell strong[data-v-55ee4f66] { font-size: 14px;
+}
+.stack-cell.library strong[data-v-55ee4f66] { color: var(--good);
+}
+.stack-cell.size strong[data-v-55ee4f66] { font-size: 16px;
+}
+.seed-cell[data-v-55ee4f66] { display: grid; gap: 4px; padding-right: 18px;
+}
+.seed-task[data-v-55ee4f66] {
+  display: grid;
+  grid-template-columns: 62px minmax(72px, auto) minmax(100px, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding-left: 8px;
+  border-left: 2px solid rgba(100, 116, 139, .28);
+}
+.seed-task i[data-v-55ee4f66] { padding: 4px 8px; border-radius: 99px; background: rgba(100, 116, 139, .1); font-size: 11px; font-style: normal; font-weight: 800; text-align: center; white-space: nowrap;
+}
+.seed-task strong[data-v-55ee4f66] { font-size: 13px;
+}
+.seed-task.warning[data-v-55ee4f66] { border-color: rgba(184, 107, 17, .45);
+}
+.seed-task.warning i[data-v-55ee4f66] { color: var(--warn); background: rgba(184, 107, 17, .1);
+}
+.seed-task.protected[data-v-55ee4f66] { border-color: rgba(196, 75, 71, .45);
+}
+.seed-task.protected i[data-v-55ee4f66] { color: var(--danger); background: rgba(196, 75, 71, .1);
+}
+.impact[data-v-55ee4f66] { display: grid; gap: 4px; padding-left: 10px; border-left: 2px solid rgba(22, 131, 107, .35);
+}
+.impact strong[data-v-55ee4f66] { font-size: 13px;
+}
+.impact.danger[data-v-55ee4f66] { border-color: rgba(196, 75, 71, .5);
+}
+.impact.danger strong[data-v-55ee4f66] { color: var(--danger);
+}
+.empty-state[data-v-55ee4f66] { display: grid; place-items: center; min-height: 150px; color: var(--muted);
+}
+.action-bar[data-v-55ee4f66] {
+  position: fixed;
+  z-index: 20;
+  right: 30px;
+  bottom: 22px;
+  left: calc(var(--v-layout-left, 0px) + 30px);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, .14);
+  border-radius: 16px;
+  background: #17243a;
+  color: white;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, .28);
+}
+.selected-count[data-v-55ee4f66] { display: grid; place-items: center; width: 44px; height: 44px; border-radius: 12px; background: #3f70b7; font-size: 18px; font-weight: 900;
+}
+.action-bar > p[data-v-55ee4f66] { display: grid; gap: 1px; min-width: 160px; margin: 0;
+}
+.action-bar > p span[data-v-55ee4f66], .action-level span[data-v-55ee4f66] { color: rgba(255, 255, 255, .64); font-size: 11px;
+}
+.clear-button[data-v-55ee4f66] { border: 0; background: transparent; color: rgba(255, 255, 255, .66); cursor: pointer;
+}
+.action-buttons[data-v-55ee4f66] { display: contents;
+}
+.action-level[data-v-55ee4f66] { display: grid; flex: 1; gap: 3px; padding: 10px 14px; border: 1px solid rgba(255, 255, 255, .17); border-radius: 11px; background: rgba(255, 255, 255, .06); color: white; text-align: left; cursor: pointer;
+}
+.action-level.delete[data-v-55ee4f66] { border-color: rgba(255, 142, 136, .32); background: rgba(196, 75, 71, .28);
+}
+.modal-backdrop[data-v-55ee4f66] {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  background: rgba(15, 23, 42, .55);
+  backdrop-filter: blur(6px);
+}
+.modal[data-v-55ee4f66] {
+  overflow: auto;
+  width: min(760px, 90vw);
+  max-height: 90vh;
+  padding: 24px;
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, .3);
+}
+.modal > header[data-v-55ee4f66] { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 16px;
+}
+.modal > header span[data-v-55ee4f66] { color: var(--primary); font-size: 11px; font-weight: 850; letter-spacing: .08em;
+}
+.modal h2[data-v-55ee4f66] { margin: 3px 0 0; font-size: 24px;
+}
+.modal > header button[data-v-55ee4f66] { width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 10px; background: transparent; font-size: 22px; cursor: pointer;
+}
+.mode-summary[data-v-55ee4f66], .plan-state[data-v-55ee4f66], .safety-note[data-v-55ee4f66] { display: grid; gap: 4px; margin-bottom: 12px; padding: 13px 15px; border-radius: 12px; background: var(--primary-soft);
+}
+.mode-summary span[data-v-55ee4f66], .plan-state span[data-v-55ee4f66], .safety-note span[data-v-55ee4f66] { color: var(--muted); font-size: 12px;
+}
+.mode-summary.delete[data-v-55ee4f66] { background: rgba(196, 75, 71, .08);
+}
+.plan-resources[data-v-55ee4f66] { max-height: 170px; overflow: auto; margin-bottom: 12px; border: 1px solid var(--line); border-radius: 12px;
+}
+.plan-resources > div[data-v-55ee4f66] { display: flex; justify-content: space-between; align-items: center; padding: 10px 13px; border-bottom: 1px solid var(--line);
+}
+.plan-resources > div[data-v-55ee4f66]:last-child { border-bottom: 0;
+}
+.plan-resources span[data-v-55ee4f66] { color: var(--muted); font-size: 11px;
+}
+.plan-state.passed[data-v-55ee4f66] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.plan-state.blocked[data-v-55ee4f66], .issues.blocked[data-v-55ee4f66] { color: var(--danger); background: rgba(196, 75, 71, .08);
+}
+.issues[data-v-55ee4f66] { display: grid; gap: 6px; margin: 0 0 12px; padding: 12px 16px 12px 34px; border-radius: 12px; font-size: 13px;
+}
+.issues.warning[data-v-55ee4f66] { color: var(--warn); background: rgba(184, 107, 17, .08);
+}
+.risk-check[data-v-55ee4f66] { position: relative; display: flex; align-items: center; gap: 9px; margin: 12px 0; font-size: 13px; font-weight: 700;
+}
+.risk-check > span[data-v-55ee4f66] { width: 20px; height: 20px; border: 1px solid rgba(100, 116, 139, .35); border-radius: 6px;
+}
+.risk-check input:checked + span[data-v-55ee4f66] { border-color: var(--primary); background: var(--primary); box-shadow: inset 0 0 0 4px var(--surface);
+}
+.safety-note[data-v-55ee4f66] { display: flex; align-items: center; background: rgba(100, 116, 139, .08);
+}
+.safety-note p[data-v-55ee4f66] { flex: 1;
+}
+.confirm-button[data-v-55ee4f66], .execution-result button[data-v-55ee4f66] {
+  width: 100%;
+  min-height: 46px;
+  border: 0;
+  border-radius: 11px;
+  background: var(--primary);
+  color: white;
+  font-weight: 800;
+  cursor: pointer;
+}
+.confirm-button[data-v-55ee4f66]:disabled { background: rgba(100, 116, 139, .22); color: var(--muted); cursor: not-allowed;
+}
+.final-confirmation[data-v-55ee4f66], .execution-result[data-v-55ee4f66] { display: grid; gap: 10px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.final-confirmation > div[data-v-55ee4f66] { display: flex; gap: 8px;
+}
+.final-confirmation button[data-v-55ee4f66] { flex: 1; min-height: 42px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); cursor: pointer;
+}
+.final-confirmation button.danger[data-v-55ee4f66] { border-color: transparent; background: var(--danger); color: white;
+}
+.error-text[data-v-55ee4f66] { color: var(--danger); font-size: 13px;
+}
+.execution-result[data-v-55ee4f66] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.compact-modal[data-v-55ee4f66] { width: min(650px, 90vw);
+}
+.gap-row[data-v-55ee4f66], .recovery-row[data-v-55ee4f66] { display: flex; align-items: center; gap: 8px; padding: 11px 4px; border-bottom: 1px solid var(--line);
+}
+.gap-row p[data-v-55ee4f66], .recovery-row p[data-v-55ee4f66] { flex: 1;
+}
+.gap-row span[data-v-55ee4f66], .recovery-row span[data-v-55ee4f66] { color: var(--muted); font-size: 11px;
+}
+.gap-row b[data-v-55ee4f66] { font-size: 12px; color: var(--warn);
+}
+.recovery-row button[data-v-55ee4f66], .recovery-confirm button[data-v-55ee4f66] { padding: 7px 10px; border: 1px solid var(--line); border-radius: 8px; background: transparent; cursor: pointer;
+}
+.recovery-confirm[data-v-55ee4f66] { display: grid; gap: 8px; margin-top: 14px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.recovery-confirm input[data-v-55ee4f66] { height: 40px; padding: 0 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); color: inherit;
+}
+@media (max-width: 1250px) {
+.table-head[data-v-55ee4f66], .resource-row[data-v-55ee4f66] {
+    grid-template-columns: 38px minmax(240px, 1.3fr) minmax(150px, .7fr) minmax(310px, 1.35fr) 120px minmax(200px, .9fr);
+}
+}
+@media (max-width: 760px) {
+.cleanup-app[data-v-55ee4f66] {
+    min-width: 0;
+    overflow-x: clip;
+    padding: 14px 12px 190px;
+}
+.page-header[data-v-55ee4f66] {
+    display: grid;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+.eyebrow[data-v-55ee4f66] { font-size: 10px;
+}
+.page-header h1[data-v-55ee4f66] { font-size: 27px;
+}
+.page-header > div > span[data-v-55ee4f66] {
+    display: block;
+    margin-top: 3px;
+    font-size: 12px;
+    line-height: 1.5;
+}
+.status-card[data-v-55ee4f66] {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+}
+.toolbar[data-v-55ee4f66] {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 8px;
+}
+.search[data-v-55ee4f66] {
+    grid-column: 1 / -1;
+    height: 44px;
+    box-sizing: border-box;
+}
+.safe-toggle[data-v-55ee4f66] {
+    min-width: 0;
+    font-size: 12px;
+}
+.soft-button[data-v-55ee4f66] { padding: 0 10px; font-size: 12px;
+}
+.icon-button[data-v-55ee4f66] { width: 40px;
+}
+.notice[data-v-55ee4f66] {
+    align-items: flex-start;
+    padding: 11px 12px;
+}
+.notice p strong[data-v-55ee4f66] { font-size: 14px;
+}
+.notice p span[data-v-55ee4f66] { font-size: 11px;
+}
+.notice b[data-v-55ee4f66] { display: none;
+}
+.filters[data-v-55ee4f66] {
+    overflow-x: auto;
+    width: calc(100vw - 24px);
+    padding: 0 0 4px;
+    scrollbar-width: none;
+}
+.filters[data-v-55ee4f66]::-webkit-scrollbar { display: none;
+}
+.filters button[data-v-55ee4f66] {
+    flex: 0 0 auto;
+    padding: 8px 11px;
+    white-space: nowrap;
+}
+.resource-card[data-v-55ee4f66] {
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+}
+.table-head[data-v-55ee4f66] { display: none;
+}
+.resource-row[data-v-55ee4f66] {
+    grid-template-areas:
+      "check title"
+      ". library"
+      ". seed"
+      ". size"
+      ". impact";
+    grid-template-columns: 34px minmax(0, 1fr);
+    gap: 12px 10px;
+    min-height: 0;
+    margin-bottom: 10px;
+    padding: 15px 13px;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: var(--surface);
+    box-shadow: 0 5px 18px rgba(15, 23, 42, .04);
+}
+.resource-row[data-v-55ee4f66]:last-child { border-bottom: 1px solid var(--line);
+}
+.row-check[data-v-55ee4f66] {
+    grid-area: check;
+    align-self: start;
+    width: 26px;
+    height: 26px;
+}
+.resource-title[data-v-55ee4f66] {
+    grid-area: title;
+    padding-right: 0;
+}
+.resource-title strong[data-v-55ee4f66] { font-size: 16px;
+}
+.resource-title b[data-v-55ee4f66] { font-size: 12px;
+}
+.resource-title span[data-v-55ee4f66] { white-space: normal;
+}
+.stack-cell.library[data-v-55ee4f66] { grid-area: library;
+}
+.seed-cell[data-v-55ee4f66] { grid-area: seed;
+}
+.stack-cell.size[data-v-55ee4f66] { grid-area: size;
+}
+.impact[data-v-55ee4f66] { grid-area: impact;
+}
+.stack-cell[data-v-55ee4f66], .seed-cell[data-v-55ee4f66], .impact[data-v-55ee4f66] {
+    min-width: 0;
+    padding: 10px 0 0;
+    border-top: 1px solid var(--line);
+}
+.stack-cell[data-v-55ee4f66]::before, .seed-cell[data-v-55ee4f66]::before, .impact[data-v-55ee4f66]::before {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--muted);
+    content: attr(data-label);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: .06em;
+}
+.impact[data-v-55ee4f66] {
+    padding-left: 0;
+    border-left: 0;
+}
+.impact.danger[data-v-55ee4f66] { border-left: 0;
+}
+.seed-task[data-v-55ee4f66] {
+    grid-template-columns: 58px minmax(58px, auto) minmax(0, 1fr);
+    gap: 6px;
+    padding-left: 6px;
+}
+.seed-task i[data-v-55ee4f66] { padding: 4px 6px; font-size: 10px;
+}
+.seed-task strong[data-v-55ee4f66] { font-size: 12px;
+}
+.seed-task span[data-v-55ee4f66] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.action-bar[data-v-55ee4f66] {
+    z-index: 2600;
+    right: 10px;
+    bottom: calc(78px + env(safe-area-inset-bottom, 0px));
+    left: 10px;
+    display: grid;
+    grid-template-columns: 38px minmax(0, 1fr) auto;
+    gap: 8px 10px;
+    padding: 10px;
+    border-radius: 15px;
+}
+.selected-count[data-v-55ee4f66] {
+    width: 38px;
+    height: 38px;
+    border-radius: 10px;
+    font-size: 16px;
+}
+.action-bar > p[data-v-55ee4f66] {
+    min-width: 0;
+}
+.action-bar > p strong[data-v-55ee4f66] {
+    overflow: hidden;
+    font-size: 13px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.action-bar > p span[data-v-55ee4f66] { font-size: 10px;
+}
+.clear-button[data-v-55ee4f66] {
+    padding: 0 4px;
+    font-size: 12px;
+}
+.action-buttons[data-v-55ee4f66] {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 7px;
+}
+.action-level[data-v-55ee4f66] {
+    display: block;
+    min-width: 0;
+    min-height: 42px;
+    padding: 9px 5px;
+    text-align: center;
+}
+.action-level strong[data-v-55ee4f66] {
+    display: block;
+    font-size: 13px;
+    white-space: nowrap;
+}
+.action-level span[data-v-55ee4f66] { display: none;
+}
+.modal-backdrop[data-v-55ee4f66] {
+    z-index: 3000;
+    padding:
+      max(12px, env(safe-area-inset-top, 0px))
+      12px
+      max(12px, env(safe-area-inset-bottom, 0px));
+}
+.modal[data-v-55ee4f66], .compact-modal[data-v-55ee4f66] {
+    width: calc(100vw - 24px);
+    max-height: calc(100dvh - 24px);
+    box-sizing: border-box;
+    padding: 16px;
+    border-radius: 16px;
+}
+.modal h2[data-v-55ee4f66] { font-size: 21px;
+}
+.modal > header[data-v-55ee4f66] { margin-bottom: 12px;
+}
+.mode-summary[data-v-55ee4f66], .plan-state[data-v-55ee4f66], .safety-note[data-v-55ee4f66] { padding: 11px 12px;
+}
+.plan-resources[data-v-55ee4f66] { max-height: 120px;
+}
+.plan-resources > div[data-v-55ee4f66] { gap: 8px; padding: 9px 10px;
+}
+.plan-resources p[data-v-55ee4f66] { min-width: 0;
+}
+.plan-resources p span[data-v-55ee4f66] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.issues[data-v-55ee4f66] { padding: 10px 12px 10px 28px; font-size: 12px;
+}
+.final-confirmation > div[data-v-55ee4f66] { display: grid; grid-template-columns: 1fr 1fr;
+}
+.gap-row[data-v-55ee4f66], .recovery-row[data-v-55ee4f66] {
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+.recovery-row p[data-v-55ee4f66] { flex-basis: 100%;
+}
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_expose_AppPage-Dw3pzGGM.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_expose_AppPage-Dw3pzGGM.js
@@ -1,0 +1,1001 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
+
+const FILTERS = [
+  { id: 'all', label: '全部资源' },
+  { id: 'library', label: '媒体库已入库' },
+  { id: 'hr', label: 'H&R 保护中' },
+  { id: 'brush', label: '刷流任务' },
+  { id: 'review', label: '无做种限制' },
+  { id: 'names', label: '名称待核' },
+];
+
+const ACTIONS = {
+  pause: {
+    title: '停止做种',
+    detail: '保留 qB 任务和全部文件',
+  },
+  retire: {
+    title: '退出做种',
+    detail: '移除 qB 任务，媒体仍保留',
+  },
+  delete: {
+    title: '完整删除',
+    detail: '移除任务、媒体和全部链接',
+  },
+};
+
+function unwrapResponse(response) {
+  if (response && Object.prototype.hasOwnProperty.call(response, 'data') && response.success !== undefined) {
+    return response.data
+  }
+  return response?.data ?? response
+}
+
+function createLatestPlanApi(api) {
+  let generation = 0;
+  let latestPlanResult = null;
+
+  return {
+    ...api,
+    get(...args) {
+      return api.get(...args)
+    },
+    post(path, body, ...args) {
+      if (!String(path || '').endsWith('/plan')) {
+        return api.post(path, body, ...args)
+      }
+
+      const requestGeneration = ++generation;
+      let rawRequest;
+      try {
+        rawRequest = Promise.resolve(api.post(path, body, ...args));
+      } catch (error) {
+        rawRequest = Promise.reject(error);
+      }
+
+      const result = (async () => {
+        try {
+          const response = await rawRequest;
+          if (requestGeneration !== generation && latestPlanResult) {
+            return await latestPlanResult
+          }
+          return response
+        } catch (error) {
+          if (requestGeneration !== generation && latestPlanResult) {
+            return await latestPlanResult
+          }
+          throw error
+        }
+      })();
+      latestPlanResult = result;
+      return result
+    },
+  }
+}
+
+function matchesFilter(item, filter) {
+  if (filter === 'all') return true
+  if (filter === 'library') return Boolean(item.library)
+  if (filter === 'hr') return Boolean(item.hr || item.hrPending)
+  if (filter === 'brush') return Boolean(item.brush)
+  if (filter === 'review') return !item.protected && item.qbSummary === '无 qB 任务'
+  return item.metadataVerified === false
+}
+
+function isDirectlyCleanable(item) {
+  return !item.protected && item.qbSummary === '无 qB 任务'
+}
+
+function filterResources(resources, { filter, search, safeOnly, descending }) {
+  const query = String(search || '').trim().toLowerCase();
+  return [...(resources || [])]
+    .filter(item => {
+      const text = `${item.title || ''} ${item.englishTitle || ''} ${item.edition || ''} ${item.siteSummary || ''}`.toLowerCase();
+      return matchesFilter(item, filter) &&
+        (!safeOnly || isDirectlyCleanable(item)) &&
+        (!query || text.includes(query))
+    })
+    .sort((left, right) => {
+      const order = descending ? Number(right.size || 0) - Number(left.size || 0) : Number(left.size || 0) - Number(right.size || 0);
+      return order || String(left.title || '').localeCompare(String(right.title || ''), 'zh-CN')
+    })
+}
+
+function formatGiB(size) {
+  const numeric = Number(size || 0);
+  return numeric >= 1024 ? `${(numeric / 1024).toFixed(2)} TB` : `${numeric.toFixed(1)} GB`
+}
+
+function formatBytes(size) {
+  return formatGiB(Number(size || 0) / 1024 ** 3)
+}
+
+function issueKey(issue, index) {
+  return `${issue?.code || 'issue'}-${index}`
+}
+
+const {createElementVNode:_createElementVNode,toDisplayString:_toDisplayString,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,normalizeClass:_normalizeClass,vModelText:_vModelText,withDirectives:_withDirectives,vModelCheckbox:_vModelCheckbox,createTextVNode:_createTextVNode,renderList:_renderList,Fragment:_Fragment,unref:_unref,withModifiers:_withModifiers,Teleport:_Teleport,createBlock:_createBlock} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "cleanup-app" };
+const _hoisted_2 = {
+  key: 0,
+  class: "page-header"
+};
+const _hoisted_3 = { key: 0 };
+const _hoisted_4 = { class: "toolbar" };
+const _hoisted_5 = { class: "search" };
+const _hoisted_6 = { class: "safe-toggle" };
+const _hoisted_7 = ["disabled"];
+const _hoisted_8 = {
+  class: "filters",
+  "aria-label": "资源筛选"
+};
+const _hoisted_9 = ["onClick"];
+const _hoisted_10 = { class: "resource-card" };
+const _hoisted_11 = { class: "table-head" };
+const _hoisted_12 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_13 = ["disabled", "onClick"];
+const _hoisted_14 = { class: "resource-title" };
+const _hoisted_15 = {
+  class: "stack-cell library",
+  "data-label": "媒体库"
+};
+const _hoisted_16 = {
+  class: "seed-cell",
+  "data-label": "做种与保护"
+};
+const _hoisted_17 = {
+  key: 1,
+  class: "stack-cell"
+};
+const _hoisted_18 = {
+  class: "stack-cell size",
+  "data-label": "实际占用"
+};
+const _hoisted_19 = {
+  key: 2,
+  class: "empty-state"
+};
+const _hoisted_20 = {
+  key: 0,
+  class: "action-bar"
+};
+const _hoisted_21 = { class: "selected-count" };
+const _hoisted_22 = { class: "action-buttons" };
+const _hoisted_23 = ["onClick"];
+const _hoisted_24 = {
+  class: "modal plan-modal",
+  role: "dialog",
+  "aria-modal": "true"
+};
+const _hoisted_25 = ["disabled"];
+const _hoisted_26 = { key: 0 };
+const _hoisted_27 = { key: 1 };
+const _hoisted_28 = { class: "plan-resources" };
+const _hoisted_29 = {
+  key: 0,
+  class: "plan-state"
+};
+const _hoisted_30 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_31 = {
+  key: 0,
+  class: "issues blocked"
+};
+const _hoisted_32 = {
+  key: 1,
+  class: "issues warning"
+};
+const _hoisted_33 = {
+  key: 2,
+  class: "risk-check"
+};
+const _hoisted_34 = ["checked"];
+const _hoisted_35 = {
+  key: 3,
+  class: "plan-state blocked"
+};
+const _hoisted_36 = { class: "safety-note" };
+const _hoisted_37 = {
+  key: 3,
+  class: "execution-result"
+};
+const _hoisted_38 = {
+  key: 4,
+  class: "final-confirmation"
+};
+const _hoisted_39 = {
+  key: 0,
+  class: "error-text"
+};
+const _hoisted_40 = ["disabled"];
+const _hoisted_41 = ["disabled"];
+const _hoisted_42 = ["disabled"];
+const _hoisted_43 = { class: "modal compact-modal" };
+const _hoisted_44 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_45 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_46 = { class: "modal compact-modal" };
+const _hoisted_47 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_48 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_49 = ["onClick"];
+const _hoisted_50 = ["onClick"];
+const _hoisted_51 = {
+  key: 2,
+  class: "recovery-confirm"
+};
+const _hoisted_52 = ["disabled"];
+
+const {computed,onMounted,ref} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'AppPage',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+  hideTitle: { type: Boolean, default: false },
+},
+  setup(__props) {
+
+const props = __props;
+
+const emptySnapshot = {
+  schemaVersion: 2,
+  snapshotId: '',
+  generatedAt: '',
+  stats: {},
+  resources: [],
+};
+
+const snapshot = ref(emptySnapshot);
+const health = ref({});
+const loading = ref(true);
+const refreshing = ref(false);
+const error = ref('');
+const search = ref('');
+const activeFilter = ref('all');
+const safeOnly = ref(false);
+const descending = ref(true);
+const selected = ref([]);
+
+const planOpen = ref(false);
+const planMode = ref(null);
+const plan = ref(null);
+const planLoading = ref(false);
+const planError = ref('');
+const acknowledgeSiteRisk = ref(false);
+const finalConfirmation = ref(false);
+const executing = ref(false);
+const executeError = ref('');
+const executeResult = ref(null);
+
+const gapOpen = ref(false);
+const gapLoading = ref(false);
+const gaps = ref([]);
+const gapError = ref('');
+
+const recoveryOpen = ref(false);
+const recoveryLoading = ref(false);
+const recoveries = ref([]);
+const recoveryError = ref('');
+const recoveryTarget = ref(null);
+const recoveryAction = ref(null);
+const recoveryPhrase = ref('');
+const recovering = ref(false);
+
+const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`);
+const resources = computed(() => snapshot.value.resources || []);
+const visible = computed(() => filterResources(resources.value, {
+  filter: activeFilter.value,
+  search: search.value,
+  safeOnly: safeOnly.value,
+  descending: descending.value,
+}));
+const selectedItems = computed(() => resources.value.filter(item => selected.value.includes(item.id)));
+const selectedSize = computed(() => selectedItems.value.reduce((total, item) => total + Number(item.size || 0), 0));
+const executionEnabled = computed(() => Boolean(health.value.executionEnabled));
+const inventoryCurrent = computed(() => health.value.inventoryCurrent !== false);
+const unresolvedTransactions = computed(() => Number(snapshot.value.stats?.unresolvedTransactions || 0));
+const hrGap = computed(() => Math.max(
+  0,
+  Number(
+    snapshot.value.stats?.hrMissingQbTasks ??
+    Number(snapshot.value.stats?.hrActiveTitles || 0) - Number(snapshot.value.stats?.hrMatchedQbTasks || 0),
+  ),
+));
+const hrUnassigned = computed(() => Number(
+  snapshot.value.stats?.hrMissingUnassigned ??
+  snapshot.value.stats?.hrMissingUncovered ??
+  0,
+));
+const filters = computed(() => FILTERS.map(filter => ({
+  ...filter,
+  count: resources.value.filter(item => {
+    if (filter.id === 'all') return true
+    return filterResources([item], {
+      filter: filter.id,
+      search: '',
+      safeOnly: false,
+      descending: true,
+    }).length === 1
+  }).length,
+})));
+const allVisibleSelected = computed(() => {
+  const selectable = visible.value.filter(item => !item.protected);
+  return selectable.length > 0 && selectable.every(item => selected.value.includes(item.id))
+});
+const currentAction = computed(() => planMode.value ? ACTIONS[planMode.value] : null);
+const planExpired = computed(() => Boolean(plan.value && Date.parse(plan.value.expiresAt) <= Date.now()));
+
+function payloadError(payload, fallback) {
+  return payload?.error?.message || fallback
+}
+
+async function get(path) {
+  return unwrapResponse(await props.api.get(`${pluginBase.value}${path}`))
+}
+
+async function post(path, body) {
+  return unwrapResponse(await props.api.post(`${pluginBase.value}${path}`, body))
+}
+
+function acceptSnapshot(next) {
+  if (!next || next.schemaVersion !== 2 || !next.snapshotId || !Array.isArray(next.resources)) {
+    throw new Error('资源快照格式不受支持。')
+  }
+  snapshot.value = next;
+  const available = new Set(next.resources.map(item => item.id));
+  selected.value = selected.value.filter(id => available.has(id));
+}
+
+async function loadStatus() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const payload = await get('/status');
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '无法读取清理台状态。'))
+    health.value = payload.health || {};
+    acceptSnapshot(payload.snapshot);
+  } catch (err) {
+    error.value = err?.message || '无法读取清理台状态。';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function refreshSnapshot() {
+  refreshing.value = true;
+  error.value = '';
+  try {
+    const payload = await post('/refresh', {});
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '刷新失败。'))
+    acceptSnapshot(payload.snapshot);
+    health.value = { ...health.value, inventoryCurrent: true };
+  } catch (err) {
+    error.value = err?.message || '刷新失败，继续显示上次快照。';
+    health.value = { ...health.value, inventoryCurrent: false };
+  } finally {
+    refreshing.value = false;
+  }
+}
+
+function toggle(item) {
+  if (item.protected) return
+  selected.value = selected.value.includes(item.id)
+    ? selected.value.filter(id => id !== item.id)
+    : [...selected.value, item.id];
+}
+
+function toggleVisible() {
+  const ids = visible.value.filter(item => !item.protected).map(item => item.id);
+  selected.value = allVisibleSelected.value
+    ? selected.value.filter(id => !ids.includes(id))
+    : [...new Set([...selected.value, ...ids])];
+}
+
+async function requestPlan(mode, acknowledged = false) {
+  planLoading.value = true;
+  planError.value = '';
+  plan.value = null;
+  finalConfirmation.value = false;
+  try {
+    const payload = await post('/plan', {
+      snapshotId: snapshot.value.snapshotId,
+      resourceIds: selected.value,
+      mode,
+      acknowledgeSiteRisk: acknowledged,
+    });
+    if (!payload?.ok || !payload.plan) throw new Error(payloadError(payload, '无法生成执行计划。'))
+    plan.value = payload.plan;
+  } catch (err) {
+    planError.value = err?.message || '无法生成执行计划。';
+  } finally {
+    planLoading.value = false;
+  }
+}
+
+function openPlan(mode) {
+  planMode.value = mode;
+  planOpen.value = true;
+  acknowledgeSiteRisk.value = false;
+  executeResult.value = null;
+  executeError.value = '';
+  requestPlan(mode, false);
+}
+
+function closePlan() {
+  if (executing.value) return
+  planOpen.value = false;
+  planMode.value = null;
+  plan.value = null;
+  planError.value = '';
+  finalConfirmation.value = false;
+  executeResult.value = null;
+}
+
+async function setSiteRisk(value) {
+  acknowledgeSiteRisk.value = value;
+  await requestPlan(planMode.value, value);
+}
+
+async function executePlan() {
+  if (!plan.value || planExpired.value || executing.value) return
+  executing.value = true;
+  executeError.value = '';
+  try {
+    const payload = await post('/execute', {
+      planId: plan.value.planId,
+      confirmPhrase: plan.value.confirmPhrase,
+    });
+    if (!payload?.ok || !payload.result) {
+      if (payload?.error?.plan) plan.value = payload.error.plan;
+      throw new Error(payloadError(payload, '执行失败。'))
+    }
+    executeResult.value = payload.result;
+    selected.value = [];
+    if (payload.result.snapshotRefreshPending) {
+      health.value = { ...health.value, inventoryCurrent: false };
+    } else {
+      const latest = await get('/snapshot');
+      if (latest?.snapshot) acceptSnapshot(latest.snapshot);
+    }
+  } catch (err) {
+    executeError.value = err?.message || '执行失败。';
+    finalConfirmation.value = false;
+  } finally {
+    executing.value = false;
+  }
+}
+
+async function loadGaps() {
+  gapOpen.value = true;
+  gapLoading.value = true;
+  gapError.value = '';
+  try {
+    const payload = await get('/protection-gaps');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取 H&R 缺口。'))
+    gaps.value = payload.gaps || [];
+  } catch (err) {
+    gapError.value = err?.message || '无法读取 H&R 缺口。';
+  } finally {
+    gapLoading.value = false;
+  }
+}
+
+async function loadRecoveries() {
+  recoveryOpen.value = true;
+  recoveryLoading.value = true;
+  recoveryError.value = '';
+  recoveryTarget.value = null;
+  try {
+    const payload = await get('/recovery');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取恢复状态。'))
+    recoveries.value = payload.recoveries || [];
+  } catch (err) {
+    recoveryError.value = err?.message || '无法读取恢复状态。';
+  } finally {
+    recoveryLoading.value = false;
+  }
+}
+
+function chooseRecovery(item, action) {
+  recoveryTarget.value = item;
+  recoveryAction.value = action;
+  recoveryPhrase.value = '';
+  recoveryError.value = '';
+}
+
+async function runRecovery() {
+  if (!recoveryTarget.value || !recoveryAction.value || recovering.value) return
+  recovering.value = true;
+  recoveryError.value = '';
+  try {
+    const payload = await post('/recovery', {
+      planId: recoveryTarget.value.planId,
+      action: recoveryAction.value,
+      confirmPhrase: recoveryPhrase.value,
+    });
+    if (!payload?.ok) throw new Error(payloadError(payload, '恢复操作失败。'))
+    await refreshSnapshot();
+    await loadRecoveries();
+  } catch (err) {
+    recoveryError.value = err?.message || '恢复操作失败。';
+  } finally {
+    recovering.value = false;
+  }
+}
+
+function recoveryExpectedPhrase() {
+  if (!recoveryTarget.value || !recoveryAction.value) return ''
+  return recoveryAction.value === 'rollback'
+    ? recoveryTarget.value.rollbackPhrase
+    : recoveryTarget.value.finalizePhrase
+}
+
+onMounted(loadStatus);
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("main", _hoisted_1, [
+    (!__props.hideTitle)
+      ? (_openBlock(), _createElementBlock("header", _hoisted_2, [
+          _cache[12] || (_cache[12] = _createElementVNode("div", null, [
+            _createElementVNode("p", { class: "eyebrow" }, "PiNAS · MoviePilot 原生页面"),
+            _createElementVNode("h1", null, "存储清理"),
+            _createElementVNode("span", null, "一部电影一行，一部剧一行；先看清影响，再选择清理等级。")
+          ], -1)),
+          _createElementVNode("div", {
+            class: _normalizeClass(['status-card', { danger: error.value || !inventoryCurrent.value }])
+          }, [
+            _createElementVNode("i", null, _toDisplayString(error.value || !inventoryCurrent.value ? '!' : '✓'), 1),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(error.value || (executionEnabled.value ? '执行链路已连接' : '只读模式')), 1),
+              (snapshot.value.generatedAt)
+                ? (_openBlock(), _createElementBlock("span", _hoisted_3, "更新于 " + _toDisplayString(snapshot.value.generatedAt.slice(5, 16).replace('T', ' ')), 1))
+                : _createCommentVNode("", true)
+            ])
+          ], 2)
+        ]))
+      : _createCommentVNode("", true),
+    _createElementVNode("section", _hoisted_4, [
+      _createElementVNode("label", _hoisted_5, [
+        _cache[13] || (_cache[13] = _createElementVNode("span", null, "⌕", -1)),
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((search).value = $event)),
+          "aria-label": "搜索资源",
+          placeholder: "搜索电影、剧集、季度或站点"
+        }, null, 512), [
+          [_vModelText, search.value]
+        ])
+      ]),
+      _createElementVNode("label", _hoisted_6, [
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[1] || (_cache[1] = $event => ((safeOnly).value = $event)),
+          type: "checkbox"
+        }, null, 512), [
+          [_vModelCheckbox, safeOnly.value]
+        ]),
+        _cache[14] || (_cache[14] = _createElementVNode("span", null, null, -1)),
+        _cache[15] || (_cache[15] = _createTextVNode(" 仅看无做种限制 ", -1))
+      ]),
+      _createElementVNode("button", {
+        class: "soft-button",
+        type: "button",
+        onClick: _cache[2] || (_cache[2] = $event => (descending.value = !descending.value))
+      }, " 实际占用 " + _toDisplayString(descending.value ? '↓' : '↑'), 1),
+      _createElementVNode("button", {
+        class: "icon-button",
+        type: "button",
+        disabled: refreshing.value,
+        onClick: refreshSnapshot
+      }, _toDisplayString(refreshing.value ? '…' : '↻'), 9, _hoisted_7)
+    ]),
+    (unresolvedTransactions.value)
+      ? (_openBlock(), _createElementBlock("button", {
+          key: 1,
+          class: "notice critical",
+          type: "button",
+          onClick: loadRecoveries
+        }, [
+          _cache[17] || (_cache[17] = _createElementVNode("i", null, "!", -1)),
+          _createElementVNode("p", null, [
+            _createElementVNode("strong", null, _toDisplayString(unresolvedTransactions.value) + " 个未完成清理事务", 1),
+            _cache[16] || (_cache[16] = _createElementVNode("span", null, "新操作已锁定；请先核对并恢复原事务。", -1))
+          ]),
+          _cache[18] || (_cache[18] = _createElementVNode("b", null, "查看恢复状态", -1))
+        ]))
+      : (hrGap.value)
+        ? (_openBlock(), _createElementBlock("button", {
+            key: 2,
+            class: _normalizeClass(['notice', { warning: hrUnassigned.value }]),
+            type: "button",
+            onClick: loadGaps
+          }, [
+            _cache[19] || (_cache[19] = _createElementVNode("i", null, "H", -1)),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(hrGap.value) + " 个学校站 H&R 尚未恢复完成", 1),
+              _createElementVNode("span", null, _toDisplayString(hrUnassigned.value
+            ? `${hrUnassigned.value} 个未精确关联媒体；不会锁定无关资源。`
+            : '缺失任务只锁定精确关联资源，其他资源可独立清理。'), 1)
+            ]),
+            _cache[20] || (_cache[20] = _createElementVNode("b", null, "查看明细", -1))
+          ], 2))
+        : _createCommentVNode("", true),
+    _createElementVNode("nav", _hoisted_8, [
+      (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(filters.value, (filter) => {
+        return (_openBlock(), _createElementBlock("button", {
+          key: filter.id,
+          class: _normalizeClass({ active: activeFilter.value === filter.id }),
+          type: "button",
+          onClick: $event => (activeFilter.value = filter.id)
+        }, [
+          _createTextVNode(_toDisplayString(filter.label) + " ", 1),
+          _createElementVNode("span", null, _toDisplayString(filter.count), 1)
+        ], 10, _hoisted_9))
+      }), 128))
+    ]),
+    _createElementVNode("section", _hoisted_10, [
+      _createElementVNode("div", _hoisted_11, [
+        _createElementVNode("button", {
+          class: "select-all",
+          type: "button",
+          onClick: toggleVisible
+        }, _toDisplayString(allVisibleSelected.value ? '✓' : ''), 1),
+        _cache[21] || (_cache[21] = _createElementVNode("span", null, "资源", -1)),
+        _cache[22] || (_cache[22] = _createElementVNode("span", null, "媒体库", -1)),
+        _cache[23] || (_cache[23] = _createElementVNode("span", null, "做种与保护", -1)),
+        _cache[24] || (_cache[24] = _createElementVNode("span", null, "实际占用", -1)),
+        _cache[25] || (_cache[25] = _createElementVNode("span", null, "完整删除影响", -1))
+      ]),
+      (loading.value)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_12, "正在读取真实资源关系…"))
+        : (_openBlock(true), _createElementBlock(_Fragment, { key: 1 }, _renderList(visible.value, (item) => {
+            return (_openBlock(), _createElementBlock("article", {
+              key: item.id,
+              class: _normalizeClass(['resource-row', { selected: selected.value.includes(item.id) }])
+            }, [
+              _createElementVNode("button", {
+                class: _normalizeClass(['row-check', { locked: item.protected }]),
+                type: "button",
+                disabled: item.protected,
+                onClick: $event => (toggle(item))
+              }, _toDisplayString(item.protected ? '锁' : selected.value.includes(item.id) ? '✓' : ''), 11, _hoisted_13),
+              _createElementVNode("div", _hoisted_14, [
+                _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                _createElementVNode("b", null, _toDisplayString(item.englishTitle), 1),
+                _createElementVNode("span", null, _toDisplayString([item.type, item.year, item.edition].filter(Boolean).join(' · ')), 1)
+              ]),
+              _createElementVNode("div", _hoisted_15, [
+                _createElementVNode("strong", null, _toDisplayString(item.librarySummary), 1),
+                _createElementVNode("span", null, _toDisplayString(item.libraryDetail), 1)
+              ]),
+              _createElementVNode("div", _hoisted_16, [
+                (item.seedTasks?.length)
+                  ? (_openBlock(true), _createElementBlock(_Fragment, { key: 0 }, _renderList(item.seedTasks, (task, index) => {
+                      return (_openBlock(), _createElementBlock("div", {
+                        key: `${task.site}-${task.scope}-${index}`,
+                        class: _normalizeClass(['seed-task', task.tone])
+                      }, [
+                        _createElementVNode("i", null, _toDisplayString(task.status), 1),
+                        _createElementVNode("strong", null, _toDisplayString(task.site), 1),
+                        _createElementVNode("span", null, _toDisplayString(task.scope) + _toDisplayString(task.count > 1 ? ` · ${task.count} 个任务` : ''), 1)
+                      ], 2))
+                    }), 128))
+                  : (_openBlock(), _createElementBlock("div", _hoisted_17, [
+                      _createElementVNode("strong", null, _toDisplayString(item.qbSummary), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.siteSummary), 1)
+                    ]))
+              ]),
+              _createElementVNode("div", _hoisted_18, [
+                _createElementVNode("strong", null, _toDisplayString(item.sizeLabel), 1),
+                _createElementVNode("span", null, _toDisplayString(item.reclaimLabel), 1)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['impact', { danger: item.protected }]),
+                "data-label": "完整删除影响"
+              }, [
+                _createElementVNode("strong", null, _toDisplayString(item.impactTitle), 1),
+                _createElementVNode("span", null, _toDisplayString(item.impactDetail), 1)
+              ], 2)
+            ], 2))
+          }), 128)),
+      (!loading.value && !visible.value.length)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_19, " 没有符合条件的资源，请取消筛选或更换关键词。 "))
+        : _createCommentVNode("", true)
+    ]),
+    (_openBlock(), _createBlock(_Teleport, { to: "body" }, [
+      (selected.value.length)
+        ? (_openBlock(), _createElementBlock("aside", _hoisted_20, [
+            _createElementVNode("div", _hoisted_21, _toDisplayString(selected.value.length), 1),
+            _createElementVNode("p", null, [
+              _cache[26] || (_cache[26] = _createElementVNode("strong", null, "已加入清理计划", -1)),
+              _createElementVNode("span", null, "完整删除上限 " + _toDisplayString(_unref(formatGiB)(selectedSize.value)), 1)
+            ]),
+            _createElementVNode("button", {
+              class: "clear-button",
+              type: "button",
+              onClick: _cache[3] || (_cache[3] = $event => (selected.value = []))
+            }, "清空"),
+            _createElementVNode("div", _hoisted_22, [
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(ACTIONS), (action, mode) => {
+                return (_openBlock(), _createElementBlock("button", {
+                  key: mode,
+                  class: _normalizeClass(['action-level', { delete: mode === 'delete' }]),
+                  type: "button",
+                  onClick: $event => (openPlan(mode))
+                }, [
+                  _createElementVNode("strong", null, _toDisplayString(action.title), 1),
+                  _createElementVNode("span", null, _toDisplayString(action.detail), 1)
+                ], 10, _hoisted_23))
+              }), 128))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (planOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 1,
+            class: "modal-backdrop",
+            onClick: _withModifiers(closePlan, ["self"])
+          }, [
+            _createElementVNode("section", _hoisted_24, [
+              _createElementVNode("header", null, [
+                _createElementVNode("div", null, [
+                  _cache[27] || (_cache[27] = _createElementVNode("span", null, "清理等级 · 真实预演", -1)),
+                  _createElementVNode("h2", null, _toDisplayString(currentAction.value?.title), 1)
+                ]),
+                _createElementVNode("button", {
+                  type: "button",
+                  disabled: executing.value,
+                  onClick: closePlan
+                }, "×", 8, _hoisted_25)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['mode-summary', planMode.value])
+              }, [
+                (plan.value && planMode.value === 'delete')
+                  ? (_openBlock(), _createElementBlock("strong", _hoisted_26, "已核算可释放 " + _toDisplayString(_unref(formatBytes)(plan.value.estimatedReclaimBytes)), 1))
+                  : (_openBlock(), _createElementBlock("strong", _hoisted_27, _toDisplayString(currentAction.value?.detail), 1)),
+                _createElementVNode("span", null, _toDisplayString(planMode.value === 'pause'
+              ? '只改变 qB 运行状态，不删除任务或文件。'
+              : planMode.value === 'retire'
+                ? '移除 qB 任务但保留文件，媒体库继续可播放。'
+                : '仅当全部路径、硬链接、H&R 与任务状态通过校验才会放行。'), 1)
+              ], 2),
+              _createElementVNode("div", _hoisted_28, [
+                (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(selectedItems.value, (item) => {
+                  return (_openBlock(), _createElementBlock("div", {
+                    key: item.id
+                  }, [
+                    _createElementVNode("p", null, [
+                      _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.englishTitle) + " · " + _toDisplayString(item.edition), 1)
+                    ]),
+                    _createElementVNode("b", null, _toDisplayString(item.sizeLabel), 1)
+                  ]))
+                }), 128))
+              ]),
+              (planLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_29, "正在刷新 NAS 状态并复核关系…"))
+                : (planError.value)
+                  ? (_openBlock(), _createElementBlock("div", _hoisted_30, [
+                      _cache[28] || (_cache[28] = _createElementVNode("strong", null, "无法生成计划", -1)),
+                      _createElementVNode("span", null, _toDisplayString(planError.value), 1)
+                    ]))
+                  : (plan.value)
+                    ? (_openBlock(), _createElementBlock(_Fragment, { key: 2 }, [
+                        _createElementVNode("div", {
+                          class: _normalizeClass(['plan-state', plan.value.canExecute ? 'passed' : 'blocked'])
+                        }, [
+                          _createElementVNode("strong", null, _toDisplayString(plan.value.canExecute ? '安全预演通过' : '计划已被安全门禁拦截'), 1),
+                          _createElementVNode("span", null, " 停止 " + _toDisplayString(plan.value.operationCounts.qbStop) + " 个任务 · 退出 " + _toDisplayString(plan.value.operationCounts.qbRemoveKeepFiles) + " 个任务 · 解除 " + _toDisplayString(plan.value.operationCounts.unlinkFiles) + " 个文件入口 ", 1)
+                        ], 2),
+                        (plan.value.blocks?.length)
+                          ? (_openBlock(), _createElementBlock("ul", _hoisted_31, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.blocks, (issue, index) => {
+                                return (_openBlock(), _createElementBlock("li", {
+                                  key: _unref(issueKey)(issue, index)
+                                }, _toDisplayString(issue.message), 1))
+                              }), 128))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (plan.value.warnings?.length)
+                          ? (_openBlock(), _createElementBlock("ul", _hoisted_32, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.warnings, (issue, index) => {
+                                return (_openBlock(), _createElementBlock("li", {
+                                  key: _unref(issueKey)(issue, index)
+                                }, _toDisplayString(issue.message), 1))
+                              }), 128))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (plan.value.requiresSiteAcknowledgement)
+                          ? (_openBlock(), _createElementBlock("label", _hoisted_33, [
+                              _createElementVNode("input", {
+                                checked: acknowledgeSiteRisk.value,
+                                type: "checkbox",
+                                onChange: _cache[4] || (_cache[4] = $event => (setSiteRisk($event.target.checked)))
+                              }, null, 40, _hoisted_34),
+                              _cache[29] || (_cache[29] = _createElementVNode("span", null, null, -1)),
+                              _cache[30] || (_cache[30] = _createTextVNode(" 我已确认会影响私有站做种，并接受站点规则风险 ", -1))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (planExpired.value)
+                          ? (_openBlock(), _createElementBlock("div", _hoisted_35, [...(_cache[31] || (_cache[31] = [
+                              _createElementVNode("strong", null, "安全预演已过期", -1),
+                              _createElementVNode("span", null, "请关闭后重新生成。", -1)
+                            ]))]))
+                          : _createCommentVNode("", true)
+                      ], 64))
+                    : _createCommentVNode("", true),
+              _createElementVNode("div", _hoisted_36, [
+                _cache[33] || (_cache[33] = _createElementVNode("i", null, "盾", -1)),
+                _createElementVNode("p", null, [
+                  _createElementVNode("strong", null, _toDisplayString(executionEnabled.value ? '执行前还需第二次确认' : '执行引擎未启用'), 1),
+                  _cache[32] || (_cache[32] = _createElementVNode("span", null, "最终执行前会重新读取 qB、路径、硬链接和保护状态。", -1))
+                ])
+              ]),
+              (executeResult.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_37, [
+                    _createElementVNode("strong", null, _toDisplayString(currentAction.value?.title) + "已完成", 1),
+                    _createElementVNode("span", null, " 停止 " + _toDisplayString(executeResult.value.qbStopped) + " · 退出 " + _toDisplayString(executeResult.value.qbRemoved) + " · 删除文件入口 " + _toDisplayString(executeResult.value.filesDeleted) + " · 清理索引 " + _toDisplayString(executeResult.value.moviepilotIndexesDeleted), 1),
+                    _createElementVNode("button", {
+                      type: "button",
+                      onClick: closePlan
+                    }, "完成")
+                  ]))
+                : (finalConfirmation.value)
+                  ? (_openBlock(), _createElementBlock("div", _hoisted_38, [
+                      _cache[34] || (_cache[34] = _createElementVNode("strong", null, "再次确认：系统将立即执行这份计划", -1)),
+                      (executeError.value)
+                        ? (_openBlock(), _createElementBlock("span", _hoisted_39, _toDisplayString(executeError.value), 1))
+                        : _createCommentVNode("", true),
+                      _createElementVNode("div", null, [
+                        _createElementVNode("button", {
+                          type: "button",
+                          disabled: executing.value,
+                          onClick: _cache[5] || (_cache[5] = $event => (finalConfirmation.value = false))
+                        }, "返回", 8, _hoisted_40),
+                        _createElementVNode("button", {
+                          class: _normalizeClass({ danger: planMode.value === 'delete' }),
+                          type: "button",
+                          disabled: executing.value || planExpired.value,
+                          onClick: executePlan
+                        }, _toDisplayString(executing.value ? '正在二次复核…' : `确认${currentAction.value?.title}`), 11, _hoisted_41)
+                      ])
+                    ]))
+                  : (_openBlock(), _createElementBlock("button", {
+                      key: 5,
+                      class: "confirm-button",
+                      type: "button",
+                      disabled: !executionEnabled.value || !plan.value?.canExecute || planExpired.value,
+                      onClick: _cache[6] || (_cache[6] = $event => (finalConfirmation.value = true))
+                    }, " 进入最终确认 ", 8, _hoisted_42))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (gapOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 2,
+            class: "modal-backdrop",
+            onClick: _cache[8] || (_cache[8] = _withModifiers($event => (gapOpen.value = false), ["self"]))
+          }, [
+            _createElementVNode("section", _hoisted_43, [
+              _createElementVNode("header", null, [
+                _cache[35] || (_cache[35] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "学校站实时保护"),
+                  _createElementVNode("h2", null, "H&R 缺口明细")
+                ], -1)),
+                _createElementVNode("button", {
+                  onClick: _cache[7] || (_cache[7] = $event => (gapOpen.value = false))
+                }, "×")
+              ]),
+              (gapLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_44, "正在核对…"))
+                : _createCommentVNode("", true),
+              (gapError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_45, _toDisplayString(gapError.value), 1))
+                : _createCommentVNode("", true),
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(gaps.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.title,
+                  class: "gap-row"
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.linkedResourceTitle || '尚未精确关联媒体'), 1)
+                  ]),
+                  _createElementVNode("b", null, _toDisplayString(item.qbTaskPresent ? 'qB 已存在' : item.coveredByCandidate ? '候选恢复中' : '任务缺失'), 1)
+                ]))
+              }), 128))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (recoveryOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 3,
+            class: "modal-backdrop",
+            onClick: _cache[11] || (_cache[11] = _withModifiers($event => (recoveryOpen.value = false), ["self"]))
+          }, [
+            _createElementVNode("section", _hoisted_46, [
+              _createElementVNode("header", null, [
+                _cache[36] || (_cache[36] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "失败关闭"),
+                  _createElementVNode("h2", null, "恢复未完成清理")
+                ], -1)),
+                _createElementVNode("button", {
+                  onClick: _cache[9] || (_cache[9] = $event => (recoveryOpen.value = false))
+                }, "×")
+              ]),
+              (recoveryLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_47, "正在读取事务…"))
+                : _createCommentVNode("", true),
+              (recoveryError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_48, _toDisplayString(recoveryError.value), 1))
+                : _createCommentVNode("", true),
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(recoveries.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.planId,
+                  class: "recovery-row"
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.mode) + " · " + _toDisplayString(item.phase), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.planId.slice(-10)), 1)
+                  ]),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: $event => (chooseRecovery(item, 'rollback'))
+                  }, "回滚", 8, _hoisted_49),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: $event => (chooseRecovery(item, 'finalize'))
+                  }, "完成原事务", 8, _hoisted_50)
+                ]))
+              }), 128)),
+              (recoveryTarget.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_51, [
+                    _createElementVNode("label", null, [
+                      _cache[37] || (_cache[37] = _createTextVNode("输入确认短语 ", -1)),
+                      _createElementVNode("code", null, _toDisplayString(recoveryExpectedPhrase()), 1)
+                    ]),
+                    _withDirectives(_createElementVNode("input", {
+                      "onUpdate:modelValue": _cache[10] || (_cache[10] = $event => ((recoveryPhrase).value = $event)),
+                      autocomplete: "off"
+                    }, null, 512), [
+                      [_vModelText, recoveryPhrase.value]
+                    ]),
+                    _createElementVNode("button", {
+                      type: "button",
+                      disabled: recovering.value || recoveryPhrase.value !== recoveryExpectedPhrase(),
+                      onClick: runRecovery
+                    }, _toDisplayString(recovering.value ? '处理中…' : '执行恢复'), 9, _hoisted_52)
+                  ]))
+                : _createCommentVNode("", true)
+            ])
+          ]))
+        : _createCommentVNode("", true)
+    ]))
+  ]))
+}
+}
+
+};
+const AppPage = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-55ee4f66"]]);
+
+export { createLatestPlanApi as c, AppPage as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_expose_Config-BHIxEI63.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_expose_Config-BHIxEI63.css
@@ -1,0 +1,41 @@
+
+.config-page[data-v-54d4575f] { display: grid; gap: 18px; padding: 22px; max-width: 980px;
+}
+header[data-v-54d4575f] { display: grid; gap: 6px;
+}
+h2[data-v-54d4575f] { margin: 0;
+}
+p[data-v-54d4575f] { margin: 0; opacity: .72; line-height: 1.6;
+}
+.form-grid[data-v-54d4575f] { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px;
+}
+label[data-v-54d4575f] { display: grid; gap: 7px; font-weight: 600;
+}
+input[data-v-54d4575f], textarea[data-v-54d4575f] { width: 100%; box-sizing: border-box; padding: 9px 11px; border: 1px solid rgba(var(--v-border-color), .35); border-radius: 8px; background: transparent; color: inherit; font: inherit; font-weight: 400;
+}
+textarea[data-v-54d4575f] { resize: vertical; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .9em;
+}
+.wide[data-v-54d4575f] { grid-column: 1 / -1;
+}
+.notice[data-v-54d4575f], .error[data-v-54d4575f], .success[data-v-54d4575f], .probe[data-v-54d4575f] { display: grid; gap: 5px; padding: 12px 14px; border-radius: 9px;
+}
+.notice[data-v-54d4575f] { background: rgba(128, 128, 128, .12);
+}
+.error[data-v-54d4575f] { color: #b42318; background: rgba(180, 35, 24, .1);
+}
+.success[data-v-54d4575f] { color: #087443; background: rgba(8, 116, 67, .1);
+}
+.probe[data-v-54d4575f] { background: rgba(32, 106, 255, .08);
+}
+.save[data-v-54d4575f] { justify-self: start; padding: 10px 18px; border: 0; border-radius: 8px; cursor: pointer; background: rgb(var(--v-theme-primary)); color: rgb(var(--v-theme-on-primary));
+}
+.save[data-v-54d4575f]:disabled { opacity: .5; cursor: default;
+}
+@media (max-width: 760px) {
+.config-page[data-v-54d4575f] { padding: 16px;
+}
+.form-grid[data-v-54d4575f] { grid-template-columns: 1fr;
+}
+.wide[data-v-54d4575f] { grid-column: auto;
+}
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_expose_Config-BlunJQWM.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_expose_Config-BlunJQWM.js
@@ -1,0 +1,263 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
+
+const {createElementVNode:_createElementVNode,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,vModelText:_vModelText,withDirectives:_withDirectives,createTextVNode:_createTextVNode,toDisplayString:_toDisplayString,renderList:_renderList,Fragment:_Fragment} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "config-page" };
+const _hoisted_2 = {
+  key: 0,
+  class: "notice"
+};
+const _hoisted_3 = {
+  key: 1,
+  class: "form-grid"
+};
+const _hoisted_4 = { class: "wide" };
+const _hoisted_5 = { class: "wide" };
+const _hoisted_6 = {
+  key: 2,
+  class: "error"
+};
+const _hoisted_7 = {
+  key: 3,
+  class: "success"
+};
+const _hoisted_8 = {
+  key: 4,
+  class: "probe"
+};
+const _hoisted_9 = { key: 0 };
+const _hoisted_10 = ["disabled"];
+
+const {computed,onMounted,reactive,ref} = await importShared('vue');
+
+
+
+const _sfc_main = {
+  __name: 'Config',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+const props = __props;
+
+const form = reactive({
+  version: 1,
+  ssh_host: '',
+  qb_url: '',
+  jellyfin_db: '',
+  moviepilot_db: '',
+  qb_backup: '',
+  execution_backup: '',
+  allowed_roots_text: '',
+  quarantine_roots_text: '',
+});
+const loading = ref(true);
+const saving = ref(false);
+const error = ref('');
+const message = ref('');
+const probe = ref(null);
+
+const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`);
+
+function unwrap(response) {
+  if (response && Object.prototype.hasOwnProperty.call(response, 'data')) {
+    return response.data
+  }
+  return response
+}
+
+function applyConfig(config) {
+  Object.assign(form, {
+    ...config,
+    allowed_roots_text: (config.allowed_roots || []).join('\n'),
+    quarantine_roots_text: Object.entries(config.quarantine_roots || {})
+      .map(([volume, target]) => `${volume}=${target}`)
+      .join('\n'),
+  });
+}
+
+function parseLines(value) {
+  return String(value || '')
+    .split('\n')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+function buildConfig() {
+  const quarantine_roots = {};
+  for (const line of parseLines(form.quarantine_roots_text)) {
+    const separator = line.indexOf('=');
+    if (separator <= 0 || separator === line.length - 1) {
+      throw new Error('隔离目录格式应为：卷根目录=隔离目录。')
+    }
+    quarantine_roots[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+  }
+  return {
+    version: 1,
+    ssh_host: form.ssh_host,
+    qb_url: form.qb_url,
+    jellyfin_db: form.jellyfin_db,
+    moviepilot_db: form.moviepilot_db,
+    qb_backup: form.qb_backup,
+    execution_backup: form.execution_backup,
+    allowed_roots: parseLines(form.allowed_roots_text),
+    quarantine_roots,
+  }
+}
+
+async function load() {
+  loading.value = true;
+  error.value = '';
+  try {
+    if (!props.api.get) throw new Error('MoviePilot 没有提供插件 API。')
+    const payload = unwrap(await props.api.get(`${pluginBase.value}/config`));
+    if (!payload?.ok || !payload.config) throw new Error(payload?.error?.message || '无法读取清理台配置。')
+    applyConfig(payload.config);
+    probe.value = payload.probe || null;
+  } catch (err) {
+    error.value = err?.message || '无法读取清理台配置。';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function save() {
+  saving.value = true;
+  error.value = '';
+  message.value = '';
+  try {
+    const config = buildConfig();
+    const payload = unwrap(await props.api.post(`${pluginBase.value}/config`, { config }));
+    if (!payload?.ok || !payload.config) throw new Error(payload?.error?.message || '配置保存失败。')
+    applyConfig(payload.config);
+    probe.value = payload.probe || null;
+    message.value = probe.value?.ok
+      ? '配置已保存，路径探测通过；请刷新资源清单。'
+      : '配置已保存，但仍有路径未就绪；清理操作保持锁定。';
+  } catch (err) {
+    const payload = err?.response?.data || err?.data;
+    probe.value = payload?.probe || probe.value;
+    error.value = err?.message || payload?.error?.message || '配置保存失败。';
+  } finally {
+    saving.value = false;
+  }
+}
+
+onMounted(load);
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("section", _hoisted_1, [
+    _cache[16] || (_cache[16] = _createElementVNode("header", null, [
+      _createElementVNode("h2", null, "存储清理设置"),
+      _createElementVNode("p", null, "这里只保存 NAS 拓扑和路径，不会写入 Cookie、passkey 或控制令牌。保存后先做只读探测，未通过探测时清理操作保持锁定。")
+    ], -1)),
+    (loading.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_2, "正在读取配置…"))
+      : (_openBlock(), _createElementBlock("div", _hoisted_3, [
+          _createElementVNode("label", null, [
+            _cache[8] || (_cache[8] = _createTextVNode("SSH 目标", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((form.ssh_host) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.ssh_host]
+            ])
+          ]),
+          _createElementVNode("label", null, [
+            _cache[9] || (_cache[9] = _createTextVNode("qBittorrent 地址", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[1] || (_cache[1] = $event => ((form.qb_url) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.qb_url]
+            ])
+          ]),
+          _createElementVNode("label", null, [
+            _cache[10] || (_cache[10] = _createTextVNode("Jellyfin 数据库", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[2] || (_cache[2] = $event => ((form.jellyfin_db) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.jellyfin_db]
+            ])
+          ]),
+          _createElementVNode("label", null, [
+            _cache[11] || (_cache[11] = _createTextVNode("MoviePilot 数据库", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[3] || (_cache[3] = $event => ((form.moviepilot_db) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.moviepilot_db]
+            ])
+          ]),
+          _createElementVNode("label", null, [
+            _cache[12] || (_cache[12] = _createTextVNode("qB 种子备份目录", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[4] || (_cache[4] = $event => ((form.qb_backup) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.qb_backup]
+            ])
+          ]),
+          _createElementVNode("label", null, [
+            _cache[13] || (_cache[13] = _createTextVNode("清理事务备份目录", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[5] || (_cache[5] = $event => ((form.execution_backup) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.execution_backup]
+            ])
+          ]),
+          _createElementVNode("label", _hoisted_4, [
+            _cache[14] || (_cache[14] = _createTextVNode("允许扫描/清理的根目录（每行一个）", -1)),
+            _withDirectives(_createElementVNode("textarea", {
+              "onUpdate:modelValue": _cache[6] || (_cache[6] = $event => ((form.allowed_roots_text) = $event)),
+              rows: "6"
+            }, null, 512), [
+              [_vModelText, form.allowed_roots_text]
+            ])
+          ]),
+          _createElementVNode("label", _hoisted_5, [
+            _cache[15] || (_cache[15] = _createTextVNode("隔离目录映射（每行：卷根目录=隔离目录）", -1)),
+            _withDirectives(_createElementVNode("textarea", {
+              "onUpdate:modelValue": _cache[7] || (_cache[7] = $event => ((form.quarantine_roots_text) = $event)),
+              rows: "4"
+            }, null, 512), [
+              [_vModelText, form.quarantine_roots_text]
+            ])
+          ])
+        ])),
+    (error.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_6, _toDisplayString(error.value), 1))
+      : _createCommentVNode("", true),
+    (message.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_7, _toDisplayString(message.value), 1))
+      : _createCommentVNode("", true),
+    (probe.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_8, [
+          _createElementVNode("strong", null, _toDisplayString(probe.value.ok ? '只读探测通过' : '只读探测未通过'), 1),
+          (probe.value.missing?.length)
+            ? (_openBlock(), _createElementBlock("span", _hoisted_9, "未找到：" + _toDisplayString(probe.value.missing.join('、')), 1))
+            : _createCommentVNode("", true),
+          (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(probe.value.problems || [], (item) => {
+            return (_openBlock(), _createElementBlock("span", { key: item }, _toDisplayString(item), 1))
+          }), 128))
+        ]))
+      : _createCommentVNode("", true),
+    _createElementVNode("button", {
+      class: "save",
+      disabled: loading.value || saving.value,
+      onClick: save
+    }, _toDisplayString(saving.value ? '保存中…' : '保存并探测'), 9, _hoisted_10)
+  ]))
+}
+}
+
+};
+const Config = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-54d4575f"]]);
+
+export { Config as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_expose_Page-ZNhfP-7r.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_expose_Page-ZNhfP-7r.js
@@ -1,0 +1,32 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage, { c as createLatestPlanApi } from './__federation_expose_AppPage-Dw3pzGGM.js';
+
+const {unref:_unref,openBlock:_openBlock,createBlock:_createBlock} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'Page',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+const props = __props;
+
+const guardedApi = createLatestPlanApi({
+  get: (...args) => props.api.get(...args),
+  post: (...args) => props.api.post(...args),
+});
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createBlock(AppPage, {
+    api: _unref(guardedApi),
+    "plugin-id": __props.pluginId
+  }, null, 8, ["api", "plugin-id"]))
+}
+}
+
+};
+
+export { _sfc_main as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_fn_import-JrT3xvdd.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.5/assets/__federation_fn_import-JrT3xvdd.js
@@ -1,0 +1,418 @@
+const buildIdentifier = "[0-9A-Za-z-]+";
+const build = `(?:\\+(${buildIdentifier}(?:\\.${buildIdentifier})*))`;
+const numericIdentifier = "0|[1-9]\\d*";
+const numericIdentifierLoose = "[0-9]+";
+const nonNumericIdentifier = "\\d*[a-zA-Z-][a-zA-Z0-9-]*";
+const preReleaseIdentifierLoose = `(?:${numericIdentifierLoose}|${nonNumericIdentifier})`;
+const preReleaseLoose = `(?:-?(${preReleaseIdentifierLoose}(?:\\.${preReleaseIdentifierLoose})*))`;
+const preReleaseIdentifier = `(?:${numericIdentifier}|${nonNumericIdentifier})`;
+const preRelease = `(?:-(${preReleaseIdentifier}(?:\\.${preReleaseIdentifier})*))`;
+const xRangeIdentifier = `${numericIdentifier}|x|X|\\*`;
+const xRangePlain = `[v=\\s]*(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:${preRelease})?${build}?)?)?`;
+const hyphenRange = `^\\s*(${xRangePlain})\\s+-\\s+(${xRangePlain})\\s*$`;
+const mainVersionLoose = `(${numericIdentifierLoose})\\.(${numericIdentifierLoose})\\.(${numericIdentifierLoose})`;
+const loosePlain = `[v=\\s]*${mainVersionLoose}${preReleaseLoose}?${build}?`;
+const gtlt = "((?:<|>)?=?)";
+const comparatorTrim = `(\\s*)${gtlt}\\s*(${loosePlain}|${xRangePlain})`;
+const loneTilde = "(?:~>?)";
+const tildeTrim = `(\\s*)${loneTilde}\\s+`;
+const loneCaret = "(?:\\^)";
+const caretTrim = `(\\s*)${loneCaret}\\s+`;
+const star = "(<|>)?=?\\s*\\*";
+const caret = `^${loneCaret}${xRangePlain}$`;
+const mainVersion = `(${numericIdentifier})\\.(${numericIdentifier})\\.(${numericIdentifier})`;
+const fullPlain = `v?${mainVersion}${preRelease}?${build}?`;
+const tilde = `^${loneTilde}${xRangePlain}$`;
+const xRange = `^${gtlt}\\s*${xRangePlain}$`;
+const comparator = `^${gtlt}\\s*(${fullPlain})$|^$`;
+const gte0 = "^\\s*>=\\s*0.0.0\\s*$";
+function parseRegex(source) {
+  return new RegExp(source);
+}
+function isXVersion(version) {
+  return !version || version.toLowerCase() === "x" || version === "*";
+}
+function pipe(...fns) {
+  return (x) => {
+    return fns.reduce((v, f) => f(v), x);
+  };
+}
+function extractComparator(comparatorString) {
+  return comparatorString.match(parseRegex(comparator));
+}
+function combineVersion(major, minor, patch, preRelease2) {
+  const mainVersion2 = `${major}.${minor}.${patch}`;
+  if (preRelease2) {
+    return `${mainVersion2}-${preRelease2}`;
+  }
+  return mainVersion2;
+}
+function parseHyphen(range) {
+  return range.replace(
+    parseRegex(hyphenRange),
+    (_range, from, fromMajor, fromMinor, fromPatch, _fromPreRelease, _fromBuild, to, toMajor, toMinor, toPatch, toPreRelease) => {
+      if (isXVersion(fromMajor)) {
+        from = "";
+      } else if (isXVersion(fromMinor)) {
+        from = `>=${fromMajor}.0.0`;
+      } else if (isXVersion(fromPatch)) {
+        from = `>=${fromMajor}.${fromMinor}.0`;
+      } else {
+        from = `>=${from}`;
+      }
+      if (isXVersion(toMajor)) {
+        to = "";
+      } else if (isXVersion(toMinor)) {
+        to = `<${+toMajor + 1}.0.0-0`;
+      } else if (isXVersion(toPatch)) {
+        to = `<${toMajor}.${+toMinor + 1}.0-0`;
+      } else if (toPreRelease) {
+        to = `<=${toMajor}.${toMinor}.${toPatch}-${toPreRelease}`;
+      } else {
+        to = `<=${to}`;
+      }
+      return `${from} ${to}`.trim();
+    }
+  );
+}
+function parseComparatorTrim(range) {
+  return range.replace(parseRegex(comparatorTrim), "$1$2$3");
+}
+function parseTildeTrim(range) {
+  return range.replace(parseRegex(tildeTrim), "$1~");
+}
+function parseCaretTrim(range) {
+  return range.replace(parseRegex(caretTrim), "$1^");
+}
+function parseCarets(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(caret),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          if (major === "0") {
+            return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+          } else {
+            return `>=${major}.${minor}.0 <${+major + 1}.0.0-0`;
+          }
+        } else if (preRelease2) {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+            }
+          } else {
+            return `>=${major}.${minor}.${patch}-${preRelease2} <${+major + 1}.0.0-0`;
+          }
+        } else {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+            }
+          }
+          return `>=${major}.${minor}.${patch} <${+major + 1}.0.0-0`;
+        }
+      }
+    );
+  }).join(" ");
+}
+function parseTildes(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(tilde),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+        } else if (preRelease2) {
+          return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+      }
+    );
+  }).join(" ");
+}
+function parseXRanges(range) {
+  return range.split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.trim().replace(
+      parseRegex(xRange),
+      (ret, gtlt2, major, minor, patch, preRelease2) => {
+        const isXMajor = isXVersion(major);
+        const isXMinor = isXMajor || isXVersion(minor);
+        const isXPatch = isXMinor || isXVersion(patch);
+        if (gtlt2 === "=" && isXPatch) {
+          gtlt2 = "";
+        }
+        preRelease2 = "";
+        if (isXMajor) {
+          if (gtlt2 === ">" || gtlt2 === "<") {
+            return "<0.0.0-0";
+          } else {
+            return "*";
+          }
+        } else if (gtlt2 && isXPatch) {
+          if (isXMinor) {
+            minor = 0;
+          }
+          patch = 0;
+          if (gtlt2 === ">") {
+            gtlt2 = ">=";
+            if (isXMinor) {
+              major = +major + 1;
+              minor = 0;
+              patch = 0;
+            } else {
+              minor = +minor + 1;
+              patch = 0;
+            }
+          } else if (gtlt2 === "<=") {
+            gtlt2 = "<";
+            if (isXMinor) {
+              major = +major + 1;
+            } else {
+              minor = +minor + 1;
+            }
+          }
+          if (gtlt2 === "<") {
+            preRelease2 = "-0";
+          }
+          return `${gtlt2 + major}.${minor}.${patch}${preRelease2}`;
+        } else if (isXMinor) {
+          return `>=${major}.0.0${preRelease2} <${+major + 1}.0.0-0`;
+        } else if (isXPatch) {
+          return `>=${major}.${minor}.0${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return ret;
+      }
+    );
+  }).join(" ");
+}
+function parseStar(range) {
+  return range.trim().replace(parseRegex(star), "");
+}
+function parseGTE0(comparatorString) {
+  return comparatorString.trim().replace(parseRegex(gte0), "");
+}
+function compareAtom(rangeAtom, versionAtom) {
+  rangeAtom = +rangeAtom || rangeAtom;
+  versionAtom = +versionAtom || versionAtom;
+  if (rangeAtom > versionAtom) {
+    return 1;
+  }
+  if (rangeAtom === versionAtom) {
+    return 0;
+  }
+  return -1;
+}
+function comparePreRelease(rangeAtom, versionAtom) {
+  const { preRelease: rangePreRelease } = rangeAtom;
+  const { preRelease: versionPreRelease } = versionAtom;
+  if (rangePreRelease === void 0 && !!versionPreRelease) {
+    return 1;
+  }
+  if (!!rangePreRelease && versionPreRelease === void 0) {
+    return -1;
+  }
+  if (rangePreRelease === void 0 && versionPreRelease === void 0) {
+    return 0;
+  }
+  for (let i = 0, n = rangePreRelease.length; i <= n; i++) {
+    const rangeElement = rangePreRelease[i];
+    const versionElement = versionPreRelease[i];
+    if (rangeElement === versionElement) {
+      continue;
+    }
+    if (rangeElement === void 0 && versionElement === void 0) {
+      return 0;
+    }
+    if (!rangeElement) {
+      return 1;
+    }
+    if (!versionElement) {
+      return -1;
+    }
+    return compareAtom(rangeElement, versionElement);
+  }
+  return 0;
+}
+function compareVersion(rangeAtom, versionAtom) {
+  return compareAtom(rangeAtom.major, versionAtom.major) || compareAtom(rangeAtom.minor, versionAtom.minor) || compareAtom(rangeAtom.patch, versionAtom.patch) || comparePreRelease(rangeAtom, versionAtom);
+}
+function eq(rangeAtom, versionAtom) {
+  return rangeAtom.version === versionAtom.version;
+}
+function compare(rangeAtom, versionAtom) {
+  switch (rangeAtom.operator) {
+    case "":
+    case "=":
+      return eq(rangeAtom, versionAtom);
+    case ">":
+      return compareVersion(rangeAtom, versionAtom) < 0;
+    case ">=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) < 0;
+    case "<":
+      return compareVersion(rangeAtom, versionAtom) > 0;
+    case "<=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) > 0;
+    case void 0: {
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+function parseComparatorString(range) {
+  return pipe(
+    parseCarets,
+    parseTildes,
+    parseXRanges,
+    parseStar
+  )(range);
+}
+function parseRange(range) {
+  return pipe(
+    parseHyphen,
+    parseComparatorTrim,
+    parseTildeTrim,
+    parseCaretTrim
+  )(range.trim()).split(/\s+/).join(" ");
+}
+function satisfy(version, range) {
+  if (!version) {
+    return false;
+  }
+  const parsedRange = parseRange(range);
+  const parsedComparator = parsedRange.split(" ").map((rangeVersion) => parseComparatorString(rangeVersion)).join(" ");
+  const comparators = parsedComparator.split(/\s+/).map((comparator2) => parseGTE0(comparator2));
+  const extractedVersion = extractComparator(version);
+  if (!extractedVersion) {
+    return false;
+  }
+  const [
+    ,
+    versionOperator,
+    ,
+    versionMajor,
+    versionMinor,
+    versionPatch,
+    versionPreRelease
+  ] = extractedVersion;
+  const versionAtom = {
+    version: combineVersion(
+      versionMajor,
+      versionMinor,
+      versionPatch,
+      versionPreRelease
+    ),
+    major: versionMajor,
+    minor: versionMinor,
+    patch: versionPatch,
+    preRelease: versionPreRelease == null ? void 0 : versionPreRelease.split(".")
+  };
+  for (const comparator2 of comparators) {
+    const extractedComparator = extractComparator(comparator2);
+    if (!extractedComparator) {
+      return false;
+    }
+    const [
+      ,
+      rangeOperator,
+      ,
+      rangeMajor,
+      rangeMinor,
+      rangePatch,
+      rangePreRelease
+    ] = extractedComparator;
+    const rangeAtom = {
+      operator: rangeOperator,
+      version: combineVersion(
+        rangeMajor,
+        rangeMinor,
+        rangePatch,
+        rangePreRelease
+      ),
+      major: rangeMajor,
+      minor: rangeMinor,
+      patch: rangePatch,
+      preRelease: rangePreRelease == null ? void 0 : rangePreRelease.split(".")
+    };
+    if (!compare(rangeAtom, versionAtom)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// eslint-disable-next-line no-undef
+const moduleMap = {};
+const moduleCache = Object.create(null);
+async function importShared(name, shareScope = 'default') {
+  return moduleCache[name]
+    ? new Promise((r) => r(moduleCache[name]))
+    : (await getSharedFromRuntime(name, shareScope)) || getSharedFromLocal(name)
+}
+async function getSharedFromRuntime(name, shareScope) {
+  let module = null;
+  if (globalThis?.__federation_shared__?.[shareScope]?.[name]) {
+    const versionObj = globalThis.__federation_shared__[shareScope][name];
+    const requiredVersion = moduleMap[name]?.requiredVersion;
+    const hasRequiredVersion = !!requiredVersion;
+    if (hasRequiredVersion) {
+      const versionKey = Object.keys(versionObj).find((version) =>
+        satisfy(version, requiredVersion)
+      );
+      if (versionKey) {
+        const versionValue = versionObj[versionKey];
+        module = await (await versionValue.get())();
+      } else {
+        console.log(
+          `provider support ${name}(${versionKey}) is not satisfied requiredVersion(\${moduleMap[name].requiredVersion})`
+        );
+      }
+    } else {
+      const versionKey = Object.keys(versionObj)[0];
+      const versionValue = versionObj[versionKey];
+      module = await (await versionValue.get())();
+    }
+  }
+  if (module) {
+    return flattenModule(module, name)
+  }
+}
+async function getSharedFromLocal(name) {
+  if (moduleMap[name]?.import) {
+    let module = await (await moduleMap[name].get())();
+    return flattenModule(module, name)
+  } else {
+    console.error(
+      `consumer config import=false,so cant use callback shared module`
+    );
+  }
+}
+function flattenModule(module, name) {
+  // use a shared module which export default a function will getting error 'TypeError: xxx is not a function'
+  if (typeof module.default === 'function') {
+    Object.keys(module).forEach((key) => {
+      if (key !== 'default') {
+        module.default[key] = module[key];
+      }
+    });
+    moduleCache[name] = module.default;
+    return module.default
+  }
+  if (module.default) module = Object.assign({}, module.default, module);
+  moduleCache[name] = module;
+  return module
+}
+
+export { importShared, getSharedFromLocal as importSharedLocal, getSharedFromRuntime as importSharedRuntime };

--- a/plugins.v2/storagecleanup/dist/v1.0.5/assets/_plugin-vue_export-helper-pcqpp-6-.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.5/assets/_plugin-vue_export-helper-pcqpp-6-.js
@@ -1,0 +1,9 @@
+const _export_sfc = (sfc, props) => {
+  const target = sfc.__vccOpts || sfc;
+  for (const [key, val] of props) {
+    target[key] = val;
+  }
+  return target;
+};
+
+export { _export_sfc as _ };

--- a/plugins.v2/storagecleanup/dist/v1.0.5/assets/index-CfFcC2bI.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.5/assets/index-CfFcC2bI.js
@@ -1,0 +1,44 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage from './__federation_expose_AppPage-Dw3pzGGM.js';
+
+true              &&(function polyfill() {
+  const relList = document.createElement("link").relList;
+  if (relList && relList.supports && relList.supports("modulepreload")) {
+    return;
+  }
+  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+    processPreload(link);
+  }
+  new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type !== "childList") {
+        continue;
+      }
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === "LINK" && node.rel === "modulepreload")
+          processPreload(node);
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  function getFetchOpts(link) {
+    const fetchOpts = {};
+    if (link.integrity) fetchOpts.integrity = link.integrity;
+    if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
+    if (link.crossOrigin === "use-credentials")
+      fetchOpts.credentials = "include";
+    else if (link.crossOrigin === "anonymous") fetchOpts.credentials = "omit";
+    else fetchOpts.credentials = "same-origin";
+    return fetchOpts;
+  }
+  function processPreload(link) {
+    if (link.ep)
+      return;
+    link.ep = true;
+    const fetchOpts = getFetchOpts(link);
+    fetch(link.href, fetchOpts);
+  }
+}());
+
+const {createApp} = await importShared('vue');
+
+createApp(AppPage).mount('#app');

--- a/plugins.v2/storagecleanup/dist/v1.0.5/assets/remoteEntry.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.5/assets/remoteEntry.js
@@ -2,11 +2,11 @@ const currentImports = {};
       const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
       let moduleMap = {
 "./AppPage":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './AppPage');
-      return __federation_import('./__federation_expose_AppPage-WrNLRDkU.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-B6tAG2vu.css"], false, './AppPage');
+      return __federation_import('./__federation_expose_AppPage-Dw3pzGGM.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Page":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './Page');
-      return __federation_import('./__federation_expose_Page-DAUTopwb.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-B6tAG2vu.css"], false, './Page');
+      return __federation_import('./__federation_expose_Page-ZNhfP-7r.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Config":()=>{
       dynamicLoadingCss(["__federation_expose_Config-BHIxEI63.css"], false, './Config');
       return __federation_import('./__federation_expose_Config-BlunJQWM.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
@@ -48,7 +48,7 @@ const currentImports = {};
          } else {
            href = cssPath;
          }
-         
+
           if (dontAppendStylesToHead) {
             const key = 'css__StorageCleanup__' + exposeItemName;
             window[key] = window[key] || [];

--- a/plugins.v2/storagecleanup/dist/v1.0.5/index.html
+++ b/plugins.v2/storagecleanup/dist/v1.0.5/index.html
@@ -1,0 +1,6 @@
+<script type="module" crossorigin src="/assets/index-CfFcC2bI.js"></script>
+<link rel="modulepreload" crossorigin href="/assets/__federation_fn_import-JrT3xvdd.js">
+<link rel="modulepreload" crossorigin href="/assets/_plugin-vue_export-helper-pcqpp-6-.js">
+<link rel="modulepreload" crossorigin href="/assets/__federation_expose_AppPage-Dw3pzGGM.js">
+<link rel="stylesheet" crossorigin href="/assets/__federation_expose_AppPage-B6tAG2vu.css">
+<div id="app"></div>

--- a/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_expose_AppPage-CIJaIXT7.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_expose_AppPage-CIJaIXT7.css
@@ -1,0 +1,611 @@
+
+.cleanup-app[data-v-d46813f7], .action-bar[data-v-d46813f7], .modal-backdrop[data-v-d46813f7] {
+  --ink: rgb(var(--v-theme-on-background, 30, 41, 59));
+  --muted: rgba(var(--v-theme-on-background, 30, 41, 59), .58);
+  --line: rgba(var(--v-border-color, 100, 116, 139), .18);
+  --surface: rgb(var(--v-theme-surface, 255, 255, 255));
+  --primary: rgb(var(--v-theme-primary, 59, 130, 246));
+  --primary-soft: rgba(var(--v-theme-primary, 59, 130, 246), .10);
+  --good: #16836b;
+  --warn: #b86b11;
+  --danger: #c44b47;
+}
+.cleanup-app[data-v-d46813f7] {
+  color: var(--ink);
+  min-width: 980px;
+  padding: 18px 24px 110px;
+}
+button[data-v-d46813f7], input[data-v-d46813f7] { font: inherit;
+}
+button[data-v-d46813f7] { color: inherit;
+}
+.page-header[data-v-d46813f7] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+.eyebrow[data-v-d46813f7] { margin: 0 0 4px; color: var(--primary); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase;
+}
+.page-header h1[data-v-d46813f7] { margin: 0; font-size: 30px; line-height: 1.2;
+}
+.page-header > div > span[data-v-d46813f7] { color: var(--muted); font-size: 14px;
+}
+.status-card[data-v-d46813f7] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 220px;
+  padding: 10px 14px;
+  border: 1px solid rgba(22, 131, 107, .22);
+  border-radius: 12px;
+  background: rgba(22, 131, 107, .08);
+}
+.status-card.danger[data-v-d46813f7] { border-color: rgba(196, 75, 71, .24); background: rgba(196, 75, 71, .08);
+}
+.status-card i[data-v-d46813f7], .notice i[data-v-d46813f7], .safety-note i[data-v-d46813f7] {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  background: rgba(22, 131, 107, .12);
+  color: var(--good);
+  font-style: normal;
+  font-weight: 900;
+}
+.status-card p[data-v-d46813f7], .notice p[data-v-d46813f7], .safety-note p[data-v-d46813f7], .plan-resources p[data-v-d46813f7], .gap-row p[data-v-d46813f7], .recovery-row p[data-v-d46813f7] { display: grid; gap: 2px; margin: 0;
+}
+.status-card strong[data-v-d46813f7] { font-size: 13px;
+}
+.status-card span[data-v-d46813f7] { color: var(--muted); font-size: 12px;
+}
+.toolbar[data-v-d46813f7] {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.search[data-v-d46813f7] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  height: 46px;
+  padding: 0 15px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+}
+.search span[data-v-d46813f7] { color: var(--muted); font-size: 21px;
+}
+.search input[data-v-d46813f7] { width: 100%; border: 0; outline: 0; color: inherit; background: transparent; font-size: 15px;
+}
+.safe-toggle[data-v-d46813f7] { display: flex; align-items: center; gap: 8px; height: 44px; white-space: nowrap; font-size: 14px; font-weight: 650;
+}
+.safe-toggle input[data-v-d46813f7], .risk-check input[data-v-d46813f7] { position: absolute; opacity: 0;
+}
+.safe-toggle > span[data-v-d46813f7] {
+  width: 38px;
+  height: 22px;
+  padding: 3px;
+  border-radius: 99px;
+  background: rgba(100, 116, 139, .24);
+}
+.safe-toggle > span[data-v-d46813f7]::after { display: block; width: 16px; height: 16px; border-radius: 50%; background: white; content: ''; transition: .2s;
+}
+.safe-toggle input:checked + span[data-v-d46813f7] { background: var(--primary);
+}
+.safe-toggle input:checked + span[data-v-d46813f7]::after { transform: translateX(16px);
+}
+.soft-button[data-v-d46813f7], .icon-button[data-v-d46813f7] {
+  height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: var(--surface);
+  cursor: pointer;
+}
+.soft-button[data-v-d46813f7] { padding: 0 14px;
+}
+.icon-button[data-v-d46813f7] { width: 42px; font-size: 20px;
+}
+.refresh-feedback[data-v-d46813f7] {
+  flex: 0 0 100%;
+  margin: -2px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+.notice[data-v-d46813f7] {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin: 0 0 14px;
+  padding: 12px 16px;
+  border: 1px solid rgba(184, 107, 17, .22);
+  border-radius: 12px;
+  background: rgba(184, 107, 17, .07);
+  text-align: left;
+  cursor: pointer;
+}
+.notice p[data-v-d46813f7] { flex: 1;
+}
+.notice p span[data-v-d46813f7] { color: var(--muted); font-size: 13px;
+}
+.notice b[data-v-d46813f7] { color: var(--warn); font-size: 13px;
+}
+.notice.critical[data-v-d46813f7] { border-color: rgba(196, 75, 71, .25); background: rgba(196, 75, 71, .08);
+}
+.notice.critical b[data-v-d46813f7] { color: var(--danger);
+}
+.filters[data-v-d46813f7] { display: flex; gap: 6px; margin-bottom: 12px;
+}
+.filters button[data-v-d46813f7] {
+  padding: 8px 13px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.filters button.active[data-v-d46813f7] { border-color: var(--line); background: var(--surface); color: var(--ink); font-weight: 750; box-shadow: 0 4px 12px rgba(15, 23, 42, .04);
+}
+.filters span[data-v-d46813f7] { margin-left: 5px; padding: 2px 6px; border-radius: 99px; background: rgba(100, 116, 139, .10); font-size: 11px;
+}
+.resource-card[data-v-d46813f7] { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--surface);
+}
+.table-head[data-v-d46813f7], .resource-row[data-v-d46813f7] {
+  display: grid;
+  grid-template-columns: 42px minmax(270px, 1.55fr) minmax(170px, .85fr) minmax(360px, 1.65fr) minmax(125px, .65fr) minmax(230px, 1fr);
+  align-items: center;
+}
+.table-head[data-v-d46813f7] { min-height: 50px; padding: 0 16px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 12px; font-weight: 800;
+}
+.resource-row[data-v-d46813f7] { min-height: 126px; padding: 0 16px; border-bottom: 1px solid var(--line);
+}
+.resource-row[data-v-d46813f7]:last-child { border-bottom: 0;
+}
+.resource-row.selected[data-v-d46813f7] { background: var(--primary-soft);
+}
+.select-all[data-v-d46813f7], .row-check[data-v-d46813f7] {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid rgba(100, 116, 139, .35);
+  border-radius: 7px;
+  background: transparent;
+  cursor: pointer;
+}
+.row-check.locked[data-v-d46813f7] { border-color: rgba(184, 107, 17, .25); background: rgba(184, 107, 17, .08); color: var(--warn); font-size: 10px; cursor: not-allowed;
+}
+.resource-title[data-v-d46813f7], .stack-cell[data-v-d46813f7] { display: grid; gap: 4px; min-width: 0; padding-right: 16px;
+}
+.resource-title strong[data-v-d46813f7] { font-size: 17px;
+}
+.resource-title b[data-v-d46813f7] { overflow: hidden; color: var(--ink); font-size: 13px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; opacity: .78;
+}
+.resource-title span[data-v-d46813f7], .stack-cell span[data-v-d46813f7], .impact span[data-v-d46813f7], .seed-task span[data-v-d46813f7] { color: var(--muted); font-size: 12px; line-height: 1.45;
+}
+.stack-cell strong[data-v-d46813f7] { font-size: 14px;
+}
+.stack-cell.library strong[data-v-d46813f7] { color: var(--good);
+}
+.stack-cell.size strong[data-v-d46813f7] { font-size: 16px;
+}
+.seed-cell[data-v-d46813f7] { display: grid; gap: 4px; padding-right: 18px;
+}
+.seed-task[data-v-d46813f7] {
+  display: grid;
+  grid-template-columns: 62px minmax(72px, auto) minmax(100px, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding-left: 8px;
+  border-left: 2px solid rgba(100, 116, 139, .28);
+}
+.seed-task i[data-v-d46813f7] { padding: 4px 8px; border-radius: 99px; background: rgba(100, 116, 139, .1); font-size: 11px; font-style: normal; font-weight: 800; text-align: center; white-space: nowrap;
+}
+.seed-task strong[data-v-d46813f7] { font-size: 13px;
+}
+.seed-task.warning[data-v-d46813f7] { border-color: rgba(184, 107, 17, .45);
+}
+.seed-task.warning i[data-v-d46813f7] { color: var(--warn); background: rgba(184, 107, 17, .1);
+}
+.seed-task.protected[data-v-d46813f7] { border-color: rgba(196, 75, 71, .45);
+}
+.seed-task.protected i[data-v-d46813f7] { color: var(--danger); background: rgba(196, 75, 71, .1);
+}
+.impact[data-v-d46813f7] { display: grid; gap: 4px; padding-left: 10px; border-left: 2px solid rgba(22, 131, 107, .35);
+}
+.impact strong[data-v-d46813f7] { font-size: 13px;
+}
+.impact.danger[data-v-d46813f7] { border-color: rgba(196, 75, 71, .5);
+}
+.impact.danger strong[data-v-d46813f7] { color: var(--danger);
+}
+.empty-state[data-v-d46813f7] { display: grid; place-items: center; min-height: 150px; color: var(--muted);
+}
+.action-bar[data-v-d46813f7] {
+  position: fixed;
+  z-index: 20;
+  right: 30px;
+  bottom: 22px;
+  left: calc(var(--v-layout-left, 0px) + 30px);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, .14);
+  border-radius: 16px;
+  background: #17243a;
+  color: white;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, .28);
+}
+.selected-count[data-v-d46813f7] { display: grid; place-items: center; width: 44px; height: 44px; border-radius: 12px; background: #3f70b7; font-size: 18px; font-weight: 900;
+}
+.action-bar > p[data-v-d46813f7] { display: grid; gap: 1px; min-width: 160px; margin: 0;
+}
+.action-bar > p span[data-v-d46813f7], .action-level span[data-v-d46813f7] { color: rgba(255, 255, 255, .64); font-size: 11px;
+}
+.clear-button[data-v-d46813f7] { border: 0; background: transparent; color: rgba(255, 255, 255, .66); cursor: pointer;
+}
+.action-buttons[data-v-d46813f7] { display: contents;
+}
+.action-level[data-v-d46813f7] { display: grid; flex: 1; gap: 3px; padding: 10px 14px; border: 1px solid rgba(255, 255, 255, .17); border-radius: 11px; background: rgba(255, 255, 255, .06); color: white; text-align: left; cursor: pointer;
+}
+.action-level.delete[data-v-d46813f7] { border-color: rgba(255, 142, 136, .32); background: rgba(196, 75, 71, .28);
+}
+.modal-backdrop[data-v-d46813f7] {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  background: rgba(15, 23, 42, .55);
+  backdrop-filter: blur(6px);
+}
+.modal[data-v-d46813f7] {
+  overflow: auto;
+  width: min(760px, 90vw);
+  max-height: 90vh;
+  padding: 24px;
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, .3);
+}
+.modal > header[data-v-d46813f7] { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 16px;
+}
+.modal > header span[data-v-d46813f7] { color: var(--primary); font-size: 11px; font-weight: 850; letter-spacing: .08em;
+}
+.modal h2[data-v-d46813f7] { margin: 3px 0 0; font-size: 24px;
+}
+.modal > header button[data-v-d46813f7] { width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 10px; background: transparent; font-size: 22px; cursor: pointer;
+}
+.mode-summary[data-v-d46813f7], .plan-state[data-v-d46813f7], .safety-note[data-v-d46813f7] { display: grid; gap: 4px; margin-bottom: 12px; padding: 13px 15px; border-radius: 12px; background: var(--primary-soft);
+}
+.mode-summary span[data-v-d46813f7], .plan-state span[data-v-d46813f7], .safety-note span[data-v-d46813f7] { color: var(--muted); font-size: 12px;
+}
+.mode-summary.delete[data-v-d46813f7] { background: rgba(196, 75, 71, .08);
+}
+.plan-resources[data-v-d46813f7] { max-height: 170px; overflow: auto; margin-bottom: 12px; border: 1px solid var(--line); border-radius: 12px;
+}
+.plan-resources > div[data-v-d46813f7] { display: flex; justify-content: space-between; align-items: center; padding: 10px 13px; border-bottom: 1px solid var(--line);
+}
+.plan-resources > div[data-v-d46813f7]:last-child { border-bottom: 0;
+}
+.plan-resources span[data-v-d46813f7] { color: var(--muted); font-size: 11px;
+}
+.plan-state.passed[data-v-d46813f7] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.plan-state.blocked[data-v-d46813f7], .issues.blocked[data-v-d46813f7] { color: var(--danger); background: rgba(196, 75, 71, .08);
+}
+.issues[data-v-d46813f7] { display: grid; gap: 6px; margin: 0 0 12px; padding: 12px 16px 12px 34px; border-radius: 12px; font-size: 13px;
+}
+.issues.warning[data-v-d46813f7] { color: var(--warn); background: rgba(184, 107, 17, .08);
+}
+.risk-check[data-v-d46813f7] { position: relative; display: flex; align-items: center; gap: 9px; margin: 12px 0; font-size: 13px; font-weight: 700;
+}
+.risk-check > span[data-v-d46813f7] { width: 20px; height: 20px; border: 1px solid rgba(100, 116, 139, .35); border-radius: 6px;
+}
+.risk-check input:checked + span[data-v-d46813f7] { border-color: var(--primary); background: var(--primary); box-shadow: inset 0 0 0 4px var(--surface);
+}
+.safety-note[data-v-d46813f7] { display: flex; align-items: center; background: rgba(100, 116, 139, .08);
+}
+.safety-note p[data-v-d46813f7] { flex: 1;
+}
+.confirm-button[data-v-d46813f7], .execution-result button[data-v-d46813f7] {
+  width: 100%;
+  min-height: 46px;
+  border: 0;
+  border-radius: 11px;
+  background: var(--primary);
+  color: white;
+  font-weight: 800;
+  cursor: pointer;
+}
+.confirm-button[data-v-d46813f7]:disabled { background: rgba(100, 116, 139, .22); color: var(--muted); cursor: not-allowed;
+}
+.final-confirmation[data-v-d46813f7], .execution-result[data-v-d46813f7] { display: grid; gap: 10px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.final-confirmation > div[data-v-d46813f7] { display: flex; gap: 8px;
+}
+.final-confirmation button[data-v-d46813f7] { flex: 1; min-height: 42px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); cursor: pointer;
+}
+.final-confirmation button.danger[data-v-d46813f7] { border-color: transparent; background: var(--danger); color: white;
+}
+.error-text[data-v-d46813f7] { color: var(--danger); font-size: 13px;
+}
+.execution-result[data-v-d46813f7] { color: var(--good); background: rgba(22, 131, 107, .08);
+}
+.compact-modal[data-v-d46813f7] { width: min(650px, 90vw);
+}
+.gap-row[data-v-d46813f7], .recovery-row[data-v-d46813f7] { display: flex; align-items: center; gap: 8px; padding: 11px 4px; border-bottom: 1px solid var(--line);
+}
+.gap-row p[data-v-d46813f7], .recovery-row p[data-v-d46813f7] { flex: 1;
+}
+.gap-row span[data-v-d46813f7], .recovery-row span[data-v-d46813f7] { color: var(--muted); font-size: 11px;
+}
+.gap-row b[data-v-d46813f7] { font-size: 12px; color: var(--warn);
+}
+.recovery-row button[data-v-d46813f7], .recovery-confirm button[data-v-d46813f7] { padding: 7px 10px; border: 1px solid var(--line); border-radius: 8px; background: transparent; cursor: pointer;
+}
+.recovery-confirm[data-v-d46813f7] { display: grid; gap: 8px; margin-top: 14px; padding: 14px; border-radius: 12px; background: rgba(196, 75, 71, .08);
+}
+.recovery-confirm input[data-v-d46813f7] { height: 40px; padding: 0 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); color: inherit;
+}
+@media (max-width: 1250px) {
+.table-head[data-v-d46813f7], .resource-row[data-v-d46813f7] {
+    grid-template-columns: 38px minmax(240px, 1.3fr) minmax(150px, .7fr) minmax(310px, 1.35fr) 120px minmax(200px, .9fr);
+}
+}
+@media (max-width: 760px) {
+.cleanup-app[data-v-d46813f7] {
+    min-width: 0;
+    overflow-x: clip;
+    padding: 14px 12px 190px;
+}
+.page-header[data-v-d46813f7] {
+    display: grid;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+.eyebrow[data-v-d46813f7] { font-size: 10px;
+}
+.page-header h1[data-v-d46813f7] { font-size: 27px;
+}
+.page-header > div > span[data-v-d46813f7] {
+    display: block;
+    margin-top: 3px;
+    font-size: 12px;
+    line-height: 1.5;
+}
+.status-card[data-v-d46813f7] {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+}
+.toolbar[data-v-d46813f7] {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 8px;
+}
+.search[data-v-d46813f7] {
+    grid-column: 1 / -1;
+    height: 44px;
+    box-sizing: border-box;
+}
+.safe-toggle[data-v-d46813f7] {
+    min-width: 0;
+    font-size: 12px;
+}
+.soft-button[data-v-d46813f7] { padding: 0 10px; font-size: 12px;
+}
+.icon-button[data-v-d46813f7] { width: 40px;
+}
+.notice[data-v-d46813f7] {
+    align-items: flex-start;
+    padding: 11px 12px;
+}
+.notice p strong[data-v-d46813f7] { font-size: 14px;
+}
+.notice p span[data-v-d46813f7] { font-size: 11px;
+}
+.notice b[data-v-d46813f7] { display: none;
+}
+.filters[data-v-d46813f7] {
+    overflow-x: auto;
+    width: calc(100vw - 24px);
+    padding: 0 0 4px;
+    scrollbar-width: none;
+}
+.filters[data-v-d46813f7]::-webkit-scrollbar { display: none;
+}
+.filters button[data-v-d46813f7] {
+    flex: 0 0 auto;
+    padding: 8px 11px;
+    white-space: nowrap;
+}
+.resource-card[data-v-d46813f7] {
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+}
+.table-head[data-v-d46813f7] { display: none;
+}
+.resource-row[data-v-d46813f7] {
+    grid-template-areas:
+      "check title"
+      ". library"
+      ". seed"
+      ". size"
+      ". impact";
+    grid-template-columns: 34px minmax(0, 1fr);
+    gap: 12px 10px;
+    min-height: 0;
+    margin-bottom: 10px;
+    padding: 15px 13px;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: var(--surface);
+    box-shadow: 0 5px 18px rgba(15, 23, 42, .04);
+}
+.resource-row[data-v-d46813f7]:last-child { border-bottom: 1px solid var(--line);
+}
+.row-check[data-v-d46813f7] {
+    grid-area: check;
+    align-self: start;
+    width: 26px;
+    height: 26px;
+}
+.resource-title[data-v-d46813f7] {
+    grid-area: title;
+    padding-right: 0;
+}
+.resource-title strong[data-v-d46813f7] { font-size: 16px;
+}
+.resource-title b[data-v-d46813f7] { font-size: 12px;
+}
+.resource-title span[data-v-d46813f7] { white-space: normal;
+}
+.stack-cell.library[data-v-d46813f7] { grid-area: library;
+}
+.seed-cell[data-v-d46813f7] { grid-area: seed;
+}
+.stack-cell.size[data-v-d46813f7] { grid-area: size;
+}
+.impact[data-v-d46813f7] { grid-area: impact;
+}
+.stack-cell[data-v-d46813f7], .seed-cell[data-v-d46813f7], .impact[data-v-d46813f7] {
+    min-width: 0;
+    padding: 10px 0 0;
+    border-top: 1px solid var(--line);
+}
+.stack-cell[data-v-d46813f7]::before, .seed-cell[data-v-d46813f7]::before, .impact[data-v-d46813f7]::before {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--muted);
+    content: attr(data-label);
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: .06em;
+}
+.impact[data-v-d46813f7] {
+    padding-left: 0;
+    border-left: 0;
+}
+.impact.danger[data-v-d46813f7] { border-left: 0;
+}
+.seed-task[data-v-d46813f7] {
+    grid-template-columns: 58px minmax(58px, auto) minmax(0, 1fr);
+    gap: 6px;
+    padding-left: 6px;
+}
+.seed-task i[data-v-d46813f7] { padding: 4px 6px; font-size: 10px;
+}
+.seed-task strong[data-v-d46813f7] { font-size: 12px;
+}
+.seed-task span[data-v-d46813f7] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.action-bar[data-v-d46813f7] {
+    z-index: 2600;
+    right: 10px;
+    bottom: calc(78px + env(safe-area-inset-bottom, 0px));
+    left: 10px;
+    display: grid;
+    grid-template-columns: 38px minmax(0, 1fr) auto;
+    gap: 8px 10px;
+    padding: 10px;
+    border-radius: 15px;
+}
+.selected-count[data-v-d46813f7] {
+    width: 38px;
+    height: 38px;
+    border-radius: 10px;
+    font-size: 16px;
+}
+.action-bar > p[data-v-d46813f7] {
+    min-width: 0;
+}
+.action-bar > p strong[data-v-d46813f7] {
+    overflow: hidden;
+    font-size: 13px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.action-bar > p span[data-v-d46813f7] { font-size: 10px;
+}
+.clear-button[data-v-d46813f7] {
+    padding: 0 4px;
+    font-size: 12px;
+}
+.action-buttons[data-v-d46813f7] {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 7px;
+}
+.action-level[data-v-d46813f7] {
+    display: block;
+    min-width: 0;
+    min-height: 42px;
+    padding: 9px 5px;
+    text-align: center;
+}
+.action-level strong[data-v-d46813f7] {
+    display: block;
+    font-size: 13px;
+    white-space: nowrap;
+}
+.action-level span[data-v-d46813f7] { display: none;
+}
+.modal-backdrop[data-v-d46813f7] {
+    z-index: 3000;
+    padding:
+      max(12px, env(safe-area-inset-top, 0px))
+      12px
+      max(12px, env(safe-area-inset-bottom, 0px));
+}
+.modal[data-v-d46813f7], .compact-modal[data-v-d46813f7] {
+    width: calc(100vw - 24px);
+    max-height: calc(100dvh - 24px);
+    box-sizing: border-box;
+    padding: 16px;
+    border-radius: 16px;
+}
+.modal h2[data-v-d46813f7] { font-size: 21px;
+}
+.modal > header[data-v-d46813f7] { margin-bottom: 12px;
+}
+.mode-summary[data-v-d46813f7], .plan-state[data-v-d46813f7], .safety-note[data-v-d46813f7] { padding: 11px 12px;
+}
+.plan-resources[data-v-d46813f7] { max-height: 120px;
+}
+.plan-resources > div[data-v-d46813f7] { gap: 8px; padding: 9px 10px;
+}
+.plan-resources p[data-v-d46813f7] { min-width: 0;
+}
+.plan-resources p span[data-v-d46813f7] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.issues[data-v-d46813f7] { padding: 10px 12px 10px 28px; font-size: 12px;
+}
+.final-confirmation > div[data-v-d46813f7] { display: grid; grid-template-columns: 1fr 1fr;
+}
+.gap-row[data-v-d46813f7], .recovery-row[data-v-d46813f7] {
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+.recovery-row p[data-v-d46813f7] { flex-basis: 100%;
+}
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_expose_AppPage-DU_5-3RL.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_expose_AppPage-DU_5-3RL.js
@@ -1,0 +1,1048 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
+
+const FILTERS = [
+  { id: 'all', label: '全部资源' },
+  { id: 'library', label: '媒体库已入库' },
+  { id: 'hr', label: 'H&R 保护中' },
+  { id: 'brush', label: '刷流任务' },
+  { id: 'review', label: '无做种限制' },
+  { id: 'names', label: '名称待核' },
+];
+
+const ACTIONS = {
+  pause: {
+    title: '停止做种',
+    detail: '保留 qB 任务和全部文件',
+  },
+  retire: {
+    title: '退出做种',
+    detail: '移除 qB 任务，媒体仍保留',
+  },
+  delete: {
+    title: '完整删除',
+    detail: '移除任务、媒体和全部链接',
+  },
+};
+
+function unwrapResponse(response) {
+  if (response && Object.prototype.hasOwnProperty.call(response, 'data') && response.success !== undefined) {
+    return response.data
+  }
+  return response?.data ?? response
+}
+
+function createLatestPlanApi(api) {
+  let generation = 0;
+  let latestPlanResult = null;
+
+  return {
+    ...api,
+    get(...args) {
+      return api.get(...args)
+    },
+    post(path, body, ...args) {
+      if (!String(path || '').endsWith('/plan')) {
+        return api.post(path, body, ...args)
+      }
+
+      const requestGeneration = ++generation;
+      let rawRequest;
+      try {
+        rawRequest = Promise.resolve(api.post(path, body, ...args));
+      } catch (error) {
+        rawRequest = Promise.reject(error);
+      }
+
+      const result = (async () => {
+        try {
+          const response = await rawRequest;
+          if (requestGeneration !== generation && latestPlanResult) {
+            return await latestPlanResult
+          }
+          return response
+        } catch (error) {
+          if (requestGeneration !== generation && latestPlanResult) {
+            return await latestPlanResult
+          }
+          throw error
+        }
+      })();
+      latestPlanResult = result;
+      return result
+    },
+  }
+}
+
+function matchesFilter(item, filter) {
+  if (filter === 'all') return true
+  if (filter === 'library') return Boolean(item.library)
+  if (filter === 'hr') return Boolean(item.hr || item.hrPending)
+  if (filter === 'brush') return Boolean(item.brush)
+  if (filter === 'review') return !item.protected && item.qbSummary === '无 qB 任务'
+  return item.metadataVerified === false
+}
+
+function isDirectlyCleanable(item) {
+  return !item.protected && item.qbSummary === '无 qB 任务'
+}
+
+function filterResources(resources, { filter, search, safeOnly, descending }) {
+  const query = String(search || '').trim().toLowerCase();
+  return [...(resources || [])]
+    .filter(item => {
+      const text = `${item.title || ''} ${item.englishTitle || ''} ${item.edition || ''} ${item.siteSummary || ''}`.toLowerCase();
+      return matchesFilter(item, filter) &&
+        (!safeOnly || isDirectlyCleanable(item)) &&
+        (!query || text.includes(query))
+    })
+    .sort((left, right) => {
+      const order = descending ? Number(right.size || 0) - Number(left.size || 0) : Number(left.size || 0) - Number(right.size || 0);
+      return order || String(left.title || '').localeCompare(String(right.title || ''), 'zh-CN')
+    })
+}
+
+function formatGiB(size) {
+  const numeric = Number(size || 0);
+  return numeric >= 1024 ? `${(numeric / 1024).toFixed(2)} TB` : `${numeric.toFixed(1)} GB`
+}
+
+function formatBytes(size) {
+  return formatGiB(Number(size || 0) / 1024 ** 3)
+}
+
+function issueKey(issue, index) {
+  return `${issue?.code || 'issue'}-${index}`
+}
+
+function refreshFeedback(elapsedSeconds) {
+  const elapsed = Math.max(0, Number(elapsedSeconds) || 0);
+  if (elapsed < 5) return '正在读取 NAS 只读快照…'
+  if (elapsed < 30) {
+    return `正在核对 qB、Jellyfin 与 H&R（已等待 ${elapsed} 秒）`
+  }
+  return `远端 H&R 探测可能需要数分钟（已等待 ${elapsed} 秒），请保持页面打开。`
+}
+
+const {createElementVNode:_createElementVNode,toDisplayString:_toDisplayString,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,normalizeClass:_normalizeClass,vModelText:_vModelText,withDirectives:_withDirectives,vModelCheckbox:_vModelCheckbox,createTextVNode:_createTextVNode,renderList:_renderList,Fragment:_Fragment,unref:_unref,withModifiers:_withModifiers,Teleport:_Teleport,createBlock:_createBlock} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "cleanup-app" };
+const _hoisted_2 = {
+  key: 0,
+  class: "page-header"
+};
+const _hoisted_3 = { key: 0 };
+const _hoisted_4 = { class: "toolbar" };
+const _hoisted_5 = { class: "search" };
+const _hoisted_6 = { class: "safe-toggle" };
+const _hoisted_7 = ["disabled", "aria-label", "aria-busy", "title"];
+const _hoisted_8 = {
+  key: 0,
+  class: "refresh-feedback",
+  role: "status",
+  "aria-live": "polite"
+};
+const _hoisted_9 = {
+  class: "filters",
+  "aria-label": "资源筛选"
+};
+const _hoisted_10 = ["onClick"];
+const _hoisted_11 = { class: "resource-card" };
+const _hoisted_12 = { class: "table-head" };
+const _hoisted_13 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_14 = ["disabled", "onClick"];
+const _hoisted_15 = { class: "resource-title" };
+const _hoisted_16 = {
+  class: "stack-cell library",
+  "data-label": "媒体库"
+};
+const _hoisted_17 = {
+  class: "seed-cell",
+  "data-label": "做种与保护"
+};
+const _hoisted_18 = {
+  key: 1,
+  class: "stack-cell"
+};
+const _hoisted_19 = {
+  class: "stack-cell size",
+  "data-label": "实际占用"
+};
+const _hoisted_20 = {
+  key: 2,
+  class: "empty-state"
+};
+const _hoisted_21 = {
+  key: 0,
+  class: "action-bar"
+};
+const _hoisted_22 = { class: "selected-count" };
+const _hoisted_23 = { class: "action-buttons" };
+const _hoisted_24 = ["onClick"];
+const _hoisted_25 = {
+  class: "modal plan-modal",
+  role: "dialog",
+  "aria-modal": "true"
+};
+const _hoisted_26 = ["disabled"];
+const _hoisted_27 = { key: 0 };
+const _hoisted_28 = { key: 1 };
+const _hoisted_29 = { class: "plan-resources" };
+const _hoisted_30 = {
+  key: 0,
+  class: "plan-state"
+};
+const _hoisted_31 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_32 = {
+  key: 0,
+  class: "issues blocked"
+};
+const _hoisted_33 = {
+  key: 1,
+  class: "issues warning"
+};
+const _hoisted_34 = {
+  key: 2,
+  class: "risk-check"
+};
+const _hoisted_35 = ["checked"];
+const _hoisted_36 = {
+  key: 3,
+  class: "plan-state blocked"
+};
+const _hoisted_37 = { class: "safety-note" };
+const _hoisted_38 = {
+  key: 3,
+  class: "execution-result"
+};
+const _hoisted_39 = {
+  key: 4,
+  class: "final-confirmation"
+};
+const _hoisted_40 = {
+  key: 0,
+  class: "error-text"
+};
+const _hoisted_41 = ["disabled"];
+const _hoisted_42 = ["disabled"];
+const _hoisted_43 = ["disabled"];
+const _hoisted_44 = { class: "modal compact-modal" };
+const _hoisted_45 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_46 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_47 = { class: "modal compact-modal" };
+const _hoisted_48 = {
+  key: 0,
+  class: "empty-state"
+};
+const _hoisted_49 = {
+  key: 1,
+  class: "plan-state blocked"
+};
+const _hoisted_50 = ["onClick"];
+const _hoisted_51 = ["onClick"];
+const _hoisted_52 = {
+  key: 2,
+  class: "recovery-confirm"
+};
+const _hoisted_53 = ["disabled"];
+
+const {computed,onMounted,onUnmounted,ref} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'AppPage',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+  hideTitle: { type: Boolean, default: false },
+},
+  setup(__props) {
+
+const props = __props;
+
+const emptySnapshot = {
+  schemaVersion: 2,
+  snapshotId: '',
+  generatedAt: '',
+  stats: {},
+  resources: [],
+};
+
+const snapshot = ref(emptySnapshot);
+const health = ref({});
+const loading = ref(true);
+const refreshing = ref(false);
+const refreshElapsed = ref(0);
+const error = ref('');
+const search = ref('');
+const activeFilter = ref('all');
+const safeOnly = ref(false);
+const descending = ref(true);
+const selected = ref([]);
+
+const planOpen = ref(false);
+const planMode = ref(null);
+const plan = ref(null);
+const planLoading = ref(false);
+const planError = ref('');
+const acknowledgeSiteRisk = ref(false);
+const finalConfirmation = ref(false);
+const executing = ref(false);
+const executeError = ref('');
+const executeResult = ref(null);
+
+const gapOpen = ref(false);
+const gapLoading = ref(false);
+const gaps = ref([]);
+const gapError = ref('');
+
+const recoveryOpen = ref(false);
+const recoveryLoading = ref(false);
+const recoveries = ref([]);
+const recoveryError = ref('');
+const recoveryTarget = ref(null);
+const recoveryAction = ref(null);
+const recoveryPhrase = ref('');
+const recovering = ref(false);
+
+const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`);
+const resources = computed(() => snapshot.value.resources || []);
+const visible = computed(() => filterResources(resources.value, {
+  filter: activeFilter.value,
+  search: search.value,
+  safeOnly: safeOnly.value,
+  descending: descending.value,
+}));
+const selectedItems = computed(() => resources.value.filter(item => selected.value.includes(item.id)));
+const selectedSize = computed(() => selectedItems.value.reduce((total, item) => total + Number(item.size || 0), 0));
+const executionEnabled = computed(() => Boolean(health.value.executionEnabled));
+const inventoryCurrent = computed(() => health.value.inventoryCurrent !== false);
+const unresolvedTransactions = computed(() => Number(snapshot.value.stats?.unresolvedTransactions || 0));
+const hrGap = computed(() => Math.max(
+  0,
+  Number(
+    snapshot.value.stats?.hrMissingQbTasks ??
+    Number(snapshot.value.stats?.hrActiveTitles || 0) - Number(snapshot.value.stats?.hrMatchedQbTasks || 0),
+  ),
+));
+const hrUnassigned = computed(() => Number(
+  snapshot.value.stats?.hrMissingUnassigned ??
+  snapshot.value.stats?.hrMissingUncovered ??
+  0,
+));
+const filters = computed(() => FILTERS.map(filter => ({
+  ...filter,
+  count: resources.value.filter(item => {
+    if (filter.id === 'all') return true
+    return filterResources([item], {
+      filter: filter.id,
+      search: '',
+      safeOnly: false,
+      descending: true,
+    }).length === 1
+  }).length,
+})));
+const allVisibleSelected = computed(() => {
+  const selectable = visible.value.filter(item => !item.protected);
+  return selectable.length > 0 && selectable.every(item => selected.value.includes(item.id))
+});
+const currentAction = computed(() => planMode.value ? ACTIONS[planMode.value] : null);
+const planExpired = computed(() => Boolean(plan.value && Date.parse(plan.value.expiresAt) <= Date.now()));
+const refreshMessage = computed(() => {
+  if (!refreshing.value) return ''
+  return refreshFeedback(refreshElapsed.value)
+});
+
+let refreshTimer = null;
+
+function stopRefreshTimer() {
+  if (refreshTimer !== null) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+function startRefreshTimer() {
+  stopRefreshTimer();
+  refreshElapsed.value = 0;
+  refreshTimer = setInterval(() => {
+    refreshElapsed.value += 1;
+  }, 1000);
+}
+
+function payloadError(payload, fallback) {
+  return payload?.error?.message || fallback
+}
+
+async function get(path) {
+  return unwrapResponse(await props.api.get(`${pluginBase.value}${path}`))
+}
+
+async function post(path, body) {
+  return unwrapResponse(await props.api.post(`${pluginBase.value}${path}`, body))
+}
+
+function acceptSnapshot(next) {
+  if (!next || next.schemaVersion !== 2 || !next.snapshotId || !Array.isArray(next.resources)) {
+    throw new Error('资源快照格式不受支持。')
+  }
+  snapshot.value = next;
+  const available = new Set(next.resources.map(item => item.id));
+  selected.value = selected.value.filter(id => available.has(id));
+}
+
+async function loadStatus() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const payload = await get('/status');
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '无法读取清理台状态。'))
+    health.value = payload.health || {};
+    acceptSnapshot(payload.snapshot);
+  } catch (err) {
+    error.value = err?.message || '无法读取清理台状态。';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function refreshSnapshot() {
+  if (refreshing.value) return
+  refreshing.value = true;
+  startRefreshTimer();
+  error.value = '';
+  try {
+    const payload = await post('/refresh', {});
+    if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '刷新失败。'))
+    acceptSnapshot(payload.snapshot);
+    health.value = { ...health.value, inventoryCurrent: true };
+  } catch (err) {
+    error.value = err?.message || '刷新失败，继续显示上次快照。';
+    health.value = { ...health.value, inventoryCurrent: false };
+  } finally {
+    stopRefreshTimer();
+    refreshing.value = false;
+  }
+}
+
+function toggle(item) {
+  if (item.protected) return
+  selected.value = selected.value.includes(item.id)
+    ? selected.value.filter(id => id !== item.id)
+    : [...selected.value, item.id];
+}
+
+function toggleVisible() {
+  const ids = visible.value.filter(item => !item.protected).map(item => item.id);
+  selected.value = allVisibleSelected.value
+    ? selected.value.filter(id => !ids.includes(id))
+    : [...new Set([...selected.value, ...ids])];
+}
+
+async function requestPlan(mode, acknowledged = false) {
+  planLoading.value = true;
+  planError.value = '';
+  plan.value = null;
+  finalConfirmation.value = false;
+  try {
+    const payload = await post('/plan', {
+      snapshotId: snapshot.value.snapshotId,
+      resourceIds: selected.value,
+      mode,
+      acknowledgeSiteRisk: acknowledged,
+    });
+    if (!payload?.ok || !payload.plan) throw new Error(payloadError(payload, '无法生成执行计划。'))
+    plan.value = payload.plan;
+  } catch (err) {
+    planError.value = err?.message || '无法生成执行计划。';
+  } finally {
+    planLoading.value = false;
+  }
+}
+
+function openPlan(mode) {
+  planMode.value = mode;
+  planOpen.value = true;
+  acknowledgeSiteRisk.value = false;
+  executeResult.value = null;
+  executeError.value = '';
+  requestPlan(mode, false);
+}
+
+function closePlan() {
+  if (executing.value) return
+  planOpen.value = false;
+  planMode.value = null;
+  plan.value = null;
+  planError.value = '';
+  finalConfirmation.value = false;
+  executeResult.value = null;
+}
+
+async function setSiteRisk(value) {
+  acknowledgeSiteRisk.value = value;
+  await requestPlan(planMode.value, value);
+}
+
+async function executePlan() {
+  if (!plan.value || planExpired.value || executing.value) return
+  executing.value = true;
+  executeError.value = '';
+  try {
+    const payload = await post('/execute', {
+      planId: plan.value.planId,
+      confirmPhrase: plan.value.confirmPhrase,
+    });
+    if (!payload?.ok || !payload.result) {
+      if (payload?.error?.plan) plan.value = payload.error.plan;
+      throw new Error(payloadError(payload, '执行失败。'))
+    }
+    executeResult.value = payload.result;
+    selected.value = [];
+    if (payload.result.snapshotRefreshPending) {
+      health.value = { ...health.value, inventoryCurrent: false };
+    } else {
+      const latest = await get('/snapshot');
+      if (latest?.snapshot) acceptSnapshot(latest.snapshot);
+    }
+  } catch (err) {
+    executeError.value = err?.message || '执行失败。';
+    finalConfirmation.value = false;
+  } finally {
+    executing.value = false;
+  }
+}
+
+async function loadGaps() {
+  gapOpen.value = true;
+  gapLoading.value = true;
+  gapError.value = '';
+  try {
+    const payload = await get('/protection-gaps');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取 H&R 缺口。'))
+    gaps.value = payload.gaps || [];
+  } catch (err) {
+    gapError.value = err?.message || '无法读取 H&R 缺口。';
+  } finally {
+    gapLoading.value = false;
+  }
+}
+
+async function loadRecoveries() {
+  recoveryOpen.value = true;
+  recoveryLoading.value = true;
+  recoveryError.value = '';
+  recoveryTarget.value = null;
+  try {
+    const payload = await get('/recovery');
+    if (!payload?.ok) throw new Error(payloadError(payload, '无法读取恢复状态。'))
+    recoveries.value = payload.recoveries || [];
+  } catch (err) {
+    recoveryError.value = err?.message || '无法读取恢复状态。';
+  } finally {
+    recoveryLoading.value = false;
+  }
+}
+
+function chooseRecovery(item, action) {
+  recoveryTarget.value = item;
+  recoveryAction.value = action;
+  recoveryPhrase.value = '';
+  recoveryError.value = '';
+}
+
+async function runRecovery() {
+  if (!recoveryTarget.value || !recoveryAction.value || recovering.value) return
+  recovering.value = true;
+  recoveryError.value = '';
+  try {
+    const payload = await post('/recovery', {
+      planId: recoveryTarget.value.planId,
+      action: recoveryAction.value,
+      confirmPhrase: recoveryPhrase.value,
+    });
+    if (!payload?.ok) throw new Error(payloadError(payload, '恢复操作失败。'))
+    await refreshSnapshot();
+    await loadRecoveries();
+  } catch (err) {
+    recoveryError.value = err?.message || '恢复操作失败。';
+  } finally {
+    recovering.value = false;
+  }
+}
+
+function recoveryExpectedPhrase() {
+  if (!recoveryTarget.value || !recoveryAction.value) return ''
+  return recoveryAction.value === 'rollback'
+    ? recoveryTarget.value.rollbackPhrase
+    : recoveryTarget.value.finalizePhrase
+}
+
+onMounted(loadStatus);
+onUnmounted(stopRefreshTimer);
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("main", _hoisted_1, [
+    (!__props.hideTitle)
+      ? (_openBlock(), _createElementBlock("header", _hoisted_2, [
+          _cache[12] || (_cache[12] = _createElementVNode("div", null, [
+            _createElementVNode("p", { class: "eyebrow" }, "PiNAS · MoviePilot 原生页面"),
+            _createElementVNode("h1", null, "存储清理"),
+            _createElementVNode("span", null, "一部电影一行，一部剧一行；先看清影响，再选择清理等级。")
+          ], -1)),
+          _createElementVNode("div", {
+            class: _normalizeClass(['status-card', { danger: error.value || !inventoryCurrent.value }])
+          }, [
+            _createElementVNode("i", null, _toDisplayString(error.value || !inventoryCurrent.value ? '!' : '✓'), 1),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(error.value || (executionEnabled.value ? '执行链路已连接' : '只读模式')), 1),
+              (snapshot.value.generatedAt)
+                ? (_openBlock(), _createElementBlock("span", _hoisted_3, "更新于 " + _toDisplayString(snapshot.value.generatedAt.slice(5, 16).replace('T', ' ')), 1))
+                : _createCommentVNode("", true)
+            ])
+          ], 2)
+        ]))
+      : _createCommentVNode("", true),
+    _createElementVNode("section", _hoisted_4, [
+      _createElementVNode("label", _hoisted_5, [
+        _cache[13] || (_cache[13] = _createElementVNode("span", null, "⌕", -1)),
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((search).value = $event)),
+          "aria-label": "搜索资源",
+          placeholder: "搜索电影、剧集、季度或站点"
+        }, null, 512), [
+          [_vModelText, search.value]
+        ])
+      ]),
+      _createElementVNode("label", _hoisted_6, [
+        _withDirectives(_createElementVNode("input", {
+          "onUpdate:modelValue": _cache[1] || (_cache[1] = $event => ((safeOnly).value = $event)),
+          type: "checkbox"
+        }, null, 512), [
+          [_vModelCheckbox, safeOnly.value]
+        ]),
+        _cache[14] || (_cache[14] = _createElementVNode("span", null, null, -1)),
+        _cache[15] || (_cache[15] = _createTextVNode(" 仅看无做种限制 ", -1))
+      ]),
+      _createElementVNode("button", {
+        class: "soft-button",
+        type: "button",
+        onClick: _cache[2] || (_cache[2] = $event => (descending.value = !descending.value))
+      }, " 实际占用 " + _toDisplayString(descending.value ? '↓' : '↑'), 1),
+      _createElementVNode("button", {
+        class: "icon-button",
+        type: "button",
+        disabled: refreshing.value,
+        "aria-label": refreshing.value ? '正在刷新资源清单' : '刷新资源清单',
+        "aria-busy": refreshing.value,
+        title: refreshMessage.value || '刷新资源清单',
+        onClick: refreshSnapshot
+      }, _toDisplayString(refreshing.value ? '…' : '↻'), 9, _hoisted_7),
+      (refreshing.value)
+        ? (_openBlock(), _createElementBlock("p", _hoisted_8, _toDisplayString(refreshMessage.value), 1))
+        : _createCommentVNode("", true)
+    ]),
+    (unresolvedTransactions.value)
+      ? (_openBlock(), _createElementBlock("button", {
+          key: 1,
+          class: "notice critical",
+          type: "button",
+          onClick: loadRecoveries
+        }, [
+          _cache[17] || (_cache[17] = _createElementVNode("i", null, "!", -1)),
+          _createElementVNode("p", null, [
+            _createElementVNode("strong", null, _toDisplayString(unresolvedTransactions.value) + " 个未完成清理事务", 1),
+            _cache[16] || (_cache[16] = _createElementVNode("span", null, "新操作已锁定；请先核对并恢复原事务。", -1))
+          ]),
+          _cache[18] || (_cache[18] = _createElementVNode("b", null, "查看恢复状态", -1))
+        ]))
+      : (hrGap.value)
+        ? (_openBlock(), _createElementBlock("button", {
+            key: 2,
+            class: _normalizeClass(['notice', { warning: hrUnassigned.value }]),
+            type: "button",
+            onClick: loadGaps
+          }, [
+            _cache[19] || (_cache[19] = _createElementVNode("i", null, "H", -1)),
+            _createElementVNode("p", null, [
+              _createElementVNode("strong", null, _toDisplayString(hrGap.value) + " 个学校站 H&R 尚未恢复完成", 1),
+              _createElementVNode("span", null, _toDisplayString(hrUnassigned.value
+            ? `${hrUnassigned.value} 个未精确关联媒体；不会锁定无关资源。`
+            : '缺失任务只锁定精确关联资源，其他资源可独立清理。'), 1)
+            ]),
+            _cache[20] || (_cache[20] = _createElementVNode("b", null, "查看明细", -1))
+          ], 2))
+        : _createCommentVNode("", true),
+    _createElementVNode("nav", _hoisted_9, [
+      (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(filters.value, (filter) => {
+        return (_openBlock(), _createElementBlock("button", {
+          key: filter.id,
+          class: _normalizeClass({ active: activeFilter.value === filter.id }),
+          type: "button",
+          onClick: $event => (activeFilter.value = filter.id)
+        }, [
+          _createTextVNode(_toDisplayString(filter.label) + " ", 1),
+          _createElementVNode("span", null, _toDisplayString(filter.count), 1)
+        ], 10, _hoisted_10))
+      }), 128))
+    ]),
+    _createElementVNode("section", _hoisted_11, [
+      _createElementVNode("div", _hoisted_12, [
+        _createElementVNode("button", {
+          class: "select-all",
+          type: "button",
+          onClick: toggleVisible
+        }, _toDisplayString(allVisibleSelected.value ? '✓' : ''), 1),
+        _cache[21] || (_cache[21] = _createElementVNode("span", null, "资源", -1)),
+        _cache[22] || (_cache[22] = _createElementVNode("span", null, "媒体库", -1)),
+        _cache[23] || (_cache[23] = _createElementVNode("span", null, "做种与保护", -1)),
+        _cache[24] || (_cache[24] = _createElementVNode("span", null, "实际占用", -1)),
+        _cache[25] || (_cache[25] = _createElementVNode("span", null, "完整删除影响", -1))
+      ]),
+      (loading.value)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_13, "正在读取真实资源关系…"))
+        : (_openBlock(true), _createElementBlock(_Fragment, { key: 1 }, _renderList(visible.value, (item) => {
+            return (_openBlock(), _createElementBlock("article", {
+              key: item.id,
+              class: _normalizeClass(['resource-row', { selected: selected.value.includes(item.id) }])
+            }, [
+              _createElementVNode("button", {
+                class: _normalizeClass(['row-check', { locked: item.protected }]),
+                type: "button",
+                disabled: item.protected,
+                onClick: $event => (toggle(item))
+              }, _toDisplayString(item.protected ? '锁' : selected.value.includes(item.id) ? '✓' : ''), 11, _hoisted_14),
+              _createElementVNode("div", _hoisted_15, [
+                _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                _createElementVNode("b", null, _toDisplayString(item.englishTitle), 1),
+                _createElementVNode("span", null, _toDisplayString([item.type, item.year, item.edition].filter(Boolean).join(' · ')), 1)
+              ]),
+              _createElementVNode("div", _hoisted_16, [
+                _createElementVNode("strong", null, _toDisplayString(item.librarySummary), 1),
+                _createElementVNode("span", null, _toDisplayString(item.libraryDetail), 1)
+              ]),
+              _createElementVNode("div", _hoisted_17, [
+                (item.seedTasks?.length)
+                  ? (_openBlock(true), _createElementBlock(_Fragment, { key: 0 }, _renderList(item.seedTasks, (task, index) => {
+                      return (_openBlock(), _createElementBlock("div", {
+                        key: `${task.site}-${task.scope}-${index}`,
+                        class: _normalizeClass(['seed-task', task.tone])
+                      }, [
+                        _createElementVNode("i", null, _toDisplayString(task.status), 1),
+                        _createElementVNode("strong", null, _toDisplayString(task.site), 1),
+                        _createElementVNode("span", null, _toDisplayString(task.scope) + _toDisplayString(task.count > 1 ? ` · ${task.count} 个任务` : ''), 1)
+                      ], 2))
+                    }), 128))
+                  : (_openBlock(), _createElementBlock("div", _hoisted_18, [
+                      _createElementVNode("strong", null, _toDisplayString(item.qbSummary), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.siteSummary), 1)
+                    ]))
+              ]),
+              _createElementVNode("div", _hoisted_19, [
+                _createElementVNode("strong", null, _toDisplayString(item.sizeLabel), 1),
+                _createElementVNode("span", null, _toDisplayString(item.reclaimLabel), 1)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['impact', { danger: item.protected }]),
+                "data-label": "完整删除影响"
+              }, [
+                _createElementVNode("strong", null, _toDisplayString(item.impactTitle), 1),
+                _createElementVNode("span", null, _toDisplayString(item.impactDetail), 1)
+              ], 2)
+            ], 2))
+          }), 128)),
+      (!loading.value && !visible.value.length)
+        ? (_openBlock(), _createElementBlock("div", _hoisted_20, " 没有符合条件的资源，请取消筛选或更换关键词。 "))
+        : _createCommentVNode("", true)
+    ]),
+    (_openBlock(), _createBlock(_Teleport, { to: "body" }, [
+      (selected.value.length)
+        ? (_openBlock(), _createElementBlock("aside", _hoisted_21, [
+            _createElementVNode("div", _hoisted_22, _toDisplayString(selected.value.length), 1),
+            _createElementVNode("p", null, [
+              _cache[26] || (_cache[26] = _createElementVNode("strong", null, "已加入清理计划", -1)),
+              _createElementVNode("span", null, "完整删除上限 " + _toDisplayString(_unref(formatGiB)(selectedSize.value)), 1)
+            ]),
+            _createElementVNode("button", {
+              class: "clear-button",
+              type: "button",
+              onClick: _cache[3] || (_cache[3] = $event => (selected.value = []))
+            }, "清空"),
+            _createElementVNode("div", _hoisted_23, [
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(ACTIONS), (action, mode) => {
+                return (_openBlock(), _createElementBlock("button", {
+                  key: mode,
+                  class: _normalizeClass(['action-level', { delete: mode === 'delete' }]),
+                  type: "button",
+                  onClick: $event => (openPlan(mode))
+                }, [
+                  _createElementVNode("strong", null, _toDisplayString(action.title), 1),
+                  _createElementVNode("span", null, _toDisplayString(action.detail), 1)
+                ], 10, _hoisted_24))
+              }), 128))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (planOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 1,
+            class: "modal-backdrop",
+            onClick: _withModifiers(closePlan, ["self"])
+          }, [
+            _createElementVNode("section", _hoisted_25, [
+              _createElementVNode("header", null, [
+                _createElementVNode("div", null, [
+                  _cache[27] || (_cache[27] = _createElementVNode("span", null, "清理等级 · 真实预演", -1)),
+                  _createElementVNode("h2", null, _toDisplayString(currentAction.value?.title), 1)
+                ]),
+                _createElementVNode("button", {
+                  type: "button",
+                  disabled: executing.value,
+                  onClick: closePlan
+                }, "×", 8, _hoisted_26)
+              ]),
+              _createElementVNode("div", {
+                class: _normalizeClass(['mode-summary', planMode.value])
+              }, [
+                (plan.value && planMode.value === 'delete')
+                  ? (_openBlock(), _createElementBlock("strong", _hoisted_27, "已核算可释放 " + _toDisplayString(_unref(formatBytes)(plan.value.estimatedReclaimBytes)), 1))
+                  : (_openBlock(), _createElementBlock("strong", _hoisted_28, _toDisplayString(currentAction.value?.detail), 1)),
+                _createElementVNode("span", null, _toDisplayString(planMode.value === 'pause'
+              ? '只改变 qB 运行状态，不删除任务或文件。'
+              : planMode.value === 'retire'
+                ? '移除 qB 任务但保留文件，媒体库继续可播放。'
+                : '仅当全部路径、硬链接、H&R 与任务状态通过校验才会放行。'), 1)
+              ], 2),
+              _createElementVNode("div", _hoisted_29, [
+                (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(selectedItems.value, (item) => {
+                  return (_openBlock(), _createElementBlock("div", {
+                    key: item.id
+                  }, [
+                    _createElementVNode("p", null, [
+                      _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                      _createElementVNode("span", null, _toDisplayString(item.englishTitle) + " · " + _toDisplayString(item.edition), 1)
+                    ]),
+                    _createElementVNode("b", null, _toDisplayString(item.sizeLabel), 1)
+                  ]))
+                }), 128))
+              ]),
+              (planLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_30, "正在刷新 NAS 状态并复核关系…"))
+                : (planError.value)
+                  ? (_openBlock(), _createElementBlock("div", _hoisted_31, [
+                      _cache[28] || (_cache[28] = _createElementVNode("strong", null, "无法生成计划", -1)),
+                      _createElementVNode("span", null, _toDisplayString(planError.value), 1)
+                    ]))
+                  : (plan.value)
+                    ? (_openBlock(), _createElementBlock(_Fragment, { key: 2 }, [
+                        _createElementVNode("div", {
+                          class: _normalizeClass(['plan-state', plan.value.canExecute ? 'passed' : 'blocked'])
+                        }, [
+                          _createElementVNode("strong", null, _toDisplayString(plan.value.canExecute ? '安全预演通过' : '计划已被安全门禁拦截'), 1),
+                          _createElementVNode("span", null, " 停止 " + _toDisplayString(plan.value.operationCounts.qbStop) + " 个任务 · 退出 " + _toDisplayString(plan.value.operationCounts.qbRemoveKeepFiles) + " 个任务 · 解除 " + _toDisplayString(plan.value.operationCounts.unlinkFiles) + " 个文件入口 ", 1)
+                        ], 2),
+                        (plan.value.blocks?.length)
+                          ? (_openBlock(), _createElementBlock("ul", _hoisted_32, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.blocks, (issue, index) => {
+                                return (_openBlock(), _createElementBlock("li", {
+                                  key: _unref(issueKey)(issue, index)
+                                }, _toDisplayString(issue.message), 1))
+                              }), 128))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (plan.value.warnings?.length)
+                          ? (_openBlock(), _createElementBlock("ul", _hoisted_33, [
+                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(plan.value.warnings, (issue, index) => {
+                                return (_openBlock(), _createElementBlock("li", {
+                                  key: _unref(issueKey)(issue, index)
+                                }, _toDisplayString(issue.message), 1))
+                              }), 128))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (plan.value.requiresSiteAcknowledgement)
+                          ? (_openBlock(), _createElementBlock("label", _hoisted_34, [
+                              _createElementVNode("input", {
+                                checked: acknowledgeSiteRisk.value,
+                                type: "checkbox",
+                                onChange: _cache[4] || (_cache[4] = $event => (setSiteRisk($event.target.checked)))
+                              }, null, 40, _hoisted_35),
+                              _cache[29] || (_cache[29] = _createElementVNode("span", null, null, -1)),
+                              _cache[30] || (_cache[30] = _createTextVNode(" 我已确认会影响私有站做种，并接受站点规则风险 ", -1))
+                            ]))
+                          : _createCommentVNode("", true),
+                        (planExpired.value)
+                          ? (_openBlock(), _createElementBlock("div", _hoisted_36, [...(_cache[31] || (_cache[31] = [
+                              _createElementVNode("strong", null, "安全预演已过期", -1),
+                              _createElementVNode("span", null, "请关闭后重新生成。", -1)
+                            ]))]))
+                          : _createCommentVNode("", true)
+                      ], 64))
+                    : _createCommentVNode("", true),
+              _createElementVNode("div", _hoisted_37, [
+                _cache[33] || (_cache[33] = _createElementVNode("i", null, "盾", -1)),
+                _createElementVNode("p", null, [
+                  _createElementVNode("strong", null, _toDisplayString(executionEnabled.value ? '执行前还需第二次确认' : '执行引擎未启用'), 1),
+                  _cache[32] || (_cache[32] = _createElementVNode("span", null, "最终执行前会重新读取 qB、路径、硬链接和保护状态。", -1))
+                ])
+              ]),
+              (executeResult.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_38, [
+                    _createElementVNode("strong", null, _toDisplayString(currentAction.value?.title) + "已完成", 1),
+                    _createElementVNode("span", null, " 停止 " + _toDisplayString(executeResult.value.qbStopped) + " · 退出 " + _toDisplayString(executeResult.value.qbRemoved) + " · 删除文件入口 " + _toDisplayString(executeResult.value.filesDeleted) + " · 清理索引 " + _toDisplayString(executeResult.value.moviepilotIndexesDeleted), 1),
+                    _createElementVNode("button", {
+                      type: "button",
+                      onClick: closePlan
+                    }, "完成")
+                  ]))
+                : (finalConfirmation.value)
+                  ? (_openBlock(), _createElementBlock("div", _hoisted_39, [
+                      _cache[34] || (_cache[34] = _createElementVNode("strong", null, "再次确认：系统将立即执行这份计划", -1)),
+                      (executeError.value)
+                        ? (_openBlock(), _createElementBlock("span", _hoisted_40, _toDisplayString(executeError.value), 1))
+                        : _createCommentVNode("", true),
+                      _createElementVNode("div", null, [
+                        _createElementVNode("button", {
+                          type: "button",
+                          disabled: executing.value,
+                          onClick: _cache[5] || (_cache[5] = $event => (finalConfirmation.value = false))
+                        }, "返回", 8, _hoisted_41),
+                        _createElementVNode("button", {
+                          class: _normalizeClass({ danger: planMode.value === 'delete' }),
+                          type: "button",
+                          disabled: executing.value || planExpired.value,
+                          onClick: executePlan
+                        }, _toDisplayString(executing.value ? '正在二次复核…' : `确认${currentAction.value?.title}`), 11, _hoisted_42)
+                      ])
+                    ]))
+                  : (_openBlock(), _createElementBlock("button", {
+                      key: 5,
+                      class: "confirm-button",
+                      type: "button",
+                      disabled: !executionEnabled.value || !plan.value?.canExecute || planExpired.value,
+                      onClick: _cache[6] || (_cache[6] = $event => (finalConfirmation.value = true))
+                    }, " 进入最终确认 ", 8, _hoisted_43))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (gapOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 2,
+            class: "modal-backdrop",
+            onClick: _cache[8] || (_cache[8] = _withModifiers($event => (gapOpen.value = false), ["self"]))
+          }, [
+            _createElementVNode("section", _hoisted_44, [
+              _createElementVNode("header", null, [
+                _cache[35] || (_cache[35] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "学校站实时保护"),
+                  _createElementVNode("h2", null, "H&R 缺口明细")
+                ], -1)),
+                _createElementVNode("button", {
+                  onClick: _cache[7] || (_cache[7] = $event => (gapOpen.value = false))
+                }, "×")
+              ]),
+              (gapLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_45, "正在核对…"))
+                : _createCommentVNode("", true),
+              (gapError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_46, _toDisplayString(gapError.value), 1))
+                : _createCommentVNode("", true),
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(gaps.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.title,
+                  class: "gap-row"
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.title), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.linkedResourceTitle || '尚未精确关联媒体'), 1)
+                  ]),
+                  _createElementVNode("b", null, _toDisplayString(item.qbTaskPresent ? 'qB 已存在' : item.coveredByCandidate ? '候选恢复中' : '任务缺失'), 1)
+                ]))
+              }), 128))
+            ])
+          ]))
+        : _createCommentVNode("", true),
+      (recoveryOpen.value)
+        ? (_openBlock(), _createElementBlock("div", {
+            key: 3,
+            class: "modal-backdrop",
+            onClick: _cache[11] || (_cache[11] = _withModifiers($event => (recoveryOpen.value = false), ["self"]))
+          }, [
+            _createElementVNode("section", _hoisted_47, [
+              _createElementVNode("header", null, [
+                _cache[36] || (_cache[36] = _createElementVNode("div", null, [
+                  _createElementVNode("span", null, "失败关闭"),
+                  _createElementVNode("h2", null, "恢复未完成清理")
+                ], -1)),
+                _createElementVNode("button", {
+                  onClick: _cache[9] || (_cache[9] = $event => (recoveryOpen.value = false))
+                }, "×")
+              ]),
+              (recoveryLoading.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_48, "正在读取事务…"))
+                : _createCommentVNode("", true),
+              (recoveryError.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_49, _toDisplayString(recoveryError.value), 1))
+                : _createCommentVNode("", true),
+              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(recoveries.value, (item) => {
+                return (_openBlock(), _createElementBlock("div", {
+                  key: item.planId,
+                  class: "recovery-row"
+                }, [
+                  _createElementVNode("p", null, [
+                    _createElementVNode("strong", null, _toDisplayString(item.mode) + " · " + _toDisplayString(item.phase), 1),
+                    _createElementVNode("span", null, _toDisplayString(item.planId.slice(-10)), 1)
+                  ]),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: $event => (chooseRecovery(item, 'rollback'))
+                  }, "回滚", 8, _hoisted_50),
+                  _createElementVNode("button", {
+                    type: "button",
+                    onClick: $event => (chooseRecovery(item, 'finalize'))
+                  }, "完成原事务", 8, _hoisted_51)
+                ]))
+              }), 128)),
+              (recoveryTarget.value)
+                ? (_openBlock(), _createElementBlock("div", _hoisted_52, [
+                    _createElementVNode("label", null, [
+                      _cache[37] || (_cache[37] = _createTextVNode("输入确认短语 ", -1)),
+                      _createElementVNode("code", null, _toDisplayString(recoveryExpectedPhrase()), 1)
+                    ]),
+                    _withDirectives(_createElementVNode("input", {
+                      "onUpdate:modelValue": _cache[10] || (_cache[10] = $event => ((recoveryPhrase).value = $event)),
+                      autocomplete: "off"
+                    }, null, 512), [
+                      [_vModelText, recoveryPhrase.value]
+                    ]),
+                    _createElementVNode("button", {
+                      type: "button",
+                      disabled: recovering.value || recoveryPhrase.value !== recoveryExpectedPhrase(),
+                      onClick: runRecovery
+                    }, _toDisplayString(recovering.value ? '处理中…' : '执行恢复'), 9, _hoisted_53)
+                  ]))
+                : _createCommentVNode("", true)
+            ])
+          ]))
+        : _createCommentVNode("", true)
+    ]))
+  ]))
+}
+}
+
+};
+const AppPage = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-d46813f7"]]);
+
+export { createLatestPlanApi as c, AppPage as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_expose_Config-BHIxEI63.css
+++ b/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_expose_Config-BHIxEI63.css
@@ -1,0 +1,41 @@
+
+.config-page[data-v-54d4575f] { display: grid; gap: 18px; padding: 22px; max-width: 980px;
+}
+header[data-v-54d4575f] { display: grid; gap: 6px;
+}
+h2[data-v-54d4575f] { margin: 0;
+}
+p[data-v-54d4575f] { margin: 0; opacity: .72; line-height: 1.6;
+}
+.form-grid[data-v-54d4575f] { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px;
+}
+label[data-v-54d4575f] { display: grid; gap: 7px; font-weight: 600;
+}
+input[data-v-54d4575f], textarea[data-v-54d4575f] { width: 100%; box-sizing: border-box; padding: 9px 11px; border: 1px solid rgba(var(--v-border-color), .35); border-radius: 8px; background: transparent; color: inherit; font: inherit; font-weight: 400;
+}
+textarea[data-v-54d4575f] { resize: vertical; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .9em;
+}
+.wide[data-v-54d4575f] { grid-column: 1 / -1;
+}
+.notice[data-v-54d4575f], .error[data-v-54d4575f], .success[data-v-54d4575f], .probe[data-v-54d4575f] { display: grid; gap: 5px; padding: 12px 14px; border-radius: 9px;
+}
+.notice[data-v-54d4575f] { background: rgba(128, 128, 128, .12);
+}
+.error[data-v-54d4575f] { color: #b42318; background: rgba(180, 35, 24, .1);
+}
+.success[data-v-54d4575f] { color: #087443; background: rgba(8, 116, 67, .1);
+}
+.probe[data-v-54d4575f] { background: rgba(32, 106, 255, .08);
+}
+.save[data-v-54d4575f] { justify-self: start; padding: 10px 18px; border: 0; border-radius: 8px; cursor: pointer; background: rgb(var(--v-theme-primary)); color: rgb(var(--v-theme-on-primary));
+}
+.save[data-v-54d4575f]:disabled { opacity: .5; cursor: default;
+}
+@media (max-width: 760px) {
+.config-page[data-v-54d4575f] { padding: 16px;
+}
+.form-grid[data-v-54d4575f] { grid-template-columns: 1fr;
+}
+.wide[data-v-54d4575f] { grid-column: auto;
+}
+}

--- a/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_expose_Config-BlunJQWM.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_expose_Config-BlunJQWM.js
@@ -1,0 +1,263 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
+
+const {createElementVNode:_createElementVNode,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,vModelText:_vModelText,withDirectives:_withDirectives,createTextVNode:_createTextVNode,toDisplayString:_toDisplayString,renderList:_renderList,Fragment:_Fragment} = await importShared('vue');
+
+
+const _hoisted_1 = { class: "config-page" };
+const _hoisted_2 = {
+  key: 0,
+  class: "notice"
+};
+const _hoisted_3 = {
+  key: 1,
+  class: "form-grid"
+};
+const _hoisted_4 = { class: "wide" };
+const _hoisted_5 = { class: "wide" };
+const _hoisted_6 = {
+  key: 2,
+  class: "error"
+};
+const _hoisted_7 = {
+  key: 3,
+  class: "success"
+};
+const _hoisted_8 = {
+  key: 4,
+  class: "probe"
+};
+const _hoisted_9 = { key: 0 };
+const _hoisted_10 = ["disabled"];
+
+const {computed,onMounted,reactive,ref} = await importShared('vue');
+
+
+
+const _sfc_main = {
+  __name: 'Config',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+const props = __props;
+
+const form = reactive({
+  version: 1,
+  ssh_host: '',
+  qb_url: '',
+  jellyfin_db: '',
+  moviepilot_db: '',
+  qb_backup: '',
+  execution_backup: '',
+  allowed_roots_text: '',
+  quarantine_roots_text: '',
+});
+const loading = ref(true);
+const saving = ref(false);
+const error = ref('');
+const message = ref('');
+const probe = ref(null);
+
+const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`);
+
+function unwrap(response) {
+  if (response && Object.prototype.hasOwnProperty.call(response, 'data')) {
+    return response.data
+  }
+  return response
+}
+
+function applyConfig(config) {
+  Object.assign(form, {
+    ...config,
+    allowed_roots_text: (config.allowed_roots || []).join('\n'),
+    quarantine_roots_text: Object.entries(config.quarantine_roots || {})
+      .map(([volume, target]) => `${volume}=${target}`)
+      .join('\n'),
+  });
+}
+
+function parseLines(value) {
+  return String(value || '')
+    .split('\n')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+function buildConfig() {
+  const quarantine_roots = {};
+  for (const line of parseLines(form.quarantine_roots_text)) {
+    const separator = line.indexOf('=');
+    if (separator <= 0 || separator === line.length - 1) {
+      throw new Error('隔离目录格式应为：卷根目录=隔离目录。')
+    }
+    quarantine_roots[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+  }
+  return {
+    version: 1,
+    ssh_host: form.ssh_host,
+    qb_url: form.qb_url,
+    jellyfin_db: form.jellyfin_db,
+    moviepilot_db: form.moviepilot_db,
+    qb_backup: form.qb_backup,
+    execution_backup: form.execution_backup,
+    allowed_roots: parseLines(form.allowed_roots_text),
+    quarantine_roots,
+  }
+}
+
+async function load() {
+  loading.value = true;
+  error.value = '';
+  try {
+    if (!props.api.get) throw new Error('MoviePilot 没有提供插件 API。')
+    const payload = unwrap(await props.api.get(`${pluginBase.value}/config`));
+    if (!payload?.ok || !payload.config) throw new Error(payload?.error?.message || '无法读取清理台配置。')
+    applyConfig(payload.config);
+    probe.value = payload.probe || null;
+  } catch (err) {
+    error.value = err?.message || '无法读取清理台配置。';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function save() {
+  saving.value = true;
+  error.value = '';
+  message.value = '';
+  try {
+    const config = buildConfig();
+    const payload = unwrap(await props.api.post(`${pluginBase.value}/config`, { config }));
+    if (!payload?.ok || !payload.config) throw new Error(payload?.error?.message || '配置保存失败。')
+    applyConfig(payload.config);
+    probe.value = payload.probe || null;
+    message.value = probe.value?.ok
+      ? '配置已保存，路径探测通过；请刷新资源清单。'
+      : '配置已保存，但仍有路径未就绪；清理操作保持锁定。';
+  } catch (err) {
+    const payload = err?.response?.data || err?.data;
+    probe.value = payload?.probe || probe.value;
+    error.value = err?.message || payload?.error?.message || '配置保存失败。';
+  } finally {
+    saving.value = false;
+  }
+}
+
+onMounted(load);
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("section", _hoisted_1, [
+    _cache[16] || (_cache[16] = _createElementVNode("header", null, [
+      _createElementVNode("h2", null, "存储清理设置"),
+      _createElementVNode("p", null, "这里只保存 NAS 拓扑和路径，不会写入 Cookie、passkey 或控制令牌。保存后先做只读探测，未通过探测时清理操作保持锁定。")
+    ], -1)),
+    (loading.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_2, "正在读取配置…"))
+      : (_openBlock(), _createElementBlock("div", _hoisted_3, [
+          _createElementVNode("label", null, [
+            _cache[8] || (_cache[8] = _createTextVNode("SSH 目标", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((form.ssh_host) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.ssh_host]
+            ])
+          ]),
+          _createElementVNode("label", null, [
+            _cache[9] || (_cache[9] = _createTextVNode("qBittorrent 地址", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[1] || (_cache[1] = $event => ((form.qb_url) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.qb_url]
+            ])
+          ]),
+          _createElementVNode("label", null, [
+            _cache[10] || (_cache[10] = _createTextVNode("Jellyfin 数据库", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[2] || (_cache[2] = $event => ((form.jellyfin_db) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.jellyfin_db]
+            ])
+          ]),
+          _createElementVNode("label", null, [
+            _cache[11] || (_cache[11] = _createTextVNode("MoviePilot 数据库", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[3] || (_cache[3] = $event => ((form.moviepilot_db) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.moviepilot_db]
+            ])
+          ]),
+          _createElementVNode("label", null, [
+            _cache[12] || (_cache[12] = _createTextVNode("qB 种子备份目录", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[4] || (_cache[4] = $event => ((form.qb_backup) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.qb_backup]
+            ])
+          ]),
+          _createElementVNode("label", null, [
+            _cache[13] || (_cache[13] = _createTextVNode("清理事务备份目录", -1)),
+            _withDirectives(_createElementVNode("input", {
+              "onUpdate:modelValue": _cache[5] || (_cache[5] = $event => ((form.execution_backup) = $event)),
+              autocomplete: "off"
+            }, null, 512), [
+              [_vModelText, form.execution_backup]
+            ])
+          ]),
+          _createElementVNode("label", _hoisted_4, [
+            _cache[14] || (_cache[14] = _createTextVNode("允许扫描/清理的根目录（每行一个）", -1)),
+            _withDirectives(_createElementVNode("textarea", {
+              "onUpdate:modelValue": _cache[6] || (_cache[6] = $event => ((form.allowed_roots_text) = $event)),
+              rows: "6"
+            }, null, 512), [
+              [_vModelText, form.allowed_roots_text]
+            ])
+          ]),
+          _createElementVNode("label", _hoisted_5, [
+            _cache[15] || (_cache[15] = _createTextVNode("隔离目录映射（每行：卷根目录=隔离目录）", -1)),
+            _withDirectives(_createElementVNode("textarea", {
+              "onUpdate:modelValue": _cache[7] || (_cache[7] = $event => ((form.quarantine_roots_text) = $event)),
+              rows: "4"
+            }, null, 512), [
+              [_vModelText, form.quarantine_roots_text]
+            ])
+          ])
+        ])),
+    (error.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_6, _toDisplayString(error.value), 1))
+      : _createCommentVNode("", true),
+    (message.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_7, _toDisplayString(message.value), 1))
+      : _createCommentVNode("", true),
+    (probe.value)
+      ? (_openBlock(), _createElementBlock("div", _hoisted_8, [
+          _createElementVNode("strong", null, _toDisplayString(probe.value.ok ? '只读探测通过' : '只读探测未通过'), 1),
+          (probe.value.missing?.length)
+            ? (_openBlock(), _createElementBlock("span", _hoisted_9, "未找到：" + _toDisplayString(probe.value.missing.join('、')), 1))
+            : _createCommentVNode("", true),
+          (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(probe.value.problems || [], (item) => {
+            return (_openBlock(), _createElementBlock("span", { key: item }, _toDisplayString(item), 1))
+          }), 128))
+        ]))
+      : _createCommentVNode("", true),
+    _createElementVNode("button", {
+      class: "save",
+      disabled: loading.value || saving.value,
+      onClick: save
+    }, _toDisplayString(saving.value ? '保存中…' : '保存并探测'), 9, _hoisted_10)
+  ]))
+}
+}
+
+};
+const Config = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-54d4575f"]]);
+
+export { Config as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_expose_Page-DBYbf6GK.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_expose_Page-DBYbf6GK.js
@@ -1,0 +1,32 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage, { c as createLatestPlanApi } from './__federation_expose_AppPage-DU_5-3RL.js';
+
+const {unref:_unref,openBlock:_openBlock,createBlock:_createBlock} = await importShared('vue');
+
+
+const _sfc_main = {
+  __name: 'Page',
+  props: {
+  api: { type: Object, default: () => ({}) },
+  pluginId: { type: String, default: 'StorageCleanup' },
+},
+  setup(__props) {
+
+const props = __props;
+
+const guardedApi = createLatestPlanApi({
+  get: (...args) => props.api.get(...args),
+  post: (...args) => props.api.post(...args),
+});
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createBlock(AppPage, {
+    api: _unref(guardedApi),
+    "plugin-id": __props.pluginId
+  }, null, 8, ["api", "plugin-id"]))
+}
+}
+
+};
+
+export { _sfc_main as default };

--- a/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_fn_import-JrT3xvdd.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.6/assets/__federation_fn_import-JrT3xvdd.js
@@ -1,0 +1,418 @@
+const buildIdentifier = "[0-9A-Za-z-]+";
+const build = `(?:\\+(${buildIdentifier}(?:\\.${buildIdentifier})*))`;
+const numericIdentifier = "0|[1-9]\\d*";
+const numericIdentifierLoose = "[0-9]+";
+const nonNumericIdentifier = "\\d*[a-zA-Z-][a-zA-Z0-9-]*";
+const preReleaseIdentifierLoose = `(?:${numericIdentifierLoose}|${nonNumericIdentifier})`;
+const preReleaseLoose = `(?:-?(${preReleaseIdentifierLoose}(?:\\.${preReleaseIdentifierLoose})*))`;
+const preReleaseIdentifier = `(?:${numericIdentifier}|${nonNumericIdentifier})`;
+const preRelease = `(?:-(${preReleaseIdentifier}(?:\\.${preReleaseIdentifier})*))`;
+const xRangeIdentifier = `${numericIdentifier}|x|X|\\*`;
+const xRangePlain = `[v=\\s]*(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:\\.(${xRangeIdentifier})(?:${preRelease})?${build}?)?)?`;
+const hyphenRange = `^\\s*(${xRangePlain})\\s+-\\s+(${xRangePlain})\\s*$`;
+const mainVersionLoose = `(${numericIdentifierLoose})\\.(${numericIdentifierLoose})\\.(${numericIdentifierLoose})`;
+const loosePlain = `[v=\\s]*${mainVersionLoose}${preReleaseLoose}?${build}?`;
+const gtlt = "((?:<|>)?=?)";
+const comparatorTrim = `(\\s*)${gtlt}\\s*(${loosePlain}|${xRangePlain})`;
+const loneTilde = "(?:~>?)";
+const tildeTrim = `(\\s*)${loneTilde}\\s+`;
+const loneCaret = "(?:\\^)";
+const caretTrim = `(\\s*)${loneCaret}\\s+`;
+const star = "(<|>)?=?\\s*\\*";
+const caret = `^${loneCaret}${xRangePlain}$`;
+const mainVersion = `(${numericIdentifier})\\.(${numericIdentifier})\\.(${numericIdentifier})`;
+const fullPlain = `v?${mainVersion}${preRelease}?${build}?`;
+const tilde = `^${loneTilde}${xRangePlain}$`;
+const xRange = `^${gtlt}\\s*${xRangePlain}$`;
+const comparator = `^${gtlt}\\s*(${fullPlain})$|^$`;
+const gte0 = "^\\s*>=\\s*0.0.0\\s*$";
+function parseRegex(source) {
+  return new RegExp(source);
+}
+function isXVersion(version) {
+  return !version || version.toLowerCase() === "x" || version === "*";
+}
+function pipe(...fns) {
+  return (x) => {
+    return fns.reduce((v, f) => f(v), x);
+  };
+}
+function extractComparator(comparatorString) {
+  return comparatorString.match(parseRegex(comparator));
+}
+function combineVersion(major, minor, patch, preRelease2) {
+  const mainVersion2 = `${major}.${minor}.${patch}`;
+  if (preRelease2) {
+    return `${mainVersion2}-${preRelease2}`;
+  }
+  return mainVersion2;
+}
+function parseHyphen(range) {
+  return range.replace(
+    parseRegex(hyphenRange),
+    (_range, from, fromMajor, fromMinor, fromPatch, _fromPreRelease, _fromBuild, to, toMajor, toMinor, toPatch, toPreRelease) => {
+      if (isXVersion(fromMajor)) {
+        from = "";
+      } else if (isXVersion(fromMinor)) {
+        from = `>=${fromMajor}.0.0`;
+      } else if (isXVersion(fromPatch)) {
+        from = `>=${fromMajor}.${fromMinor}.0`;
+      } else {
+        from = `>=${from}`;
+      }
+      if (isXVersion(toMajor)) {
+        to = "";
+      } else if (isXVersion(toMinor)) {
+        to = `<${+toMajor + 1}.0.0-0`;
+      } else if (isXVersion(toPatch)) {
+        to = `<${toMajor}.${+toMinor + 1}.0-0`;
+      } else if (toPreRelease) {
+        to = `<=${toMajor}.${toMinor}.${toPatch}-${toPreRelease}`;
+      } else {
+        to = `<=${to}`;
+      }
+      return `${from} ${to}`.trim();
+    }
+  );
+}
+function parseComparatorTrim(range) {
+  return range.replace(parseRegex(comparatorTrim), "$1$2$3");
+}
+function parseTildeTrim(range) {
+  return range.replace(parseRegex(tildeTrim), "$1~");
+}
+function parseCaretTrim(range) {
+  return range.replace(parseRegex(caretTrim), "$1^");
+}
+function parseCarets(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(caret),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          if (major === "0") {
+            return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+          } else {
+            return `>=${major}.${minor}.0 <${+major + 1}.0.0-0`;
+          }
+        } else if (preRelease2) {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+            }
+          } else {
+            return `>=${major}.${minor}.${patch}-${preRelease2} <${+major + 1}.0.0-0`;
+          }
+        } else {
+          if (major === "0") {
+            if (minor === "0") {
+              return `>=${major}.${minor}.${patch} <${major}.${minor}.${+patch + 1}-0`;
+            } else {
+              return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+            }
+          }
+          return `>=${major}.${minor}.${patch} <${+major + 1}.0.0-0`;
+        }
+      }
+    );
+  }).join(" ");
+}
+function parseTildes(range) {
+  return range.trim().split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.replace(
+      parseRegex(tilde),
+      (_, major, minor, patch, preRelease2) => {
+        if (isXVersion(major)) {
+          return "";
+        } else if (isXVersion(minor)) {
+          return `>=${major}.0.0 <${+major + 1}.0.0-0`;
+        } else if (isXVersion(patch)) {
+          return `>=${major}.${minor}.0 <${major}.${+minor + 1}.0-0`;
+        } else if (preRelease2) {
+          return `>=${major}.${minor}.${patch}-${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return `>=${major}.${minor}.${patch} <${major}.${+minor + 1}.0-0`;
+      }
+    );
+  }).join(" ");
+}
+function parseXRanges(range) {
+  return range.split(/\s+/).map((rangeVersion) => {
+    return rangeVersion.trim().replace(
+      parseRegex(xRange),
+      (ret, gtlt2, major, minor, patch, preRelease2) => {
+        const isXMajor = isXVersion(major);
+        const isXMinor = isXMajor || isXVersion(minor);
+        const isXPatch = isXMinor || isXVersion(patch);
+        if (gtlt2 === "=" && isXPatch) {
+          gtlt2 = "";
+        }
+        preRelease2 = "";
+        if (isXMajor) {
+          if (gtlt2 === ">" || gtlt2 === "<") {
+            return "<0.0.0-0";
+          } else {
+            return "*";
+          }
+        } else if (gtlt2 && isXPatch) {
+          if (isXMinor) {
+            minor = 0;
+          }
+          patch = 0;
+          if (gtlt2 === ">") {
+            gtlt2 = ">=";
+            if (isXMinor) {
+              major = +major + 1;
+              minor = 0;
+              patch = 0;
+            } else {
+              minor = +minor + 1;
+              patch = 0;
+            }
+          } else if (gtlt2 === "<=") {
+            gtlt2 = "<";
+            if (isXMinor) {
+              major = +major + 1;
+            } else {
+              minor = +minor + 1;
+            }
+          }
+          if (gtlt2 === "<") {
+            preRelease2 = "-0";
+          }
+          return `${gtlt2 + major}.${minor}.${patch}${preRelease2}`;
+        } else if (isXMinor) {
+          return `>=${major}.0.0${preRelease2} <${+major + 1}.0.0-0`;
+        } else if (isXPatch) {
+          return `>=${major}.${minor}.0${preRelease2} <${major}.${+minor + 1}.0-0`;
+        }
+        return ret;
+      }
+    );
+  }).join(" ");
+}
+function parseStar(range) {
+  return range.trim().replace(parseRegex(star), "");
+}
+function parseGTE0(comparatorString) {
+  return comparatorString.trim().replace(parseRegex(gte0), "");
+}
+function compareAtom(rangeAtom, versionAtom) {
+  rangeAtom = +rangeAtom || rangeAtom;
+  versionAtom = +versionAtom || versionAtom;
+  if (rangeAtom > versionAtom) {
+    return 1;
+  }
+  if (rangeAtom === versionAtom) {
+    return 0;
+  }
+  return -1;
+}
+function comparePreRelease(rangeAtom, versionAtom) {
+  const { preRelease: rangePreRelease } = rangeAtom;
+  const { preRelease: versionPreRelease } = versionAtom;
+  if (rangePreRelease === void 0 && !!versionPreRelease) {
+    return 1;
+  }
+  if (!!rangePreRelease && versionPreRelease === void 0) {
+    return -1;
+  }
+  if (rangePreRelease === void 0 && versionPreRelease === void 0) {
+    return 0;
+  }
+  for (let i = 0, n = rangePreRelease.length; i <= n; i++) {
+    const rangeElement = rangePreRelease[i];
+    const versionElement = versionPreRelease[i];
+    if (rangeElement === versionElement) {
+      continue;
+    }
+    if (rangeElement === void 0 && versionElement === void 0) {
+      return 0;
+    }
+    if (!rangeElement) {
+      return 1;
+    }
+    if (!versionElement) {
+      return -1;
+    }
+    return compareAtom(rangeElement, versionElement);
+  }
+  return 0;
+}
+function compareVersion(rangeAtom, versionAtom) {
+  return compareAtom(rangeAtom.major, versionAtom.major) || compareAtom(rangeAtom.minor, versionAtom.minor) || compareAtom(rangeAtom.patch, versionAtom.patch) || comparePreRelease(rangeAtom, versionAtom);
+}
+function eq(rangeAtom, versionAtom) {
+  return rangeAtom.version === versionAtom.version;
+}
+function compare(rangeAtom, versionAtom) {
+  switch (rangeAtom.operator) {
+    case "":
+    case "=":
+      return eq(rangeAtom, versionAtom);
+    case ">":
+      return compareVersion(rangeAtom, versionAtom) < 0;
+    case ">=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) < 0;
+    case "<":
+      return compareVersion(rangeAtom, versionAtom) > 0;
+    case "<=":
+      return eq(rangeAtom, versionAtom) || compareVersion(rangeAtom, versionAtom) > 0;
+    case void 0: {
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+function parseComparatorString(range) {
+  return pipe(
+    parseCarets,
+    parseTildes,
+    parseXRanges,
+    parseStar
+  )(range);
+}
+function parseRange(range) {
+  return pipe(
+    parseHyphen,
+    parseComparatorTrim,
+    parseTildeTrim,
+    parseCaretTrim
+  )(range.trim()).split(/\s+/).join(" ");
+}
+function satisfy(version, range) {
+  if (!version) {
+    return false;
+  }
+  const parsedRange = parseRange(range);
+  const parsedComparator = parsedRange.split(" ").map((rangeVersion) => parseComparatorString(rangeVersion)).join(" ");
+  const comparators = parsedComparator.split(/\s+/).map((comparator2) => parseGTE0(comparator2));
+  const extractedVersion = extractComparator(version);
+  if (!extractedVersion) {
+    return false;
+  }
+  const [
+    ,
+    versionOperator,
+    ,
+    versionMajor,
+    versionMinor,
+    versionPatch,
+    versionPreRelease
+  ] = extractedVersion;
+  const versionAtom = {
+    version: combineVersion(
+      versionMajor,
+      versionMinor,
+      versionPatch,
+      versionPreRelease
+    ),
+    major: versionMajor,
+    minor: versionMinor,
+    patch: versionPatch,
+    preRelease: versionPreRelease == null ? void 0 : versionPreRelease.split(".")
+  };
+  for (const comparator2 of comparators) {
+    const extractedComparator = extractComparator(comparator2);
+    if (!extractedComparator) {
+      return false;
+    }
+    const [
+      ,
+      rangeOperator,
+      ,
+      rangeMajor,
+      rangeMinor,
+      rangePatch,
+      rangePreRelease
+    ] = extractedComparator;
+    const rangeAtom = {
+      operator: rangeOperator,
+      version: combineVersion(
+        rangeMajor,
+        rangeMinor,
+        rangePatch,
+        rangePreRelease
+      ),
+      major: rangeMajor,
+      minor: rangeMinor,
+      patch: rangePatch,
+      preRelease: rangePreRelease == null ? void 0 : rangePreRelease.split(".")
+    };
+    if (!compare(rangeAtom, versionAtom)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// eslint-disable-next-line no-undef
+const moduleMap = {};
+const moduleCache = Object.create(null);
+async function importShared(name, shareScope = 'default') {
+  return moduleCache[name]
+    ? new Promise((r) => r(moduleCache[name]))
+    : (await getSharedFromRuntime(name, shareScope)) || getSharedFromLocal(name)
+}
+async function getSharedFromRuntime(name, shareScope) {
+  let module = null;
+  if (globalThis?.__federation_shared__?.[shareScope]?.[name]) {
+    const versionObj = globalThis.__federation_shared__[shareScope][name];
+    const requiredVersion = moduleMap[name]?.requiredVersion;
+    const hasRequiredVersion = !!requiredVersion;
+    if (hasRequiredVersion) {
+      const versionKey = Object.keys(versionObj).find((version) =>
+        satisfy(version, requiredVersion)
+      );
+      if (versionKey) {
+        const versionValue = versionObj[versionKey];
+        module = await (await versionValue.get())();
+      } else {
+        console.log(
+          `provider support ${name}(${versionKey}) is not satisfied requiredVersion(\${moduleMap[name].requiredVersion})`
+        );
+      }
+    } else {
+      const versionKey = Object.keys(versionObj)[0];
+      const versionValue = versionObj[versionKey];
+      module = await (await versionValue.get())();
+    }
+  }
+  if (module) {
+    return flattenModule(module, name)
+  }
+}
+async function getSharedFromLocal(name) {
+  if (moduleMap[name]?.import) {
+    let module = await (await moduleMap[name].get())();
+    return flattenModule(module, name)
+  } else {
+    console.error(
+      `consumer config import=false,so cant use callback shared module`
+    );
+  }
+}
+function flattenModule(module, name) {
+  // use a shared module which export default a function will getting error 'TypeError: xxx is not a function'
+  if (typeof module.default === 'function') {
+    Object.keys(module).forEach((key) => {
+      if (key !== 'default') {
+        module.default[key] = module[key];
+      }
+    });
+    moduleCache[name] = module.default;
+    return module.default
+  }
+  if (module.default) module = Object.assign({}, module.default, module);
+  moduleCache[name] = module;
+  return module
+}
+
+export { importShared, getSharedFromLocal as importSharedLocal, getSharedFromRuntime as importSharedRuntime };

--- a/plugins.v2/storagecleanup/dist/v1.0.6/assets/_plugin-vue_export-helper-pcqpp-6-.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.6/assets/_plugin-vue_export-helper-pcqpp-6-.js
@@ -1,0 +1,9 @@
+const _export_sfc = (sfc, props) => {
+  const target = sfc.__vccOpts || sfc;
+  for (const [key, val] of props) {
+    target[key] = val;
+  }
+  return target;
+};
+
+export { _export_sfc as _ };

--- a/plugins.v2/storagecleanup/dist/v1.0.6/assets/index-BTdzl-4_.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.6/assets/index-BTdzl-4_.js
@@ -1,0 +1,44 @@
+import { importShared } from './__federation_fn_import-JrT3xvdd.js';
+import AppPage from './__federation_expose_AppPage-DU_5-3RL.js';
+
+true              &&(function polyfill() {
+  const relList = document.createElement("link").relList;
+  if (relList && relList.supports && relList.supports("modulepreload")) {
+    return;
+  }
+  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+    processPreload(link);
+  }
+  new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type !== "childList") {
+        continue;
+      }
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === "LINK" && node.rel === "modulepreload")
+          processPreload(node);
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  function getFetchOpts(link) {
+    const fetchOpts = {};
+    if (link.integrity) fetchOpts.integrity = link.integrity;
+    if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy;
+    if (link.crossOrigin === "use-credentials")
+      fetchOpts.credentials = "include";
+    else if (link.crossOrigin === "anonymous") fetchOpts.credentials = "omit";
+    else fetchOpts.credentials = "same-origin";
+    return fetchOpts;
+  }
+  function processPreload(link) {
+    if (link.ep)
+      return;
+    link.ep = true;
+    const fetchOpts = getFetchOpts(link);
+    fetch(link.href, fetchOpts);
+  }
+}());
+
+const {createApp} = await importShared('vue');
+
+createApp(AppPage).mount('#app');

--- a/plugins.v2/storagecleanup/dist/v1.0.6/assets/remoteEntry.js
+++ b/plugins.v2/storagecleanup/dist/v1.0.6/assets/remoteEntry.js
@@ -2,11 +2,11 @@ const currentImports = {};
       const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
       let moduleMap = {
 "./AppPage":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './AppPage');
-      return __federation_import('./__federation_expose_AppPage-WrNLRDkU.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-CIJaIXT7.css"], false, './AppPage');
+      return __federation_import('./__federation_expose_AppPage-DU_5-3RL.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Page":()=>{
-      dynamicLoadingCss(["__federation_expose_AppPage-7DnY9Ffm.css"], false, './Page');
-      return __federation_import('./__federation_expose_Page-DAUTopwb.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_AppPage-CIJaIXT7.css"], false, './Page');
+      return __federation_import('./__federation_expose_Page-DBYbf6GK.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Config":()=>{
       dynamicLoadingCss(["__federation_expose_Config-BHIxEI63.css"], false, './Config');
       return __federation_import('./__federation_expose_Config-BlunJQWM.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};
@@ -48,7 +48,7 @@ const currentImports = {};
          } else {
            href = cssPath;
          }
-         
+
           if (dontAppendStylesToHead) {
             const key = 'css__StorageCleanup__' + exposeItemName;
             window[key] = window[key] || [];

--- a/plugins.v2/storagecleanup/dist/v1.0.6/index.html
+++ b/plugins.v2/storagecleanup/dist/v1.0.6/index.html
@@ -1,0 +1,6 @@
+<script type="module" crossorigin src="/assets/index-BTdzl-4_.js"></script>
+<link rel="modulepreload" crossorigin href="/assets/__federation_fn_import-JrT3xvdd.js">
+<link rel="modulepreload" crossorigin href="/assets/_plugin-vue_export-helper-pcqpp-6-.js">
+<link rel="modulepreload" crossorigin href="/assets/__federation_expose_AppPage-DU_5-3RL.js">
+<link rel="stylesheet" crossorigin href="/assets/__federation_expose_AppPage-CIJaIXT7.css">
+<div id="app"></div>

--- a/plugins.v2/storagecleanup/package-lock.json
+++ b/plugins.v2/storagecleanup/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moviepilot-storage-cleanup-plugin",
-  "version": "1.0.7",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moviepilot-storage-cleanup-plugin",
-      "version": "1.0.7",
+      "version": "1.0.15",
       "dependencies": {
         "vue": "^3.5.13"
       },

--- a/plugins.v2/storagecleanup/package.json
+++ b/plugins.v2/storagecleanup/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moviepilot-storage-cleanup-plugin",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.15",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/plugins.v2/storagecleanup/src/components/AppPage.vue
+++ b/plugins.v2/storagecleanup/src/components/AppPage.vue
@@ -2,7 +2,9 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import {
   ACTIONS,
-  FILTERS,
+  FILTER_GROUPS,
+  createFilterState,
+  filterOptionCount,
   filterResources,
   formatBytes,
   formatGiB,
@@ -10,6 +12,7 @@ import {
   unwrapResponse,
 } from '../provider.js'
 import { refreshFeedback } from '../refresh-feedback.js'
+import Config from './Config.vue'
 
 const props = defineProps({
   api: { type: Object, default: () => ({}) },
@@ -32,7 +35,7 @@ const refreshing = ref(false)
 const refreshElapsed = ref(0)
 const error = ref('')
 const search = ref('')
-const activeFilter = ref('all')
+const filterState = ref(createFilterState())
 const safeOnly = ref(false)
 const descending = ref(true)
 const selected = ref([])
@@ -61,11 +64,12 @@ const recoveryTarget = ref(null)
 const recoveryAction = ref(null)
 const recoveryPhrase = ref('')
 const recovering = ref(false)
+const settingsOpen = ref(false)
 
 const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`)
 const resources = computed(() => snapshot.value.resources || [])
 const visible = computed(() => filterResources(resources.value, {
-  filter: activeFilter.value,
+  filters: filterState.value,
   search: search.value,
   safeOnly: safeOnly.value,
   descending: descending.value,
@@ -74,6 +78,9 @@ const selectedItems = computed(() => resources.value.filter(item => selected.val
 const selectedSize = computed(() => selectedItems.value.reduce((total, item) => total + Number(item.size || 0), 0))
 const executionEnabled = computed(() => Boolean(health.value.executionEnabled))
 const inventoryCurrent = computed(() => health.value.inventoryCurrent !== false)
+const onboardingRequired = computed(() => !loading.value && (
+  !snapshot.value.snapshotId || health.value.configReady === false
+))
 const unresolvedTransactions = computed(() => Number(snapshot.value.stats?.unresolvedTransactions || 0))
 const hrGap = computed(() => Math.max(
   0,
@@ -87,24 +94,34 @@ const hrUnassigned = computed(() => Number(
   snapshot.value.stats?.hrMissingUncovered ??
   0,
 ))
-const filters = computed(() => FILTERS.map(filter => ({
-  ...filter,
-  count: resources.value.filter(item => {
-    if (filter.id === 'all') return true
-    return filterResources([item], {
-      filter: filter.id,
-      search: '',
-      safeOnly: false,
-      descending: true,
-    }).length === 1
-  }).length,
+const filterGroups = computed(() => FILTER_GROUPS.map(group => ({
+  ...group,
+  options: group.options.map(option => ({
+    ...option,
+    count: filterOptionCount(resources.value, filterState.value, group.id, option.id),
+  })),
 })))
+const activeFilterChips = computed(() => {
+  const chips = []
+  for (const group of FILTER_GROUPS) {
+    const selected = group.id === 'flags'
+      ? filterState.value.flags
+      : [filterState.value[group.id]]
+    for (const option of group.options) {
+      if (option.id !== 'all' && selected.includes(option.id)) {
+        chips.push({ group: group.id, id: option.id, label: option.label })
+      }
+    }
+  }
+  return chips
+})
 const allVisibleSelected = computed(() => {
   const selectable = visible.value.filter(item => !item.protected)
   return selectable.length > 0 && selectable.every(item => selected.value.includes(item.id))
 })
 const currentAction = computed(() => planMode.value ? ACTIONS[planMode.value] : null)
 const planExpired = computed(() => Boolean(plan.value && Date.parse(plan.value.expiresAt) <= Date.now()))
+const allFiltersDefault = computed(() => activeFilterChips.value.length === 0)
 const refreshMessage = computed(() => {
   if (!refreshing.value) return ''
   return refreshFeedback(refreshElapsed.value)
@@ -129,6 +146,17 @@ function startRefreshTimer() {
 
 function payloadError(payload, fallback) {
   return payload?.error?.message || fallback
+}
+
+function requestErrorMessage(error, fallback) {
+  const response = error?.response || {}
+  const payload = response.data || error?.data || {}
+  const nested = payload?.error || {}
+  if (nested.code === 'inventory_stale' || response.status === 409 || error?.status === 409) {
+    health.value = { ...health.value, inventoryCurrent: false }
+    return '资源清单已过期，请点击“刷新资源清单”后再操作。浏览器重新加载不会重新核对 NAS。'
+  }
+  return nested.message || payload.message || error?.message || fallback
 }
 
 async function get(path) {
@@ -156,6 +184,9 @@ async function loadStatus() {
     if (!payload?.ok || !payload.snapshot) throw new Error(payloadError(payload, '无法读取清理台状态。'))
     health.value = payload.health || {}
     acceptSnapshot(payload.snapshot)
+    if (health.value.inventoryCurrent === false) {
+      selected.value = []
+    }
   } catch (err) {
     error.value = err?.message || '无法读取清理台状态。'
   } finally {
@@ -196,11 +227,49 @@ function toggleVisible() {
     : [...new Set([...selected.value, ...ids])]
 }
 
+function isFilterActive(group, option) {
+  if (group.id === 'flags') return filterState.value.flags.includes(option.id)
+  return filterState.value[group.id] === option.id
+}
+
+function selectFilter(group, option) {
+  if (group.id === 'flags') {
+    filterState.value = {
+      ...filterState.value,
+      flags: filterState.value.flags.includes(option.id)
+        ? filterState.value.flags.filter(id => id !== option.id)
+        : [...filterState.value.flags, option.id],
+    }
+    return
+  }
+  filterState.value = { ...filterState.value, [group.id]: option.id }
+}
+
+function clearFilters() {
+  filterState.value = createFilterState()
+}
+
+function clearFilterChip(chip) {
+  if (chip.group === 'flags') {
+    filterState.value = {
+      ...filterState.value,
+      flags: filterState.value.flags.filter(id => id !== chip.id),
+    }
+    return
+  }
+  filterState.value = { ...filterState.value, [chip.group]: 'all' }
+}
+
 async function requestPlan(mode, acknowledged = false) {
   planLoading.value = true
   planError.value = ''
   plan.value = null
   finalConfirmation.value = false
+  if (!inventoryCurrent.value) {
+    planError.value = '资源清单已过期，请点击“刷新资源清单”后再操作。浏览器重新加载不会重新核对 NAS。'
+    planLoading.value = false
+    return
+  }
   try {
     const payload = await post('/plan', {
       snapshotId: snapshot.value.snapshotId,
@@ -211,7 +280,7 @@ async function requestPlan(mode, acknowledged = false) {
     if (!payload?.ok || !payload.plan) throw new Error(payloadError(payload, '无法生成执行计划。'))
     plan.value = payload.plan
   } catch (err) {
-    planError.value = err?.message || '无法生成执行计划。'
+    planError.value = requestErrorMessage(err, '无法生成执行计划。')
   } finally {
     planLoading.value = false
   }
@@ -256,6 +325,13 @@ async function executePlan() {
     }
     executeResult.value = payload.result
     selected.value = []
+    if (plan.value?.mode === 'delete') {
+      const deletedIds = new Set(plan.value.resources.map(item => item.id))
+      snapshot.value = {
+        ...snapshot.value,
+        resources: snapshot.value.resources.filter(item => !deletedIds.has(item.id)),
+      }
+    }
     if (payload.result.snapshotRefreshPending) {
       health.value = { ...health.value, inventoryCurrent: false }
     } else {
@@ -335,6 +411,14 @@ function recoveryExpectedPhrase() {
     : recoveryTarget.value.finalizePhrase
 }
 
+function openSettings() {
+  settingsOpen.value = true
+}
+
+function closeSettings() {
+  settingsOpen.value = false
+}
+
 onMounted(loadStatus)
 onUnmounted(stopRefreshTimer)
 </script>
@@ -350,7 +434,7 @@ onUnmounted(stopRefreshTimer)
       <div :class="['status-card', { danger: error || !inventoryCurrent }]">
         <i>{{ error || !inventoryCurrent ? '!' : '✓' }}</i>
         <p>
-          <strong>{{ error || (executionEnabled ? '执行链路已连接' : '只读模式') }}</strong>
+          <strong>{{ error || (!inventoryCurrent ? '资源清单待刷新' : executionEnabled ? '执行链路已连接' : '只读模式') }}</strong>
           <span v-if="snapshot.generatedAt">更新于 {{ snapshot.generatedAt.slice(5, 16).replace('T', ' ') }}</span>
         </p>
       </div>
@@ -370,6 +454,14 @@ onUnmounted(stopRefreshTimer)
         实际占用 {{ descending ? '↓' : '↑' }}
       </button>
       <button
+        class="soft-button settings-button"
+        type="button"
+        aria-label="打开存储清理设置"
+        @click="openSettings"
+      >
+        设置
+      </button>
+      <button
         class="icon-button"
         type="button"
         :disabled="refreshing"
@@ -383,6 +475,24 @@ onUnmounted(stopRefreshTimer)
       <p v-if="refreshing" class="refresh-feedback" role="status" aria-live="polite">
         {{ refreshMessage }}
       </p>
+    </section>
+
+    <div v-if="!inventoryCurrent && !refreshing" class="notice critical stale-notice" role="status">
+      <i>!</i>
+      <p>
+        <strong>资源清单待刷新</strong>
+        <span>浏览器重新加载只重载页面，不会重新核对 NAS；刷新完成前已锁定清理动作。</span>
+      </p>
+      <button type="button" @click="refreshSnapshot">刷新资源清单</button>
+    </div>
+
+    <section v-if="onboardingRequired" class="onboarding-card">
+      <div>
+        <strong>{{ health.configReady === false ? '清理台还没有完成配置' : '还没有连接到清理后台' }}</strong>
+        <span v-if="error">{{ error }}</span>
+        <span v-else>请由 NAS 管理员先部署 PiNAS 清理台，并完成只读路径探测；插件不会自动登录或配置 NAS。</span>
+      </div>
+      <button type="button" @click="openSettings">打开设置</button>
     </section>
 
     <button
@@ -417,16 +527,47 @@ onUnmounted(stopRefreshTimer)
       <b>查看明细</b>
     </button>
 
-    <nav class="filters" aria-label="资源筛选">
-      <button
-        v-for="filter in filters"
-        :key="filter.id"
-        :class="{ active: activeFilter === filter.id }"
-        type="button"
-        @click="activeFilter = filter.id"
-      >
-        {{ filter.label }} <span>{{ filter.count }}</span>
-      </button>
+    <nav class="filter-panel" aria-label="资源筛选">
+      <div v-for="group in filterGroups" :key="group.id" class="filter-row">
+        <div class="filter-label">
+          {{ group.label }}
+          <small>{{ group.multi ? '可多选' : '单选' }}</small>
+        </div>
+        <div class="filter-options">
+          <button
+            v-for="option in group.options"
+            :key="option.id"
+            :class="['filter-option', { active: isFilterActive(group, option) }, { warning: option.tone === 'warning' }]"
+            :aria-pressed="isFilterActive(group, option)"
+            type="button"
+            @click="selectFilter(group, option)"
+          >
+            {{ option.label }} <span>{{ option.count }}</span>
+          </button>
+        </div>
+      </div>
+      <div class="filter-footer">
+        <div class="active-filter-chips" aria-live="polite">
+          <span v-if="allFiltersDefault" class="filter-caption">当前筛选：全部资源</span>
+          <template v-else>
+            <span class="filter-caption">当前筛选</span>
+            <button
+              v-for="chip in activeFilterChips"
+              :key="`${chip.group}-${chip.id}`"
+              class="active-filter-chip"
+              type="button"
+              @click="clearFilterChip(chip)"
+            >
+              {{ chip.label }} ×
+            </button>
+          </template>
+        </div>
+        <div class="filter-result-count">
+          <strong>{{ visible.length }}</strong> 条结果
+          <button v-if="!allFiltersDefault" type="button" @click="clearFilters">清除筛选</button>
+        </div>
+      </div>
+      <p class="filter-help">同组条件单选；不同组条件按 AND 组合。待处理 / 质量标签可以叠加。</p>
     </nav>
 
     <section class="resource-card">
@@ -466,6 +607,9 @@ onUnmounted(stopRefreshTimer)
         <div class="stack-cell library" data-label="媒体库">
           <strong>{{ item.librarySummary }}</strong>
           <span>{{ item.libraryDetail }}</span>
+          <span v-if="item.episodeStatus === 'incomplete'">
+            缺 {{ item.episodeMissing }} 集 · 已有 {{ item.episodeActual }} / 应有 {{ item.episodeExpected }}
+          </span>
         </div>
 
         <div class="seed-cell" data-label="做种与保护">
@@ -518,6 +662,8 @@ onUnmounted(stopRefreshTimer)
             v-for="(action, mode) in ACTIONS"
             :key="mode"
             :class="['action-level', { delete: mode === 'delete' }]"
+            :disabled="!inventoryCurrent || refreshing"
+            :title="!inventoryCurrent ? '请先刷新资源清单' : action.detail"
             type="button"
             @click="openPlan(mode)"
           >
@@ -593,7 +739,7 @@ onUnmounted(stopRefreshTimer)
           <i>盾</i>
           <p>
             <strong>{{ executionEnabled ? '执行前还需第二次确认' : '执行引擎未启用' }}</strong>
-            <span>最终执行前会重新读取 qB、路径、硬链接和保护状态。</span>
+            <span>最终执行前复核当前清单，执行器只回读所选资源的 qB、路径和硬链接。</span>
           </p>
         </div>
 
@@ -602,6 +748,9 @@ onUnmounted(stopRefreshTimer)
           <span>
             停止 {{ executeResult.qbStopped }} · 退出 {{ executeResult.qbRemoved }} ·
             删除文件入口 {{ executeResult.filesDeleted }} · 清理索引 {{ executeResult.moviepilotIndexesDeleted }}
+          </span>
+          <span v-if="executeResult.snapshotRefreshPending">
+            {{ planMode === 'delete' ? '已从当前列表移除，请刷新资源清单后继续操作。' : '操作已完成，请刷新资源清单后继续操作。' }}
           </span>
           <button type="button" @click="closePlan">完成</button>
         </div>
@@ -616,7 +765,7 @@ onUnmounted(stopRefreshTimer)
               :disabled="executing || planExpired"
               @click="executePlan"
             >
-              {{ executing ? '正在二次复核…' : `确认${currentAction?.title}` }}
+              {{ executing ? '正在定向复核…' : `确认${currentAction?.title}` }}
             </button>
           </div>
         </div>
@@ -665,6 +814,24 @@ onUnmounted(stopRefreshTimer)
               {{ recovering ? '处理中…' : '执行恢复' }}
             </button>
           </div>
+        </section>
+      </div>
+
+      <div v-if="settingsOpen" class="modal-backdrop" @click.self="closeSettings">
+        <section
+          class="modal settings-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="storage-cleanup-settings-title"
+        >
+          <header>
+            <div>
+              <span>清理台配置</span>
+              <h2 id="storage-cleanup-settings-title">设置</h2>
+            </div>
+            <button type="button" aria-label="关闭设置" @click="closeSettings">×</button>
+          </header>
+          <Config :api="props.api" :plugin-id="props.pluginId" />
         </section>
       </div>
     </Teleport>
@@ -765,6 +932,11 @@ button { color: inherit; }
   cursor: pointer;
 }
 .soft-button { padding: 0 14px; }
+.settings-button { border-color: rgba(var(--v-theme-primary, 59, 130, 246), .35); color: var(--primary); font-weight: 750; }
+.onboarding-card { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 16px 18px; border: 1px solid rgba(var(--v-theme-primary, 59, 130, 246), .22); border-radius: 12px; background: var(--primary-soft); }
+.onboarding-card div { display: grid; gap: 4px; }
+.onboarding-card span { color: var(--muted); font-size: 13px; line-height: 1.5; }
+.onboarding-card button { flex: 0 0 auto; padding: 9px 14px; border: 1px solid rgba(var(--v-theme-primary, 59, 130, 246), .35); border-radius: 8px; background: transparent; color: var(--primary); cursor: pointer; font-weight: 700; }
 .icon-button { width: 42px; font-size: 20px; }
 .refresh-feedback {
   flex: 0 0 100%;
@@ -790,17 +962,85 @@ button { color: inherit; }
 .notice b { color: var(--warn); font-size: 13px; }
 .notice.critical { border-color: rgba(196, 75, 71, .25); background: rgba(196, 75, 71, .08); }
 .notice.critical b { color: var(--danger); }
-.filters { display: flex; gap: 6px; margin-bottom: 12px; }
-.filters button {
-  padding: 8px 13px;
-  border: 1px solid transparent;
-  border-radius: 10px;
-  background: transparent;
+.stale-notice { cursor: default; }
+.stale-notice button { flex: 0 0 auto; padding: 8px 12px; border: 1px solid rgba(196, 75, 71, .28); border-radius: 9px; background: var(--surface); color: var(--danger); font-weight: 750; cursor: pointer; }
+.filter-panel {
+  display: grid;
+  gap: 0;
+  margin-bottom: 12px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--surface) 88%, var(--primary-soft));
+}
+.filter-row {
+  display: grid;
+  grid-template-columns: 126px minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line);
+}
+.filter-label {
+  padding-top: 8px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+.filter-label small {
+  display: block;
+  margin-top: 3px;
+  font-size: 10px;
+  font-weight: 500;
+  opacity: .8;
+}
+.filter-options { display: flex; flex-wrap: wrap; gap: 7px; }
+.filter-option {
+  min-height: 34px;
+  padding: 6px 11px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface);
   color: var(--muted);
   cursor: pointer;
+  transition: .15s ease;
 }
-.filters button.active { border-color: var(--line); background: var(--surface); color: var(--ink); font-weight: 750; box-shadow: 0 4px 12px rgba(15, 23, 42, .04); }
-.filters span { margin-left: 5px; padding: 2px 6px; border-radius: 99px; background: rgba(100, 116, 139, .10); font-size: 11px; }
+.filter-option:hover { border-color: var(--primary); color: var(--ink); }
+.filter-option.active {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+  color: var(--primary);
+  font-weight: 750;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, .04);
+}
+.filter-option.warning.active { border-color: var(--warn); color: var(--warn); background: rgba(184, 107, 17, .08); }
+.filter-option span {
+  display: inline-block;
+  min-width: 20px;
+  margin-left: 5px;
+  padding: 2px 6px;
+  border-radius: 99px;
+  background: rgba(100, 116, 139, .10);
+  font-size: 11px;
+  text-align: center;
+}
+.filter-option.active span { background: color-mix(in srgb, currentColor 14%, transparent); }
+.filter-footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 42px; }
+.active-filter-chips { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; }
+.filter-caption { color: var(--muted); font-size: 11px; }
+.active-filter-chip {
+  padding: 4px 9px;
+  border: 0;
+  border-radius: 99px;
+  background: var(--primary-soft);
+  color: var(--primary);
+  font-size: 11px;
+  cursor: pointer;
+}
+.filter-result-count { color: var(--muted); font-size: 12px; white-space: nowrap; }
+.filter-result-count strong { color: var(--ink); font-size: 17px; }
+.filter-result-count button { margin-left: 8px; padding: 0; border: 0; background: transparent; color: var(--primary); font-size: 11px; cursor: pointer; }
+.filter-help { margin: 0; padding: 0 0 10px; color: var(--muted); font-size: 10px; }
 .resource-card { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--surface); }
 .table-head, .resource-row {
   display: grid;
@@ -874,13 +1114,14 @@ button { color: inherit; }
 .action-buttons { display: contents; }
 .action-level { display: grid; flex: 1; gap: 3px; padding: 10px 14px; border: 1px solid rgba(255, 255, 255, .17); border-radius: 11px; background: rgba(255, 255, 255, .06); color: white; text-align: left; cursor: pointer; }
 .action-level.delete { border-color: rgba(255, 142, 136, .32); background: rgba(196, 75, 71, .28); }
+.action-level:disabled { cursor: not-allowed; opacity: .45; }
 .modal-backdrop {
   position: fixed;
   z-index: 100;
   inset: 0;
   display: grid;
   place-items: center;
-  padding: 28px;
+  padding: 28px 28px 28px calc(28px + 260px);
   background: rgba(15, 23, 42, .55);
   backdrop-filter: blur(6px);
 }
@@ -931,6 +1172,8 @@ button { color: inherit; }
 .error-text { color: var(--danger); font-size: 13px; }
 .execution-result { color: var(--good); background: rgba(22, 131, 107, .08); }
 .compact-modal { width: min(650px, 90vw); }
+.settings-modal { width: min(980px, 94vw); max-height: calc(100dvh - 56px); padding: 20px; }
+.settings-modal :deep(.config-page) { max-width: none; padding: 0; }
 .gap-row, .recovery-row { display: flex; align-items: center; gap: 8px; padding: 11px 4px; border-bottom: 1px solid var(--line); }
 .gap-row p, .recovery-row p { flex: 1; }
 .gap-row span, .recovery-row span { color: var(--muted); font-size: 11px; }
@@ -944,6 +1187,7 @@ button { color: inherit; }
   }
 }
 @media (max-width: 760px) {
+  .modal-backdrop { padding: 16px; }
   .cleanup-app {
     min-width: 0;
     overflow-x: clip;
@@ -969,7 +1213,7 @@ button { color: inherit; }
   }
   .toolbar {
     display: grid;
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
     gap: 8px;
   }
   .search {
@@ -990,18 +1234,18 @@ button { color: inherit; }
   .notice p strong { font-size: 14px; }
   .notice p span { font-size: 11px; }
   .notice b { display: none; }
-  .filters {
-    overflow-x: auto;
+  .filter-panel {
     width: calc(100vw - 24px);
-    padding: 0 0 4px;
-    scrollbar-width: none;
+    padding: 0 10px;
   }
-  .filters::-webkit-scrollbar { display: none; }
-  .filters button {
-    flex: 0 0 auto;
-    padding: 8px 11px;
-    white-space: nowrap;
-  }
+  .filter-row { display: block; padding: 10px 0; }
+  .filter-label { padding: 0 0 7px; }
+  .filter-options { flex-wrap: nowrap; overflow-x: auto; padding-bottom: 2px; scrollbar-width: none; }
+  .filter-options::-webkit-scrollbar { display: none; }
+  .filter-option { flex: 0 0 auto; white-space: nowrap; }
+  .filter-footer { align-items: flex-start; flex-direction: column; gap: 6px; padding: 7px 0; }
+  .filter-result-count { width: 100%; }
+  .filter-help { line-height: 1.45; }
   .resource-card {
     overflow: visible;
     border: 0;

--- a/plugins.v2/storagecleanup/src/components/Config.vue
+++ b/plugins.v2/storagecleanup/src/components/Config.vue
@@ -8,9 +8,8 @@ const props = defineProps({
 
 const form = reactive({
   version: 1,
-  ssh_host: '',
   qb_url: '',
-  jellyfin_db: '',
+  media_index_db: '',
   moviepilot_db: '',
   qb_backup: '',
   execution_backup: '',
@@ -22,6 +21,10 @@ const saving = ref(false)
 const error = ref('')
 const message = ref('')
 const probe = ref(null)
+const discovery = ref(null)
+const discovering = ref(false)
+const discoveryError = ref('')
+const advancedOpen = ref(false)
 
 const pluginBase = computed(() => `plugin/${props.pluginId || 'StorageCleanup'}`)
 
@@ -35,6 +38,7 @@ function unwrap(response) {
 function applyConfig(config) {
   Object.assign(form, {
     ...config,
+    media_index_db: config.media_index_db || config.jellyfin_db || '',
     allowed_roots_text: (config.allowed_roots || []).join('\n'),
     quarantine_roots_text: Object.entries(config.quarantine_roots || {})
       .map(([volume, target]) => `${volume}=${target}`)
@@ -60,9 +64,8 @@ function buildConfig() {
   }
   return {
     version: 1,
-    ssh_host: form.ssh_host,
     qb_url: form.qb_url,
-    jellyfin_db: form.jellyfin_db,
+    media_index_db: form.media_index_db,
     moviepilot_db: form.moviepilot_db,
     qb_backup: form.qb_backup,
     execution_backup: form.execution_backup,
@@ -80,10 +83,59 @@ async function load() {
     if (!payload?.ok || !payload.config) throw new Error(payload?.error?.message || '无法读取清理台配置。')
     applyConfig(payload.config)
     probe.value = payload.probe || null
+    if (!probe.value?.ok) void discover()
   } catch (err) {
     error.value = err?.message || '无法读取清理台配置。'
   } finally {
     loading.value = false
+  }
+}
+
+async function discover() {
+  if (discovering.value) return
+  discovering.value = true
+  discoveryError.value = ''
+  try {
+    if (!props.api.get) throw new Error('MoviePilot 没有提供插件 API。')
+    const payload = unwrap(await props.api.get(`${pluginBase.value}/discover`))
+    if (!payload?.ok || !payload.config) {
+      throw new Error(payload?.error?.message || '自动发现失败。')
+    }
+    discovery.value = payload
+    if ((payload.checks || []).some(item => item.ambiguous || (!item.found && !item.optional && !item.willCreate))) {
+      advancedOpen.value = true
+    }
+  } catch (err) {
+    discoveryError.value = err?.message || '自动发现失败。'
+    advancedOpen.value = true
+  } finally {
+    discovering.value = false
+  }
+}
+
+async function applyDiscovery() {
+  if (!discovery.value?.config || !discovery.value?.ready || saving.value) return
+  saving.value = true
+  error.value = ''
+  message.value = ''
+  try {
+    const payload = unwrap(await props.api.post(`${pluginBase.value}/config`, {
+      config: discovery.value.config,
+    }))
+    if (!payload?.ok || !payload.config) {
+      throw new Error(payload?.error?.message || '自动配置保存失败。')
+    }
+    applyConfig(payload.config)
+    probe.value = payload.probe || null
+    message.value = probe.value?.ok
+      ? '自动识别完成，路径探测通过；请刷新资源清单。'
+      : '已应用自动识别结果，但仍有项目未就绪；清理操作保持锁定。'
+  } catch (err) {
+    const payload = err?.response?.data || err?.data
+    probe.value = payload?.probe || probe.value
+    error.value = err?.message || payload?.error?.message || '自动配置保存失败。'
+  } finally {
+    saving.value = false
   }
 }
 
@@ -116,29 +168,74 @@ onMounted(load)
   <section class="config-page">
     <header>
       <h2>存储清理设置</h2>
-      <p>这里只保存 NAS 拓扑和路径，不会写入 Cookie、passkey 或控制令牌。保存后先做只读探测，未通过探测时清理操作保持锁定。</p>
+      <p>一般无需填写，先点“自动识别”；识别失败再用手动配置。</p>
     </header>
 
     <div v-if="loading" class="notice">正在读取配置…</div>
-    <div v-else class="form-grid">
-      <label>SSH 目标<input v-model="form.ssh_host" autocomplete="off" /></label>
-      <label>qBittorrent 地址<input v-model="form.qb_url" autocomplete="off" /></label>
-      <label>Jellyfin 数据库<input v-model="form.jellyfin_db" autocomplete="off" /></label>
-      <label>MoviePilot 数据库<input v-model="form.moviepilot_db" autocomplete="off" /></label>
-      <label>qB 种子备份目录<input v-model="form.qb_backup" autocomplete="off" /></label>
-      <label>清理事务备份目录<input v-model="form.execution_backup" autocomplete="off" /></label>
-      <label class="wide">允许扫描/清理的根目录（每行一个）<textarea v-model="form.allowed_roots_text" rows="6" /></label>
-      <label class="wide">隔离目录映射（每行：卷根目录=隔离目录）<textarea v-model="form.quarantine_roots_text" rows="4" /></label>
-    </div>
+    <section v-else class="discovery-card">
+      <div class="discovery-heading">
+        <div>
+          <strong>自动识别</strong>
+          <span>读取 MoviePilot、qB 和媒体目录；媒体库索引可留空。候选不唯一时不会自动猜。</span>
+        </div>
+        <div class="discovery-actions">
+          <button type="button" :disabled="discovering || saving" @click="discover">
+            {{ discovering ? '识别中…' : '自动识别' }}
+          </button>
+          <button v-if="!advancedOpen" class="secondary" type="button" :disabled="saving" @click="advancedOpen = true">
+            手动配置
+          </button>
+        </div>
+      </div>
+      <div v-if="discovery" class="discovery-results">
+        <div v-for="item in discovery.checks || []" :key="item.key" class="discovery-row">
+          <div>
+            <span>{{ item.label }}</span>
+            <small v-if="item.ambiguous">候选：{{ (item.candidates || []).join('；') }}</small>
+          </div>
+          <b :class="item.ambiguous ? 'missing' : item.found || item.willCreate ? 'found' : item.optional ? 'optional' : 'missing'">{{ item.ambiguous ? '发现多个候选，需手动选择' : item.found ? '已找到' : item.willCreate ? '将自动创建' : item.optional ? '未配置（可选）' : '需管理员处理' }}</b>
+        </div>
+        <button
+          class="apply-discovery"
+          type="button"
+          :disabled="saving || !discovery.ready"
+          @click="applyDiscovery"
+        >
+          {{ saving ? '应用中…' : '应用识别结果并验证' }}
+        </button>
+      </div>
+      <div v-if="discoveryError" class="discovery-error">
+        <span>{{ discoveryError }} 请改用手动配置。</span>
+        <button type="button" :disabled="saving" @click="advancedOpen = true">打开手动配置</button>
+      </div>
+    </section>
+    <details v-if="!loading" class="advanced-settings" :open="advancedOpen" @toggle="advancedOpen = $event.target.open">
+      <summary>手动配置（自动识别失败时使用）</summary>
+      <p>从 NAS 文件管理器复制路径；必须是清理台服务能访问到的路径。媒体库索引可以留空。</p>
+      <div class="form-grid">
+        <label>qBittorrent 地址<input v-model="form.qb_url" autocomplete="off" placeholder="例：http://127.0.0.1:8080" /></label>
+        <label>MoviePilot 数据库<input v-model="form.moviepilot_db" autocomplete="off" placeholder="MoviePilot 容器内 user.db 路径" /></label>
+        <label>媒体库索引（可选）<input v-model="form.media_index_db" autocomplete="off" placeholder="Jellyfin / Emby 数据库路径，可留空" /></label>
+        <label>qB 种子备份目录<input v-model="form.qb_backup" autocomplete="off" placeholder="qB 备份目录" /></label>
+        <label>清理事务备份目录<input v-model="form.execution_backup" autocomplete="off" placeholder="清理台可写的备份目录" /></label>
+        <label class="wide">允许扫描/清理的根目录（每行一个）<textarea v-model="form.allowed_roots_text" rows="5" placeholder="下载完成目录、电影目录、电视剧目录" /></label>
+        <label class="wide">隔离目录映射（每行：卷根目录=隔离目录）<textarea v-model="form.quarantine_roots_text" rows="3" placeholder="例如：/mnt/data=/mnt/data/.storage-cleanup-quarantine" /></label>
+      </div>
+      <button class="save" :disabled="loading || saving" @click="save">{{ saving ? '保存中…' : '保存手动配置并探测' }}</button>
+    </details>
 
     <div v-if="error" class="error">{{ error }}</div>
     <div v-if="message" class="success">{{ message }}</div>
     <div v-if="probe" class="probe">
       <strong>{{ probe.ok ? '只读探测通过' : '只读探测未通过' }}</strong>
-      <span v-if="probe.missing?.length">未找到：{{ probe.missing.join('、') }}</span>
-      <span v-for="item in probe.problems || []" :key="item">{{ item }}</span>
+      <span v-if="probe.missing?.length">还有 {{ probe.missing.length }} 项路径未找到，请展开管理员配置查看。</span>
+      <span v-if="probe.problems?.length">有 {{ probe.problems.length }} 项安全校验未通过，请展开管理员配置查看。</span>
+      <details v-if="probe.missing?.length || probe.problems?.length" class="probe-details">
+        <summary>查看管理员诊断</summary>
+        <span v-for="item in probe.missing || []" :key="`missing-${item}`">未找到：{{ item }}</span>
+        <span v-for="item in probe.problems || []" :key="item">{{ item }}</span>
+      </details>
     </div>
-    <button class="save" :disabled="loading || saving" @click="save">{{ saving ? '保存中…' : '保存并探测' }}</button>
   </section>
 </template>
 
@@ -147,6 +244,28 @@ onMounted(load)
 header { display: grid; gap: 6px; }
 h2 { margin: 0; }
 p { margin: 0; opacity: .72; line-height: 1.6; }
+.discovery-card { display: grid; gap: 12px; padding: 14px 16px; border: 1px solid rgba(var(--v-theme-primary, 59, 130, 246), .24); border-radius: 10px; background: rgba(var(--v-theme-primary, 59, 130, 246), .06); }
+.discovery-heading { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.discovery-heading > div { display: grid; gap: 4px; }
+.discovery-heading span { opacity: .72; line-height: 1.5; }
+.discovery-actions { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+.discovery-heading button, .apply-discovery { padding: 9px 14px; border: 1px solid rgba(var(--v-theme-primary, 59, 130, 246), .35); border-radius: 8px; cursor: pointer; background: transparent; color: inherit; font: inherit; font-weight: 700; }
+.discovery-actions .secondary { opacity: .78; }
+.discovery-heading button:disabled, .apply-discovery:disabled { opacity: .5; cursor: default; }
+.discovery-results { display: grid; gap: 7px; }
+.discovery-row { display: flex; justify-content: space-between; gap: 12px; padding: 7px 0; border-top: 1px solid rgba(var(--v-border-color), .16); }
+.discovery-row > div { display: grid; gap: 4px; min-width: 0; }
+.discovery-row small { opacity: .68; overflow-wrap: anywhere; line-height: 1.45; }
+.discovery-row b { font-size: .9em; }
+.discovery-row .found { color: #087443; }
+.discovery-row .optional { color: #6b7280; }
+.discovery-row .missing { color: #b86b11; }
+.apply-discovery { justify-self: start; background: rgb(var(--v-theme-primary)); color: rgb(var(--v-theme-on-primary)); }
+.discovery-error { display: flex; align-items: center; justify-content: space-between; gap: 12px; color: #b42318; line-height: 1.5; }
+.discovery-error button { border: 0; padding: 0; cursor: pointer; background: transparent; color: inherit; font: inherit; font-weight: 700; text-decoration: underline; }
+.advanced-settings { display: grid; gap: 12px; padding: 2px 0; }
+.advanced-settings summary { cursor: pointer; font-weight: 700; }
+.advanced-settings > p { padding-left: 2px; }
 .form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
 label { display: grid; gap: 7px; font-weight: 600; }
 input, textarea { width: 100%; box-sizing: border-box; padding: 9px 11px; border: 1px solid rgba(var(--v-border-color), .35); border-radius: 8px; background: transparent; color: inherit; font: inherit; font-weight: 400; }
@@ -157,7 +276,9 @@ textarea { resize: vertical; font-family: ui-monospace, SFMono-Regular, Menlo, m
 .error { color: #b42318; background: rgba(180, 35, 24, .1); }
 .success { color: #087443; background: rgba(8, 116, 67, .1); }
 .probe { background: rgba(32, 106, 255, .08); }
+.probe-details { display: grid; gap: 5px; margin-top: 4px; }
+.probe-details summary { cursor: pointer; font-weight: 700; }
 .save { justify-self: start; padding: 10px 18px; border: 0; border-radius: 8px; cursor: pointer; background: rgb(var(--v-theme-primary)); color: rgb(var(--v-theme-on-primary)); }
 .save:disabled { opacity: .5; cursor: default; }
-@media (max-width: 760px) { .config-page { padding: 16px; } .form-grid { grid-template-columns: 1fr; } .wide { grid-column: auto; } }
+@media (max-width: 760px) { .config-page { padding: 16px; } .form-grid { grid-template-columns: 1fr; } .wide { grid-column: auto; } .discovery-heading { align-items: stretch; flex-direction: column; } .discovery-actions { justify-content: flex-start; } }
 </style>

--- a/plugins.v2/storagecleanup/src/provider.js
+++ b/plugins.v2/storagecleanup/src/provider.js
@@ -1,11 +1,61 @@
+export const FILTER_GROUPS = [
+  {
+    id: 'type',
+    label: '资源类型',
+    multi: false,
+    options: [
+      { id: 'all', label: '全部资源' },
+      { id: 'movie', label: '电影' },
+      { id: 'tv', label: '电视剧' },
+    ],
+  },
+  {
+    id: 'library',
+    label: '媒体库状态',
+    multi: false,
+    options: [
+      { id: 'all', label: '全部' },
+      { id: 'imported', label: '已入库' },
+      { id: 'not-imported', label: '未入库' },
+    ],
+  },
+  {
+    id: 'seed',
+    label: '做种约束',
+    multi: false,
+    options: [
+      { id: 'all', label: '全部' },
+      { id: 'hr', label: 'H&R 保护中', tone: 'warning' },
+      { id: 'none', label: '无做种要求' },
+    ],
+  },
+  {
+    id: 'flags',
+    label: '待处理 / 质量',
+    multi: true,
+    options: [
+      { id: 'incomplete', label: '剧集不完整', tone: 'warning' },
+      { id: 'name-pending', label: '名称待确认' },
+    ],
+  },
+]
+
+// Kept as a flat export for callers that only need a legacy filter label.
+// The UI uses FILTER_GROUPS so each dimension can be combined with AND logic.
 export const FILTERS = [
   { id: 'all', label: '全部资源' },
+  { id: 'movie', label: '电影' },
+  { id: 'tv', label: '电视剧' },
+  { id: 'tv-incomplete', label: '不完整电视剧' },
   { id: 'library', label: '媒体库已入库' },
   { id: 'hr', label: 'H&R 保护中' },
-  { id: 'brush', label: '刷流任务' },
   { id: 'review', label: '无做种限制' },
   { id: 'names', label: '名称待核' },
 ]
+
+export function createFilterState() {
+  return { type: 'all', library: 'all', seed: 'all', flags: [] }
+}
 
 export const ACTIONS = {
   pause: {
@@ -71,25 +121,92 @@ export function createLatestPlanApi(api) {
   }
 }
 
+export function mediaType(item) {
+  const type = String(item?.type || '').trim().toLowerCase()
+  if (type === '电影' || type === 'movie') return 'movie'
+  if (type === '电视剧' || type === 'tv' || type === 'series') return 'tv'
+
+  // Keep older snapshots usable when the explicit type field is absent.
+  const edition = String(item?.edition || '').trim().toLowerCase()
+  if (edition === '电影' || edition.startsWith('电影 ·')) return 'movie'
+  return ''
+}
+
+export function isIncompleteTv(item) {
+  return mediaType(item) === 'tv' && item?.episodeIncomplete === true
+}
+
 export function matchesFilter(item, filter) {
   if (filter === 'all') return true
+  if (filter === 'movie') return mediaType(item) === 'movie'
+  if (filter === 'tv') return mediaType(item) === 'tv'
+  if (filter === 'tv-incomplete') return isIncompleteTv(item)
   if (filter === 'library') return Boolean(item.library)
   if (filter === 'hr') return Boolean(item.hr || item.hrPending)
-  if (filter === 'brush') return Boolean(item.brush)
   if (filter === 'review') return !item.protected && item.qbSummary === '无 qB 任务'
   return item.metadataVerified === false
+}
+
+function matchesFlag(item, flag) {
+  if (flag === 'incomplete') return isIncompleteTv(item)
+  if (flag === 'name-pending') return item.metadataVerified === false
+  return false
+}
+
+export function matchesFilterState(item, filters = createFilterState()) {
+  const state = filters || createFilterState()
+  const type = state.type || 'all'
+  const library = state.library || 'all'
+  const seed = state.seed || 'all'
+  const flags = Array.isArray(state.flags) ? state.flags : []
+
+  if (type !== 'all' && mediaType(item) !== type) return false
+  if (library === 'imported' && !item.library) return false
+  if (library === 'not-imported' && item.library) return false
+  if (seed === 'hr' && !matchesFilter(item, 'hr')) return false
+  if (seed === 'none' && !matchesFilter(item, 'review')) return false
+  return flags.every(flag => matchesFlag(item, flag))
+}
+
+function legacyFilterState(filter) {
+  const state = createFilterState()
+  if (filter === 'movie' || filter === 'tv') state.type = filter
+  else if (filter === 'tv-incomplete') state.flags = ['incomplete']
+  else if (filter === 'library') state.library = 'imported'
+  else if (filter === 'hr') state.seed = 'hr'
+  else if (filter === 'review') state.seed = 'none'
+  else if (filter === 'names') state.flags = ['name-pending']
+  return state
+}
+
+export function filterOptionCount(resources, filters, groupId, optionId) {
+  const state = {
+    ...createFilterState(),
+    ...(filters || {}),
+    flags: Array.isArray(filters?.flags) ? [...filters.flags] : [],
+  }
+  if (groupId === 'type') state.type = optionId
+  if (groupId === 'library') state.library = optionId
+  if (groupId === 'seed') state.seed = optionId
+  if (groupId === 'flags') {
+    state.flags = optionId === 'all'
+      ? []
+      : [...new Set([...state.flags, optionId])]
+  }
+  return (resources || []).filter(item => matchesFilterState(item, state)).length
 }
 
 export function isDirectlyCleanable(item) {
   return !item.protected && item.qbSummary === '无 qB 任务'
 }
 
-export function filterResources(resources, { filter, search, safeOnly, descending }) {
+export function filterResources(resources, { filter, filters, search, safeOnly, descending }) {
   const query = String(search || '').trim().toLowerCase()
+  const state = filters || legacyFilterState(filter)
   return [...(resources || [])]
     .filter(item => {
       const text = `${item.title || ''} ${item.englishTitle || ''} ${item.edition || ''} ${item.siteSummary || ''}`.toLowerCase()
-      return matchesFilter(item, filter) &&
+      return matchesFilterState(item, state) &&
         (!safeOnly || isDirectlyCleanable(item)) &&
         (!query || text.includes(query))
     })

--- a/plugins.v2/storagecleanup/src/refresh-feedback.js
+++ b/plugins.v2/storagecleanup/src/refresh-feedback.js
@@ -2,7 +2,7 @@ export function refreshFeedback(elapsedSeconds) {
   const elapsed = Math.max(0, Number(elapsedSeconds) || 0)
   if (elapsed < 5) return '正在读取 NAS 只读快照…'
   if (elapsed < 30) {
-    return `正在核对 qB、Jellyfin 与 H&R（已等待 ${elapsed} 秒）`
+    return `正在核对媒体目录、qB 与 H&R（已等待 ${elapsed} 秒）`
   }
   return `远端 H&R 探测可能需要数分钟（已等待 ${elapsed} 秒），请保持页面打开。`
 }

--- a/plugins.v2/storagecleanup/tests/mobile-shell.html
+++ b/plugins.v2/storagecleanup/tests/mobile-shell.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8">
+    <title>StorageCleanup mobile shell</title>
+    <style>
+      html, body {
+        display: grid;
+        min-height: 100%;
+        margin: 0;
+        place-items: center;
+        background: #dbe3ef;
+      }
+      iframe {
+        width: 390px;
+        height: 844px;
+        border: 0;
+        border-radius: 28px;
+        background: white;
+        box-shadow: 0 24px 70px rgba(15, 23, 42, .25);
+      }
+    </style>
+  </head>
+  <body>
+    <iframe
+      title="StorageCleanup mobile viewport"
+      src="/tests/viewport-harness.html"
+    ></iframe>
+  </body>
+</html>

--- a/plugins.v2/storagecleanup/tests/provider.test.mjs
+++ b/plugins.v2/storagecleanup/tests/provider.test.mjs
@@ -3,9 +3,16 @@ import assert from 'node:assert/strict'
 
 import {
   createLatestPlanApi,
+  createFilterState,
+  FILTER_GROUPS,
   filterResources,
+  filterOptionCount,
+  FILTERS,
   formatGiB,
+  isIncompleteTv,
+  mediaType,
   matchesFilter,
+  matchesFilterState,
   unwrapResponse,
 } from '../src/provider.js'
 
@@ -29,6 +36,11 @@ test('review filter means no seeding task or protection restriction', () => {
   assert.equal(matchesFilter(resources[1], 'review'), false)
 })
 
+test('generic filter list does not expose brush-flow tasks', () => {
+  assert.equal(FILTERS.some(filter => filter.id === 'brush'), false)
+  assert.equal(FILTERS.some(filter => filter.label === '刷流任务'), false)
+})
+
 test('resource filtering supports bilingual search and size order', () => {
   assert.deepEqual(
     filterResources(resources, { filter: 'all', search: 'Back to', safeOnly: false, descending: true }).map(item => item.id),
@@ -38,6 +50,52 @@ test('resource filtering supports bilingual search and size order', () => {
     filterResources(resources, { filter: 'all', search: '', safeOnly: false, descending: true }).map(item => item.id),
     ['safe', 'hr'],
   )
+})
+
+test('media type filters include all TV and retain an incomplete-TV legacy shortcut', () => {
+  const typedResources = [
+    { id: 'movie', title: '电影', type: '电影', library: false, size: 30 },
+    { id: 'tv', title: '完整剧集', type: '电视剧', library: true, edition: 'S01 · 8 集', size: 20 },
+    { id: 'tv-incomplete', title: '缺集剧集', type: '电视剧', library: true, edition: 'S01 · 6 集', episodeExpected: 8, episodeActual: 6, episodeIncomplete: true, size: 10 },
+    { id: 'tv-unimported', title: '未入库剧集', type: '电视剧', library: false, edition: 'S01 · 未入库', size: 5 },
+  ]
+
+  assert.equal(mediaType(typedResources[0]), 'movie')
+  assert.equal(mediaType(typedResources[1]), 'tv')
+  assert.equal(isIncompleteTv(typedResources[2]), true)
+  assert.equal(isIncompleteTv(typedResources[3]), false)
+  assert.equal(isIncompleteTv(typedResources[0]), false)
+  assert.deepEqual(
+    filterResources(typedResources, { filter: 'movie', search: '', safeOnly: false, descending: true }).map(item => item.id),
+    ['movie'],
+  )
+  assert.deepEqual(
+    filterResources(typedResources, { filter: 'tv', search: '', safeOnly: false, descending: true }).map(item => item.id),
+    ['tv', 'tv-incomplete', 'tv-unimported'],
+  )
+  assert.deepEqual(
+    filterResources(typedResources, { filter: 'tv-incomplete', search: '', safeOnly: false, descending: true }).map(item => item.id),
+    ['tv-incomplete'],
+  )
+})
+
+test('grouped filters combine with AND and quality flags can stack', () => {
+  const typedResources = [
+    { id: 'movie', type: '电影', library: true, protected: false, qbSummary: '无 qB 任务', size: 30 },
+    { id: 'complete-tv', type: '电视剧', library: true, metadataVerified: true, protected: false, qbSummary: '1 个 qB 任务', size: 20 },
+    { id: 'incomplete-tv', type: '电视剧', library: false, episodeIncomplete: true, metadataVerified: false, protected: true, hr: true, qbSummary: '1 个 qB 任务', size: 10 },
+  ]
+  const state = { ...createFilterState(), type: 'tv', library: 'not-imported', flags: ['incomplete', 'name-pending'] }
+
+  assert.equal(matchesFilterState(typedResources[2], state), true)
+  assert.equal(matchesFilterState(typedResources[1], state), false)
+  assert.deepEqual(
+    filterResources(typedResources, { filters: state, search: '', safeOnly: false, descending: true }).map(item => item.id),
+    ['incomplete-tv'],
+  )
+  assert.equal(filterOptionCount(typedResources, createFilterState(), 'type', 'tv'), 2)
+  assert.equal(filterOptionCount(typedResources, { ...createFilterState(), type: 'tv' }, 'library', 'not-imported'), 1)
+  assert.equal(FILTER_GROUPS.find(group => group.id === 'flags')?.multi, true)
 })
 
 test('MoviePilot response wrapper is normalized', () => {

--- a/plugins.v2/storagecleanup/tests/refresh-feedback.test.mjs
+++ b/plugins.v2/storagecleanup/tests/refresh-feedback.test.mjs
@@ -9,7 +9,7 @@ test('refresh feedback starts with a read-only snapshot message', () => {
 })
 
 test('refresh feedback exposes elapsed time during normal checks', () => {
-  assert.equal(refreshFeedback(5), '正在核对 qB、Jellyfin 与 H&R（已等待 5 秒）')
+  assert.equal(refreshFeedback(5), '正在核对媒体目录、qB 与 H&R（已等待 5 秒）')
   assert.match(refreshFeedback(29), /已等待 29 秒/)
 })
 

--- a/plugins.v2/storagecleanup/tests/viewport-harness.html
+++ b/plugins.v2/storagecleanup/tests/viewport-harness.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>StorageCleanup viewport harness</title>
+    <style>
+      html, body { margin: 0; min-height: 100%; background: #f4f7fb; }
+      #app {
+        min-height: 2600px;
+        transform: translateZ(0);
+      }
+      .moviepilot-mobile-nav { display: none; }
+      @media (max-width: 760px) {
+        .moviepilot-mobile-nav {
+          position: fixed;
+          z-index: 2200;
+          right: 16px;
+          bottom: calc(8px + env(safe-area-inset-bottom, 0px));
+          left: 16px;
+          display: flex;
+          align-items: center;
+          justify-content: space-around;
+          height: 62px;
+          border-radius: 24px;
+          background: rgba(226, 232, 240, .96);
+          color: #64748b;
+          box-shadow: 0 10px 35px rgba(15, 23, 42, .18);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <nav class="moviepilot-mobile-nav">
+      <span>仪表盘</span><span>推荐</span><span>探索</span><span>更多</span>
+    </nav>
+    <script type="module">
+      import { createApp } from 'vue'
+      import AppPage from '../src/components/AppPage.vue'
+
+      const resource = {
+        id: 'viewport-test',
+        title: '视口测试电影',
+        englishTitle: 'Viewport Test Movie',
+        type: '电影',
+        year: 2026,
+        edition: '2160p WEB-DL',
+        size: 42.5,
+        sizeLabel: '42.5 GB',
+        reclaimLabel: '最多 42.5 GB',
+        library: true,
+        librarySummary: '已入库',
+        libraryDetail: '媒体库可播放',
+        seedTasks: [],
+        qbSummary: '无 qB 任务',
+        siteSummary: '下载区 + 媒体库',
+        impactTitle: '不会影响当前做种',
+        impactDetail: '完整删除需要安全预演',
+        protected: false,
+        metadataVerified: true,
+      }
+      const snapshot = {
+        schemaVersion: 2,
+        snapshotId: 'viewport-snapshot',
+        generatedAt: '2026-07-30T12:00:00+08:00',
+        stats: {},
+        resources: [resource],
+      }
+      const api = {
+        async get(path) {
+          if (path.endsWith('/status')) {
+            return {
+              ok: true,
+              health: { executionEnabled: true, inventoryCurrent: true },
+              snapshot,
+            }
+          }
+          if (path.endsWith('/snapshot')) return { ok: true, snapshot }
+          return { ok: true, gaps: [], recoveries: [] }
+        },
+        async post(path) {
+          if (path.endsWith('/plan')) {
+            return {
+              ok: true,
+              plan: {
+                planId: 'viewport-plan',
+                canExecute: true,
+                expiresAt: '2099-12-31T23:59:59Z',
+                estimatedReclaimBytes: 45634027520,
+                confirmPhrase: '完整删除 1 项',
+                requiresSiteAcknowledgement: false,
+                operationCounts: {
+                  qbStop: 0,
+                  qbRemoveKeepFiles: 0,
+                  unlinkFiles: 2,
+                },
+                blocks: [],
+                warnings: [],
+              },
+            }
+          }
+          return { ok: true, snapshot }
+        },
+      }
+
+      createApp(AppPage, { api, hideTitle: true }).mount('#app')
+    </script>
+  </body>
+</html>

--- a/plugins.v2/storagecleanup/vite.config.js
+++ b/plugins.v2/storagecleanup/vite.config.js
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import federation from '@originjs/vite-plugin-federation'
 
+const pluginVersion = '1.0.15'
+
 export default defineConfig({
   plugins: [
     vue(),
@@ -23,7 +25,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    outDir: 'dist/v1.0.7',
+    outDir: `dist/v${pluginVersion}`,
     target: 'esnext',
     minify: false,
     cssCodeSplit: true,


### PR DESCRIPTION
## 变更
同步 `Hommchen/nas-storage-cleanup-ui-public` 的 MoviePilot 插件源码到官方插件仓库，使已发布索引的 StorageCleanup v1.0.15 与实际安装源一致。

- Public 源提交：`72faa6b`
- 当前官方索引：StorageCleanup `1.0.15`
- 当前官方安装源：仍为 `1.0.7`
- 本 PR 更新 `plugins.v2/storagecleanup`，包括 Python 入口、Vue 前端、分组筛选、测试与 v1.0.15 dist 资源
- 保留官方插件目录中的 README；不改版本号，不新增版本号

## 验证
- `node --test plugins.v2/storagecleanup/tests/*.test.mjs`：10/10 通过
- `npm run build`：Vite 生产构建通过
- 远端分支回读：`plugin_version = 1.0.15`，渲染目录为 `dist/v1.0.15/assets`，包含 `FILTER_GROUPS`

合并后才能按正式流程在 Pi 上重新安装并做页面/版本回读。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 4b244dd2abd4780856751e8cab93ea7ec95260d0

- 升级 `StorageCleanup` 至 `1.0.15`
- 新增 NAS 配置自动发现与验证
- 支持组合筛选、剧集完整性提示
- 清单过期锁定操作并引导刷新
- 删除后同步更新本地资源列表
- 兼容旧版 `jellyfin_db` 配置
- 风险：依赖清理台新增 `/discover` 接口
- 未见新增测试，需验证完整部署流程
<!-- pr-agent-summary:end -->
