### PR TITLE
feat(hrblocker): v1.2.0 搜索链全链路过滤 + 图标可访问性修复

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -1099,17 +1099,19 @@
   "HRBlocker": {
     "name": "H&R Blocker",
     "description": "屏蔽所有带H&R的种子，搜索、订阅等任何场景都不会选中H&R种子。",
-    "labels": "站点,下载",
-    "version": "1.1.3",
-    "icon": "https://raw.githubusercontent.com/ltdstudio/hrblocker/main/icons/hrblocker.png",
+    "labels": "站点",
+    "version": "1.2.0",
+    "icon": "https://ltdstudio.github.io/hrblocker/icons/hrblocker.png",
     "author": "ltdstudio",
     "level": 1,
     "system_version": ">=2.12.0",
     "history": {
-      "v1.1.3": "设置按钮加大并移至插件页右下角",
-      "v1.1.2": "插件页补标题栏与设置齿轮按钮，/status 接口返回版本号",
-      "v1.1.1": "补 Config 联邦组件修复设置弹窗；插件页改为屏蔽记录弹窗展示",
-      "v1.1.0": "首个版本：逐种子 H&R 标记屏蔽，可联动 H&R助手屏蔽全站 H&R 站点，手动下载兜底拦截，拦截通知与屏蔽记录"
+      "v1.2.0": "搜索结果列表直接过滤H&R种子（运行时包装搜索链，显示层也不出现）；记录显示 X/100；屏蔽记录弹窗新增两段确认的「清除记录」功能",
+      "v1.1.3": "设置按钮加大并移至插件页右下角（参照插件卡片 bottom-right 动作位样式）",
+      "v1.1.2": "插件页补标题栏（H&R Blocker + 版本号 + 设置齿轮按钮，emit switch 切到宿主设置弹窗）；/status 返回版本号",
+      "v1.1.1": "修复设置弹窗组件加载错误（补 Config 联邦组件）；插件页改为居中「查看屏蔽记录」按钮，点击弹出记录窗口，记录显示精简",
+      "v1.1.0": "新增插件页「H&R 屏蔽记录」固定面板（Vue联邦），保留最近100条屏蔽记录",
+      "v1.0.0": "初始版本：资源选择+资源下载双事件拦截，支持站点H&R标记种子与全站H&R站点屏蔽（联动H&R助手）"
     }
   }
 }

--- a/package.v2.json
+++ b/package.v2.json
@@ -1101,7 +1101,7 @@
     "description": "屏蔽所有带H&R的种子，搜索、订阅等任何场景都不会选中H&R种子。",
     "labels": "站点",
     "version": "1.2.0",
-    "icon": "https://ltdstudio.github.io/hrblocker/icons/hrblocker.png",
+    "icon": "hrblocker.png",
     "author": "ltdstudio",
     "level": 1,
     "system_version": ">=2.12.0",

--- a/plugins.v2/hrblocker/__init__.py
+++ b/plugins.v2/hrblocker/__init__.py
@@ -110,7 +110,7 @@ class HRBlocker(_PluginBase):
     # 插件描述
     plugin_desc = "屏蔽所有带H&R的种子，搜索、订阅等任何场景都不会选中H&R种子。"
     # 插件图标
-    plugin_icon = "https://ltdstudio.github.io/hrblocker/icons/hrblocker.png"
+    plugin_icon = "hrblocker.png"
     # 插件版本
     plugin_version = "1.2.0"
     # 插件作者

--- a/plugins.v2/hrblocker/__init__.py
+++ b/plugins.v2/hrblocker/__init__.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+import re
+import time
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from app.core.event import Event, eventmanager
@@ -10,6 +12,97 @@ from app.schemas import NotificationType
 from app.schemas.event import ResourceDownloadEventData, ResourceSelectionEventData
 from app.schemas.types import ChainEventType
 
