### PR TITLE
feat: add MediaInfo rename enhancer

### DIFF
--- a/package.v3.json
+++ b/package.v3.json
@@ -430,5 +430,17 @@
       "v1.1.0": "将任务队列、GPU 推理和 FFmpeg 流水线直接集成到 MoviePilot 插件",
       "v1.0.0": "首个版本：支持服务状态、模型下载与校验、任务提交和管理"
     }
+  },
+  "MediaInfoRenameEnhancer": {
+    "name": "MediaInfo命名增强",
+    "description": "为整理模板提供 HDR、编码、音频、Atmos、字幕及发布组兜底字段。",
+    "labels": "文件整理,MediaInfo",
+    "version": "1.0.0",
+    "author": "annanygy",
+    "level": 1,
+    "system_version": ">=3.0.0",
+    "history": {
+      "v1.0.0": "V3 独立版本：在重命名模板渲染前读取 MediaInfo 并注入技术字段。"
+    }
   }
 }

--- a/plugins.v3/mediainforenameenhancer/__init__.py
+++ b/plugins.v3/mediainforenameenhancer/__init__.py
@@ -1,0 +1,290 @@
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+from app.plugins import _PluginBase
+from app.schemas.types import ChainEventType
+
+
+class MediaInfoRenameEnhancer(_PluginBase):
+    """在整理文件名渲染前读取 MediaInfo 技术元数据并注入模板变量。"""
+
+    plugin_name = "MediaInfo命名增强"
+    plugin_desc = "为整理模板提供HDR、编码、音频、Atmos、字幕及发布组兜底字段"
+    plugin_version = "1.0.0"
+    plugin_author = "annanygy"
+    plugin_config_prefix = "mediainforenameenhancer_"
+    plugin_order = 20
+    auth_level = 1
+
+    _enabled = False
+    _mediainfo_path = ""
+
+    def init_plugin(self, config: dict = None) -> None:
+        config = config or {}
+        self._enabled = config.get("enabled", False)
+        self._mediainfo_path = config.get("mediainfo_path") or shutil.which("mediainfo") or ""
+
+    def get_state(self) -> bool:
+        return self._enabled and bool(self._mediainfo_path)
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 3},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {"model": "enabled", "label": "启用插件"},
+                                    }
+                                ],
+                            },
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 9},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "mediainfo_path",
+                                            "label": "MediaInfo命令行路径",
+                                            "placeholder": "mediainfo",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VAlert",
+                        "props": {
+                            "type": "info",
+                            "variant": "tonal",
+                            "text": (
+                                "注入 miVideoFormat、miHdrFormat、miVideoCodec、"
+                                "miVideoBit、miAudioCodec、miAtmos、miSubtitle、"
+                                "miReleaseGroup 模板变量。只读取媒体头信息，不修改源文件。"
+                            ),
+                        },
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "mediainfo_path": shutil.which("mediainfo") or "mediainfo",
+        }
+
+    def get_page(self) -> Optional[List[dict]]:
+        return None
+
+    def stop_service(self) -> None:
+        return None
+
+    @eventmanager.register(ChainEventType.TransferRenameBuild)
+    def on_transfer_rename_build(self, event: Event) -> None:
+        if not self.get_state() or not event or not event.event_data:
+            return
+
+        event_data = event.event_data
+        source_path = event_data.source_path
+        source_item = event_data.source_item
+        if not source_path:
+            return
+        if source_item and source_item.storage not in (None, "local"):
+            return
+
+        media_path = Path(source_path)
+        if not media_path.is_file():
+            return
+
+        fields = self._probe(media_path, event_data.rename_dict.get("releaseGroup"))
+        if fields:
+            event_data.rename_dict.update(fields)
+
+    def _probe(self, media_path: Path, release_group: Optional[str]) -> Dict[str, str]:
+        try:
+            completed = subprocess.run(
+                [self._mediainfo_path, "--Output=JSON", "--Full", "--", str(media_path)],
+                capture_output=True,
+                check=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=20,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            payload = json.loads(completed.stdout)
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as err:
+            logger.warning(f"MediaInfo命名增强读取失败：{media_path.name} - {str(err)}")
+            return {}
+
+        return self._parse_mediainfo(payload, media_path, release_group)
+
+    @classmethod
+    def _parse_mediainfo(
+        cls,
+        payload: Dict[str, Any],
+        media_path: Path,
+        release_group: Optional[str],
+    ) -> Dict[str, str]:
+        tracks = payload.get("media", {}).get("track", [])
+        video_tracks = [track for track in tracks if track.get("@type") == "Video"]
+        audio_tracks = [track for track in tracks if track.get("@type") == "Audio"]
+        text_tracks = [track for track in tracks if track.get("@type") == "Text"]
+
+        video = video_tracks[0] if video_tracks else {}
+        audio = cls._preferred_audio_track(audio_tracks)
+        audio_codec, atmos = cls._audio_summary(audio)
+        fields = {
+            "miVideoFormat": cls._resolution(video),
+            "miHdrFormat": cls._hdr_format(video),
+            "miVideoCodec": cls._video_codec(video),
+            "miVideoBit": cls._video_bit(video),
+            "miAudioCodec": audio_codec,
+            "miAtmos": "Atmos" if atmos else "",
+            "miSubtitle": cls._subtitle_summary(text_tracks),
+            "miReleaseGroup": cls._release_group(media_path) or release_group,
+        }
+        return {key: value for key, value in fields.items() if value}
+
+    @staticmethod
+    def _digits(value: Any) -> Optional[int]:
+        match = re.search(r"\d+", str(value or "").replace(" ", ""))
+        return int(match.group()) if match else None
+
+    @classmethod
+    def _resolution(cls, video: Dict[str, Any]) -> str:
+        width = cls._digits(video.get("Width")) or 0
+        if width >= 7000:
+            return "4320p"
+        if width >= 3500:
+            return "2160p"
+        if width >= 1800:
+            return "1080p"
+        if width >= 1200:
+            return "720p"
+        return ""
+
+    @staticmethod
+    def _video_codec(video: Dict[str, Any]) -> str:
+        codec = str(video.get("Format") or "").upper()
+        return {"HEVC": "HEVC", "AVC": "AVC", "AV1": "AV1", "VP9": "VP9"}.get(codec, codec)
+
+    @staticmethod
+    def _video_bit(video: Dict[str, Any]) -> str:
+        bit_depth = re.search(r"\d+", str(video.get("BitDepth") or ""))
+        return f"{bit_depth.group()}bit" if bit_depth else ""
+
+    @staticmethod
+    def _hdr_format(video: Dict[str, Any]) -> str:
+        raw = " ".join(
+            str(video.get(key) or "")
+            for key in (
+                "HDR_Format",
+                "HDR_Format_Profile",
+                "HDR_Format_Compatibility",
+                "HDR_Format_String",
+            )
+        )
+        upper = raw.upper()
+        if "DOLBY VISION" in upper or "DVHE." in upper:
+            profile = re.search(r"DVHE\.0?(\d+)", upper)
+            label = f"DoVi.P{int(profile.group(1))}" if profile else "DoVi"
+            if "HDR10+" in upper or "HDR10PLUS" in upper:
+                return f"{label}+HDR10+"
+            if "HDR10" in upper or "ST 2086" in upper:
+                return f"{label}+HDR10"
+            return label
+        if "HDR10+" in upper or "HDR10PLUS" in upper or "ST 2094" in upper:
+            return "HDR10+"
+        if "HLG" in upper:
+            return "HLG"
+        if "HDR10" in upper or "ST 2086" in upper:
+            return "HDR10"
+        return "SDR"
+
+    @staticmethod
+    def _preferred_audio_track(audio_tracks: List[Dict[str, Any]]) -> Dict[str, Any]:
+        for track in audio_tracks:
+            if str(track.get("Default") or "").lower() == "yes":
+                return track
+        return audio_tracks[0] if audio_tracks else {}
+
+    @classmethod
+    def _audio_summary(cls, audio: Dict[str, Any]) -> Tuple[str, bool]:
+        raw = " ".join(
+            str(audio.get(key) or "")
+            for key in ("Format", "Format_Commercial_IfAny", "Title", "Format_AdditionalFeatures")
+        )
+        upper = raw.upper()
+        base_format = str(audio.get("Format") or "").upper()
+        if "TRUEHD" in upper or base_format == "MLP FBA":
+            codec = "TrueHD"
+        elif "DTS-HD MASTER" in upper:
+            codec = "DTS-HD MA"
+        elif base_format == "E-AC-3":
+            codec = "DDP"
+        elif base_format == "AC-3":
+            codec = "DD"
+        else:
+            codec = base_format
+
+        channels = cls._digits(audio.get("Channels"))
+        channel_label = {8: "7.1", 6: "5.1", 2: "2.0", 1: "1.0"}.get(channels, "")
+        summary = " ".join(part for part in (codec, channel_label) if part)
+        return summary, "ATMOS" in upper
+
+    @classmethod
+    def _subtitle_summary(cls, text_tracks: List[Dict[str, Any]]) -> str:
+        languages = set()
+        for track in text_tracks:
+            language = cls._normalize_language(track.get("Language"))
+            if language:
+                languages.add(language)
+            title = str(track.get("Title") or "")
+            if re.search(r"中英|简英|繁英", title):
+                languages.update({"ZH", "EN"})
+
+        priority = {"ZH": 0, "EN": 1, "JA": 2, "KO": 3, "ES": 4}
+        ordered = sorted(languages, key=lambda item: (priority.get(item, 99), item))
+        preferred = [language for language in ordered if language in {"ZH", "EN"}]
+        return "-".join(preferred or ordered[:2])
+
+    @staticmethod
+    def _normalize_language(language: Any) -> str:
+        code = str(language or "").split("-")[0].lower()
+        return {
+            "zh": "ZH", "zho": "ZH", "chi": "ZH", "en": "EN", "eng": "EN",
+            "ja": "JA", "jpn": "JA", "ko": "KO", "kor": "KO", "es": "ES", "spa": "ES",
+        }.get(code, code.upper() if code and code != "und" else "")
+
+    @staticmethod
+    def _release_group(media_path: Path) -> str:
+        stem = media_path.stem
+        last_token = stem.rsplit(".", 1)[-1]
+        excluded = {"HEVC", "H265", "X265", "AVC", "H264", "X264", "MKV"}
+        if re.fullmatch(r"[A-Z][A-Z0-9]{1,15}", last_token) and last_token not in excluded:
+            return last_token
+
+        hyphen_match = re.search(r"-([A-Za-z0-9][A-Za-z0-9._]{0,20})$", stem)
+        if hyphen_match:
+            return hyphen_match.group(1)
+        return ""

--- a/tests/v3/mediainforenameenhancer/test_plugin.py
+++ b/tests/v3/mediainforenameenhancer/test_plugin.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from app.plugins.mediainforenameenhancer import MediaInfoRenameEnhancer
+
+
+def test_parse_dolby_vision_mediainfo() -> None:
+    payload = {
+        "media": {"track": [
+            {"@type": "Video", "Width": "3840", "Format": "HEVC", "BitDepth": "10",
+             "HDR_Format": "Dolby Vision / SMPTE ST 2086", "HDR_Format_Profile": "dvhe.08 / ",
+             "HDR_Format_Compatibility": " / HDR10"},
+            {"@type": "Audio", "Format": "MLP FBA", "Format_Commercial_IfAny": "Dolby TrueHD with Dolby Atmos", "Channels": "8"},
+            {"@type": "Text", "Language": "zh", "Title": "中英双语"},
+        ]}
+    }
+    result = MediaInfoRenameEnhancer._parse_mediainfo(
+        payload, Path("Dune.2021.2160p.DoVi.TrueHD.Atmos.x265-b.mkv"), None
+    )
+    assert result == {
+        "miVideoFormat": "2160p", "miHdrFormat": "DoVi.P8+HDR10", "miVideoCodec": "HEVC",
+        "miVideoBit": "10bit", "miAudioCodec": "TrueHD 7.1", "miAtmos": "Atmos",
+        "miSubtitle": "ZH-EN", "miReleaseGroup": "b",
+    }
+
+
+def test_parse_sdr_mediainfo() -> None:
+    payload = {"media": {"track": [
+        {"@type": "Video", "Width": "3840", "Format": "HEVC", "BitDepth": "10"},
+        {"@type": "Audio", "Format": "E-AC-3", "Format_Commercial_IfAny": "Dolby Digital Plus with Dolby Atmos", "Channels": "6"},
+        {"@type": "Text", "Language": "zh", "Title": "中英特效字幕"},
+    ]}}
+    result = MediaInfoRenameEnhancer._parse_mediainfo(
+        payload, Path("Dune.2021.2160p.SDR.H265.Atmos.DDP5.1.CHS-ENG.BOBO.mkv"), "ENG.BOBO"
+    )
+    assert result["miHdrFormat"] == "SDR"
+    assert result["miAudioCodec"] == "DDP 5.1"
+    assert result["miAtmos"] == "Atmos"
+    assert result["miSubtitle"] == "ZH-EN"
+    assert result["miReleaseGroup"] == "BOBO"


### PR DESCRIPTION
## Summary
- Add the V3 `MediaInfoRenameEnhancer` plugin and marketplace metadata.
- Inject MediaInfo-derived resolution, HDR/Dolby Vision, codecs, bit depth, Atmos, subtitle, and release-group fields before rename-template rendering.
- The plugin only reads media metadata; it does not rename or modify source files itself.

## Validation
- `python -m py_compile plugins.v3/mediainforenameenhancer/__init__.py`
- `check_plugin_versions.py package.json package.v2.json package.v3.json`
- Isolated V3 import and MediaInfo parsing assertions

Full repository pytest was not run locally because the checkout environment lacks the MoviePilot development dependency `alembic`.

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 5294e62cdbda6556c41ddc05becbb090042dbb01

- 新增 MediaInfo 重命名模板增强插件
- 注入视频、HDR、音频、字幕及发布组字段
- 仅处理本地文件，依赖 MediaInfo 命令
- 增加杜比视界与 SDR 解析测试
- 风险：字段识别受 MediaInfo 输出影响
<!-- pr-agent-summary:end -->
