### PR TITLE
fix: 修复北洋园(tjupt)签到——站点改版后 XPath 过时 + 答案库 KeyError 未捕获

### DIFF
--- a/plugins.v2/autosignin/sites/tjupt.py
+++ b/plugins.v2/autosignin/sites/tjupt.py
@@ -112,8 +112,8 @@ class Tjupt(_ISiteSigninHandler):
         logger.debug(f"签到图片hash {captcha_img_hash}")
 
         # 签到答案选项
-        values = html.xpath("//input[@name='answer']/@value")
-        options = html.xpath("//input[@name='answer']/following-sibling::text()")
+        values = html.xpath("//input[@name='ban_robot']/@value")
+        options = html.xpath("//input[@name='ban_robot']/following-sibling::text()")
 
         if not values or not options:
             logger.error(f"{site} 签到失败，未获取到答案选项")
@@ -142,7 +142,7 @@ class Tjupt(_ISiteSigninHandler):
                                              ua=ua,
                                              proxy=proxy,
                                              site=site)
-        except (FileNotFoundError, IOError, OSError) as e:
+        except (KeyError, FileNotFoundError, IOError, OSError) as e:
             logger.debug(f"查询本地已知答案失败：{str(e)}，继续请求豆瓣查询")
 
         # 本地不存在正确答案则请求豆瓣查询匹配
@@ -200,7 +200,7 @@ class Tjupt(_ISiteSigninHandler):
         签到请求
         """
         data = {
-            'answer': answer,
+            'ban_robot': answer,
             'submit': '提交'
         }
         logger.debug(f"提交data {data}")


### PR DESCRIPTION
## 修复北洋园(tjupt)签到：站点改版后 XPath 过时 + 答案库 KeyError 未捕获

### 问题描述

北洋园（tjupt.org）签到验证码流程存在两个 bug，导致自动签到完全不可用：

**Bug 1：签到页改版后 XPath 过时 → 报"未获取到答案选项"**

站点签到页已改版，验证码答案选项从 `<input name='answer'>` 改为 `<input type='radio' name='ban_robot' value='时间戳&序号'>` + label 内影视名文本，提交字段也改为 `ban_robot`。插件仍用旧 XPath `//input[@name='answer']`，匹配不到任何选项，直接报 `签到失败，未获取到答案选项`。

**Bug 2：答案库查询 KeyError 未捕获 → 跳过豆瓣匹配**

```python
captcha_answer = exits_answers[captcha_img_hash]  # hash 未命中时抛 KeyError!
...
except (FileNotFoundError, IOError, OSError) as e:  # 未捕获 KeyError
```

当验证码图片 hash 不在本地答案库（`tjupt.json`）时，`exits_answers[captcha_img_hash]` 抛 `KeyError`，但 `except` 只捕获 `FileNotFoundError / IOError / OSError`。`KeyError` 冒泡到上层 `signin_site()` 通用异常处理，导致：

- 签到直接失败，通知显示 `签到失败：'<hash字符串>'`（KeyError 的 key 被当作错误信息）
- **豆瓣图片匹配分支永远执行不到** —— 即使签到图片与豆瓣海报相似度高达 1.0（实测"似锦"），也无法自动签到

### 根因与关联

- Bug 1 是站点改版适配问题（站点方变更）。
- Bug 2 是插件原版就有的潜伏 bug：站点改版前解析失败会提前返回，流程走不到答案库查询，因此从未暴露；修复 Bug 1 后流程能走到答案库查询，才触发 Bug 2。

### 修复

1. XPath 解析：`name='answer'` → `name='ban_robot'`（2 处）
2. 提交字段：`'answer': answer` → `'ban_robot': answer`
3. except 元组加入 `KeyError`，hash 未命中时正确降级到豆瓣匹配分支

### 验证

- 本地模拟：未知 hash 查询，修复前 KeyError 冒泡报错，修复后进入豆瓣匹配分支 ✅
- 实测豆瓣匹配：签到图 vs "似锦"豆瓣海报相似度 **1.0**，修复后即可自动签到 ✅
- 已在生产环境部署验证（容器内补丁 + 插件 reload 生效，今日 0 点前签到成功）✅

### 影响范围

仅影响北洋园签到：修复后由"解析失败/直接失败"变为"解析选项 + 继续豆瓣匹配"。答案库命中路径不受影响。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at f9be6afed3f1fa90b19e9fc3498caaf643f4bec6

- 适配北洋园新版 `ban_robot` 签到字段
- 修复答案库未命中时的 `KeyError`
- 允许继续执行豆瓣图片匹配兜底
- 兼容性：仅更新 tjupt 当前页面协议
<!-- pr-agent-summary:end -->