+# region 搜索结果显示层过滤（运行时包装 SearchChain）
+# MoviePilot 未为搜索结果列表提供插件钩子（搜索链无链式事件、系统过滤规则不支持 hit_and_run 字段），
+# 只能在运行时包装 SearchChain 的搜索方法，在结果返回前剔除 H&R 种子。
+# 包装器在插件未启用/实例不存在时完全放行，过滤异常时同样放行原结果（不影响系统搜索）。
+_search_patch = {
+    "installed": False,
+    "instance": None,
+}
+
+
+def _hrb_get_instance():
+    inst = _search_patch.get("instance")
+    return inst if inst and getattr(inst, "_enabled", False) else None
+
+
+def _hrb_wrap_list_sync(orig):
+    def wrapper(*args, **kwargs):
+        result = orig(*args, **kwargs)
+        inst = _hrb_get_instance()
+        if not inst or not result:
+            return result
+        try:
+            return inst.hr_filter_contexts(result)
+        except Exception as e:
+            logger.error(f"【H&R Blocker】搜索结果过滤异常（已放行原结果）：{e}")
+            return result
+    wrapper.__hrb_wrapped__ = True
+    return wrapper
+
+
+def _hrb_wrap_list_async(orig):
+    async def wrapper(*args, **kwargs):
+        result = await orig(*args, **kwargs)
+        inst = _hrb_get_instance()
+        if not inst or not result:
+            return result
+        try:
+            return inst.hr_filter_contexts(result)
+        except Exception as e:
+            logger.error(f"【H&R Blocker】搜索结果过滤异常（已放行原结果）：{e}")
+            return result
+    wrapper.__hrb_wrapped__ = True
+    return wrapper
+
+
+def _hrb_wrap_stream(orig):
+    async def wrapper(*args, **kwargs):
+        removed_cum = 0
+        async for event in orig(*args, **kwargs):
+            inst = _hrb_get_instance()
+            if inst and isinstance(event, dict):
+                try:
+                    event, removed_cum = inst.hr_filter_event(event, removed_cum)
+                except Exception as e:
+                    logger.error(f"【H&R Blocker】搜索事件过滤异常（已放行原事件）：{e}")
+            yield event
+    wrapper.__hrb_wrapped__ = True
+    return wrapper
+
+
+def _hrb_install_search_patch():
+    """幂等地为 SearchChain 安装搜索结果显示过滤包装器"""
+    if _search_patch["installed"]:
+        return
+    try:
+        from app.chain.search import SearchChain
+    except Exception as e:
+        logger.error(f"【H&R Blocker】导入 SearchChain 失败，搜索显示过滤不可用：{e}")
+        return
+    targets = {
+        "process": _hrb_wrap_list_sync,
+        "search_by_id": _hrb_wrap_list_sync,
+        "search_by_title": _hrb_wrap_list_sync,
+        "async_process": _hrb_wrap_list_async,
+        "async_search_by_id": _hrb_wrap_list_async,
+        "async_search_by_title": _hrb_wrap_list_async,
+        "async_process_stream": _hrb_wrap_stream,
+        "async_search_by_title_stream": _hrb_wrap_stream,
+    }
+    patched = []
+    for name, wrap in targets.items():
+        fn = getattr(SearchChain, name, None)
+        if callable(fn) and not getattr(fn, "__hrb_wrapped__", False):
+            setattr(SearchChain, name, wrap(fn))
+            patched.append(name)
+    _search_patch["installed"] = True
+    logger.info(f"【H&R Blocker】搜索结果显示过滤已就绪（已包装 {len(patched)} 个 SearchChain 方法）")
+
+
+# endregion
+
 
 class HRBlocker(_PluginBase):
     # 插件名称
@@ -17,9 +110,9 @@ class HRBlocker(_PluginBase):
     # 插件描述
     plugin_desc = "屏蔽所有带H&R的种子，搜索、订阅等任何场景都不会选中H&R种子。"
     # 插件图标
-    plugin_icon = "https://raw.githubusercontent.com/ltdstudio/hrblocker/main/icons/hrblocker.png"
+    plugin_icon = "https://ltdstudio.github.io/hrblocker/icons/hrblocker.png"
     # 插件版本
-    plugin_version = "1.1.3"
+    plugin_version = "1.2.0"
     # 插件作者
     plugin_author = "ltdstudio"
     # 作者主页
@@ -45,6 +138,9 @@ class HRBlocker(_PluginBase):
     _records: List[Dict[str, Any]] = []
     # 记录保留条数
     MAX_RECORDS = 100
+    # 全站H&R站点缓存（60秒）
+    _hr_sites_cache_ts = 0.0
+    _hr_sites_cache_ids: Set[int] = set()
 
     def init_plugin(self, config: dict = None):
         if config:
@@ -62,6 +158,9 @@ class HRBlocker(_PluginBase):
             })
         # 加载历史屏蔽记录
         self._records = self.get_data("records") or []
+        # 注册当前实例并安装搜索显示层包装（未启用时包装器自动放行）
+        _search_patch["instance"] = self
+        _hrb_install_search_patch()
         if self._enabled:
             hr_sites = self.__get_hr_active_sites()
             logger.info(f"【{self.plugin_name}】已启用，逐种子H&R标记屏蔽：{'开' if self._block_marked else '关'}，"
@@ -91,6 +190,13 @@ class HRBlocker(_PluginBase):
                 "methods": ["GET"],
                 "summary": "屏蔽记录",
                 "description": "查看最近屏蔽的H&R种子记录（最多100条）",
+            },
+            {
+                "path": "/records/clear",
+                "endpoint": self.api_clear_records,
+                "methods": ["POST"],
+                "summary": "清空屏蔽记录",
+                "description": "清空全部屏蔽记录",
             }
         ]
 
@@ -220,7 +326,8 @@ class HRBlocker(_PluginBase):
         return "vue", "dist/assets"
 
     def stop_service(self):
-        pass
+        # 摘除实例引用，搜索包装器自动放行
+        _search_patch["instance"] = None
 
     # region 事件处理
 
@@ -314,6 +421,75 @@ class HRBlocker(_PluginBase):
 
     # region 私有方法
 
+    def _hr_sites_cached(self) -> Set[int]:
+        """全站H&R站点ID集合（60秒缓存，避免渐进式搜索每批事件都查库）"""
+        now = time.time()
+        if now - self._hr_sites_cache_ts > 60:
+            self._hr_sites_cache_ids = set(self.__get_hr_active_sites().keys())
+            self._hr_sites_cache_ts = now
+        return self._hr_sites_cache_ids
+
+    def hr_is_item_blocked(self, item: Any) -> bool:
+        """判定搜索结果条目（Context.to_dict() 字典）是否为H&R种子"""
+        try:
+            ti = (item or {}).get("torrent_info") or {}
+            if self._block_marked and ti.get("hit_and_run"):
+                return True
+            if self._sync_assistant:
+                sid = ti.get("site")
+                if sid and sid in self._hr_sites_cached():
+                    return True
+        except Exception:
+            pass
+        return False
+
+    def hr_filter_contexts(self, contexts: List[Any]) -> List[Any]:
+        """从 Context 列表中剔除H&R种子（供搜索链包装器调用）"""
+        kept, removed = [], 0
+        for context in contexts:
+            try:
+                blocked, _ = self.__is_hr_context(context)
+            except Exception:
+                blocked = False
+            if blocked:
+                removed += 1
+            else:
+                kept.append(context)
+        if removed:
+            logger.info(f"【{self.plugin_name}】搜索结果已过滤 {removed} 个H&R种子，剩余 {len(kept)} 个")
+        return kept
+
+    def hr_filter_event(self, event: Dict[str, Any], removed_cum: int) -> Tuple[Dict[str, Any], int]:
+        """
+        过滤渐进式搜索（SSE）事件中的H&R种子（供搜索链包装器调用）
+        :param event: 搜索事件字典（append/replace/done/progress 等）
+        :param removed_cum: append 阶段已累计剔除数（total_items 为累计值，需同步扣减）
+        :return: (过滤后的事件, 新的累计剔除数)
+        """
+        etype = event.get("type")
+        items = event.get("items")
+        if isinstance(items, list) and items:
+            kept = [it for it in items if not self.hr_is_item_blocked(it)]
+            removed = len(items) - len(kept)
+            if removed:
+                event["items"] = kept
+                if etype == "append":
+                    removed_cum += removed
+                    if isinstance(event.get("total_items"), int):
+                        event["total_items"] = max(0, event["total_items"] - removed_cum)
+                else:
+                    # replace/done：items 为最终全量，直接以过滤后数量为准
+                    if isinstance(event.get("total_items"), int):
+                        event["total_items"] = len(kept)
+                    text = event.get("text")
+                    if isinstance(text, str):
+                        event["text"] = re.sub(r"共\s*\d+\s*个资源", f"共 {len(kept)} 个资源", text)
+                logger.info(f"【{self.plugin_name}】搜索结果已过滤 {removed} 个H&R种子（{etype}）")
+        contexts = event.get("contexts")
+        if isinstance(contexts, list) and contexts:
+            event["contexts"] = self.hr_filter_contexts(contexts)
+        return event, removed_cum
+
     def __add_record(self, title: str, site: str, reason: str, source: str, stage: str):
         """
         追加一条屏蔽记录（最新在前，上限 MAX_RECORDS 条，持久化到插件数据）
@@ -404,6 +580,19 @@ class HRBlocker(_PluginBase):
             "total": len(records),
             "max_records": self.MAX_RECORDS,
             "records": records,
+        }
+
+    def api_clear_records(self) -> Dict[str, Any]:
+        """
+        清空全部屏蔽记录
+        """
+        self._records = []
+        self.save_data("records", [])
+        logger.info(f"【{self.plugin_name}】屏蔽记录已清空")
+        return {
+            "total": 0,
+            "max_records": self.MAX_RECORDS,
+            "records": [],
         }
 
     def api_status(self) -> Dict[str, Any]:

--- a/plugins.v2/hrblocker/dist/assets/__federation_expose_Page-BS_KBPCO.js
+++ b/plugins.v2/hrblocker/dist/assets/__federation_expose_Page-BS_KBPCO.js
@@ -1,7 +1,7 @@
 import { importShared } from './__federation_fn_import-JrT3xvdd.js';
 import { _ as _export_sfc } from './_plugin-vue_export-helper-pcqpp-6-.js';
 
-const {resolveComponent:_resolveComponent,createVNode:_createVNode,createElementVNode:_createElementVNode,toDisplayString:_toDisplayString,createTextVNode:_createTextVNode,withCtx:_withCtx,Fragment:_Fragment,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,renderList:_renderList} = await importShared('vue');
+const {resolveComponent:_resolveComponent,createVNode:_createVNode,createElementVNode:_createElementVNode,toDisplayString:_toDisplayString,createTextVNode:_createTextVNode,withCtx:_withCtx,Fragment:_Fragment,openBlock:_openBlock,createElementBlock:_createElementBlock,createCommentVNode:_createCommentVNode,createBlock:_createBlock,renderList:_renderList} = await importShared('vue');
 
 
 const _hoisted_1 = { class: "hrb-page" };
@@ -45,7 +45,10 @@ const version = ref('');
 const hrSites = ref(0);
 const loading = ref(false);
 const dialog = ref(false);
+const clearing = ref(false);
+const confirmClear = ref(false);
 let timer = null;
+let confirmTimer = null;
 
 function getApi() {
   return props.api || (typeof window !== 'undefined' ? window.MoviePilotAPI : null)
@@ -92,6 +95,33 @@ function openSettings() {
   emit('switch'); // 宿主切到 Config 弹窗
 }
 
+// 两段式确认：第一次点击变为「确认清除」（3秒内有效），第二次真正清空
+function onClearClick() {
+  if (!confirmClear.value) {
+    confirmClear.value = true;
+    confirmTimer = setTimeout(() => { confirmClear.value = false; }, 3000);
+    return
+  }
+  if (confirmTimer) clearTimeout(confirmTimer);
+  confirmClear.value = false;
+  clearRecords();
+}
+
+async function clearRecords() {
+  const api = getApi();
+  if (!api) return
+  clearing.value = true;
+  try {
+    await api.post('plugin/HRBlocker/records/clear');
+    records.value = [];
+    total.value = 0;
+  } catch (e) {
+    console.error('[HRBlocker] 清空屏蔽记录失败', e);
+  } finally {
+    clearing.value = false;
+  }
+}
+
 function openDialog() {
   dialog.value = true;
   fetchRecords();
@@ -106,6 +136,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   if (timer) clearInterval(timer);
+  if (confirmTimer) clearTimeout(confirmTimer);
 });
 
 return (_ctx, _cache) => {
@@ -144,7 +175,7 @@ return (_ctx, _cache) => {
             })
           ]),
           _createElementVNode("div", _hoisted_5, [
-            _createTextVNode(" 已屏蔽 " + _toDisplayString(total.value) + " 条 H&R 种子 ", 1),
+            _createTextVNode(" 已屏蔽 " + _toDisplayString(total.value) + "/" + _toDisplayString(maxRecords.value) + " 条 H&R 种子 ", 1),
             (hrSites.value > 0)
               ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
                   _createTextVNode(" · 联动 " + _toDisplayString(hrSites.value) + " 个全站H&R站点", 1)
@@ -168,7 +199,7 @@ return (_ctx, _cache) => {
         ]))]),
         _: 1
       }),
-      _createElementVNode("div", _hoisted_7, " 保留最近 " + _toDisplayString(maxRecords.value) + " 条 ", 1)
+      _createElementVNode("div", _hoisted_7, " 已屏蔽 " + _toDisplayString(total.value) + "/" + _toDisplayString(maxRecords.value) + " 条（保留最近 " + _toDisplayString(maxRecords.value) + " 条） ", 1)
     ]),
     _createVNode(_component_v_btn, {
       class: "hrb-settings-btn",
@@ -214,6 +245,22 @@ return (_ctx, _cache) => {
                   _: 1
                 }),
                 _createVNode(_component_v_spacer),
+                (records.value.length > 0)
+                  ? (_openBlock(), _createBlock(_component_v_btn, {
+                      key: 0,
+                      size: "small",
+                      color: confirmClear.value ? 'error' : undefined,
+                      variant: confirmClear.value ? 'flat' : 'text',
+                      "prepend-icon": "mdi-delete-sweep-outline",
+                      loading: clearing.value,
+                      onClick: onClearClick
+                    }, {
+                      default: _withCtx(() => [
+                        _createTextVNode(_toDisplayString(confirmClear.value ? '确认清除' : '清除记录'), 1)
+                      ]),
+                      _: 1
+                    }, 8, ["color", "variant", "loading"]))
+                  : _createCommentVNode("", true),
                 _createVNode(_component_v_btn, {
                   icon: "mdi-refresh",
                   variant: "text",
@@ -296,6 +343,6 @@ return (_ctx, _cache) => {
 }
 
 };
-const Page = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-f18e04a0"]]);
+const Page = /*#__PURE__*/_export_sfc(_sfc_main, [['__scopeId',"data-v-7686036f"]]);
 
 export { Page as default };

--- a/plugins.v2/hrblocker/dist/assets/__federation_expose_Page-jUn9n6-0.css
+++ b/plugins.v2/hrblocker/dist/assets/__federation_expose_Page-jUn9n6-0.css
@@ -1,65 +1,65 @@
 
-.hrb-page[data-v-f18e04a0] {
+.hrb-page[data-v-7686036f] {
   width: 100%;
   position: relative;
 }
 
 /* 右下角设置按钮（对齐插件卡片 absolute bottom-0 right-0 动作位） */
-.hrb-settings-btn[data-v-f18e04a0] {
+.hrb-settings-btn[data-v-7686036f] {
   position: absolute;
   bottom: 0;
   right: 0;
 }
-.hrb-header[data-v-f18e04a0] {
+.hrb-header[data-v-7686036f] {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   padding: 4px 4px 0;
 }
-.hrb-title[data-v-f18e04a0] {
+.hrb-title[data-v-7686036f] {
   display: flex;
   align-items: center;
 }
-.hrb-meta-line[data-v-f18e04a0] {
+.hrb-meta-line[data-v-7686036f] {
   font-size: 12px;
   opacity: 0.6;
   margin-top: 2px;
 }
-.hrb-header-actions[data-v-f18e04a0] {
+.hrb-header-actions[data-v-7686036f] {
   display: flex;
   align-items: center;
 }
-.hrb-center[data-v-f18e04a0] {
+.hrb-center[data-v-7686036f] {
   min-height: 300px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
 }
-.hrb-empty[data-v-f18e04a0] {
+.hrb-empty[data-v-7686036f] {
   height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
 }
-.hrb-item[data-v-f18e04a0] {
+.hrb-item[data-v-7686036f] {
   padding: 6px 8px;
   border-radius: 6px;
   margin-bottom: 4px;
   background: rgba(var(--v-theme-on-surface), 0.04);
 }
-.hrb-item[data-v-f18e04a0]:hover {
+.hrb-item[data-v-7686036f]:hover {
   background: rgba(var(--v-theme-on-surface), 0.08);
 }
-.hrb-title[data-v-f18e04a0] {
+.hrb-title[data-v-7686036f] {
   font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.hrb-item-meta[data-v-f18e04a0] {
+.hrb-item-meta[data-v-7686036f] {
   display: flex;
   flex-wrap: wrap;
   gap: 2px 10px;

--- a/plugins.v2/hrblocker/dist/assets/remoteEntry.js
+++ b/plugins.v2/hrblocker/dist/assets/remoteEntry.js
@@ -2,8 +2,8 @@ const currentImports = {};
       const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
       let moduleMap = {
 "./Page":()=>{
-      dynamicLoadingCss(["__federation_expose_Page-DK50FMrC.css"], false, './Page');
-      return __federation_import('./__federation_expose_Page-7mM9mckM.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
+      dynamicLoadingCss(["__federation_expose_Page-jUn9n6-0.css"], false, './Page');
+      return __federation_import('./__federation_expose_Page-BS_KBPCO.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},
 "./Config":()=>{
       dynamicLoadingCss(["__federation_expose_Config-B6GwL-47.css"], false, './Config');
       return __federation_import('./__federation_expose_Config-BS1ffTHh.js').then(module =>Object.keys(module).every(item => exportSet.has(item)) ? () => module.default : () => module)},};


### PR DESCRIPTION
## 更新说明

**H&R Blocker** v1.1.3 → v1.2.0（#1131 合并时的 head 为 v1.1.3，v1.2.0 提交在合并之后推送，单独提 PR）

### v1.2.0
- 搜索/订阅全链路 H&R 过滤：SearchChain 方法包装 + SSE 流式过滤，搜索页列表直接不显示 H&R 种子
- 屏蔽记录 X/100 计数显示 + 两段确认「清除记录」
- 图标 URL 改用 GitHub Pages（`raw.githubusercontent.com` 在部分网络不可达，导致图标无法显示）

### 自查
- [x] 版本一致（1.2.0），`check_plugin_versions.py` 通过
- [x] `py_compile` 通过
- [x] 已在 MoviePilot 实测：搜索页 H&R 种子过滤、屏蔽记录计数/清除均验证通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 9ddc3a6bd7976580848ef65773019d574392efe9

- 搜索结果层直接隐藏 H&R 种子
- 包装同步、异步及 SSE 搜索链
- 缓存全站 H&R 站点查询结果
- 新增记录计数、清空接口与二次确认
- 图标改用内置静态资源，提升可访问性
- 兼容 `>=2.12.0`；依赖内部 `SearchChain` 方法
- 未新增自动化测试，需验证各版本搜索事件结构
<!-- pr-agent-summary:end -->
