### PR TITLE
fix: LunaTVSource v0.4.39

### DIFF
--- a/package.v3.json
+++ b/package.v3.json
@@ -464,13 +464,14 @@
     "name": "LunaTV 资源订阅",
     "description": "接入 LunaTV/MoonTV 苹果 CMS 资源，复用 MoviePilot 原生搜索、订阅、目录、整理与媒体库链路。",
     "labels": "订阅,苹果CMS,m3u8,下载,媒体库",
-    "version": "0.4.38",
-    "icon": "lunatvsource.png",
+    "version": "0.4.39",
+    "icon": "https://raw.githubusercontent.com/OneBigMoon/moviepilot-v3-lunatv-source/master/icons/lunatvsource.png",
     "author": "OneBigMoon",
     "project_url": "https://github.com/OneBigMoon/moviepilot-v3-lunatv-source",
     "level": 1,
     "release": true,
     "history": {
+      "0.4.39": "搜索按实际 CMS 源显示 X/N 进度，修复欧美剧等分类导致的电视剧 0 结果；电影与电视剧按实际分辨率降序展示，整季逐集探测并在同集多地址中选择最高画质；下载入队后立即启动，HLS 分片启用 HTTP/1.1 多连接；修正插件图标与整理关闭、完成回调串行等边界。",
       "0.4.38": "电视剧资源按季聚合，冲突同集自动选择最高画质；大季按首、中、末代表集实测并按该结果排序，未抽样集明确标记，资源搜索按媒体类型过滤，季订阅不再只刷新首集。",
       "0.4.37": "非标准视频高度按首帧实测值显示；订阅刷新与 MoviePilot 原生一致，同时处理订阅中（R）和待定（P）状态。",
       "0.4.36": "原生资源按首个视频流标注实际分辨率并优先展示高画质；自动订阅在多个匹配来源中优先选择已验证的高分辨率资源。",
@@ -519,8 +520,9 @@
       "0.3.3": "移除独立 LunaTV 订阅导航，订阅统一使用 MoviePilot 原生探索与订阅页面。",
       "0.3.2": "精简插件设置，目录、智能助手、TMDB、整理和媒体库均强制复用 MoviePilot 原生配置；LunaTV 仅保留源适配与可选目录覆盖。",
       "0.3.1": "搜索结果显示默认 TMDB 关联并支持重新搜索候选与手动切换，平铺多季可按所选作品的季集数安全映射。",
-      "0.3.0": "复用 MoviePilot 系统目录与媒体库路径，加入 TMDB 自动关联和多季边界保护；规范化 CMS 标题、恢复中断队列，并完善说明与诊断。",
-      "0.2.0": "接入 V3 原生探索媒体源、系统智能助手标题清理、可选原生整理链和完成后媒体库刷新；保留串行下载与 STRM。"
+      "0.3.0": "复用 MoviePilot 目录设置，自动关联 TMDB，支持多季边界校验、恢复中断队列和说明诊断页。",
+      "0.2.0": "接入 V3 原生探索媒体源、系统智能助手标题清理、可选原生整理链和完成后媒体库刷新；保留串行下载与 STRM。",
+      "0.1.0": "首版：读取 LunaTV-config，串行搜索苹果 CMS 源，支持订阅队列、本地 m3u8 下载和 STRM。"
     },
     "system_version": ">=3.0.0"
   },

--- a/plugins.v3/lunatvsource/__init__.py
+++ b/plugins.v3/lunatvsource/__init__.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import json
 import base64
 import hashlib
+import inspect
 import logging
 import asyncio
+from contextvars import ContextVar
 import re
 import threading
 import time
@@ -121,7 +123,6 @@ except Exception:  # pragma: no cover - standalone tests
     _HostMediaChain = None
     _HostMetaInfo = None
 
-
 LOGGER = logging.getLogger("LunaTVSource")
 
 
@@ -137,12 +138,25 @@ DEFAULT_SOURCE_ALLOWLIST = (
     "ukuzy0.com,api.ukuapi88.com,www.xinlangzy.com,xinlangapi.com,okzyw.cc"
 )
 PLUGIN_MEDIA_SOURCE = "lunatv"
+_TMDB_CACHE_MAX_ENTRIES = 512
+_QUALITY_CACHE_MAX_ENTRIES = 512
+_RESOURCE_SEARCH_CACHE_MAX_ENTRIES = 128
+_RESOURCE_SEARCH_CACHE_TTL = 30.0
 
 
 # MoviePilot 3.0.0 returns before module resource providers are called when no
 # PT/indexer site is enabled. Keep this compatibility bridge inside the plugin.
 # Existing MoviePilot plugins use the same reversible runtime-wrapper pattern.
-_SEARCH_BRIDGE: Dict[str, Any] = {"owner": None, "chain": None, "originals": {}}
+_SEARCH_BRIDGE: Dict[str, Any] = {
+    "owner": None,
+    "chain": None,
+    "originals": {},
+    "mode": None,
+}
+_SEARCH_PROGRESS_CALLBACK: ContextVar[Optional[Callable[..., None]]] = ContextVar(
+    "lunatv_search_progress_callback",
+    default=None,
+)
 
 
 class _CompatDownloaderTorrent:
@@ -173,39 +187,241 @@ def _bridge_search_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _progress_stream_event(
+    *,
+    finished: int,
+    total: int,
+    text: str,
+    page: Any,
+) -> Optional[Dict[str, Any]]:
+    try:
+        total_value = max(0, int(total))
+        finished_value = max(0, int(finished))
+    except (TypeError, ValueError):
+        return None
+    if total_value:
+        finished_value = min(finished_value, total_value)
+        value = min(100, int(finished_value * 100 / total_value))
+    else:
+        finished_value = 0
+        value = 100
+    return {
+        "type": "progress",
+        "stage": "searching",
+        "value": value,
+        "text": str(text or f"LunaTV 正在搜索源 {finished_value}/{total_value}"),
+        "items": [],
+        "site": "LunaTV",
+        "site_id": None,
+        "page": page,
+        "finished": finished_value,
+        "total": total_value,
+    }
+
+
+def _is_compatible_search_stream(callback: Any) -> bool:
+    return callable(callback) and inspect.isasyncgenfunction(callback)
+
+
+def _make_search_stream_wrapper(
+    owner: "LunaTVSource",
+    stream_original: Callable[..., Any],
+    *,
+    native_plugin_fanout: bool,
+) -> Callable[..., Any]:
+    @wraps(stream_original)
+    async def stream_wrapper(chain: Any, *args: Any, **kwargs: Any):
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        state = {"active": True, "closed": False}
+        page = kwargs.get("page") or 0
+        legacy_plugin = _bridge_owner() if not native_plugin_fanout else None
+
+        def progress_callback(*, finished: int, total: int, text: str) -> None:
+            if not state["active"] or state["closed"]:
+                return
+            event = _progress_stream_event(
+                finished=finished,
+                total=total,
+                text=text,
+                page=page,
+            )
+            if event is None:
+                return
+
+            def enqueue() -> None:
+                if state["active"] and not state["closed"]:
+                    queue.put_nowait(("event", event))
+
+            try:
+                loop.call_soon_threadsafe(enqueue)
+            except RuntimeError:
+                # The event loop may already be closed during shutdown.
+                return
+
+        async def flush_progress_callbacks() -> None:
+            # CMS callbacks come from asyncio.to_thread. Yield once before a
+            # host event so every already-scheduled X/N remains ordered ahead
+            # of append/done.
+            await asyncio.sleep(0)
+
+        async def emit(event: Any, *, close_progress: bool = False) -> None:
+            await flush_progress_callbacks()
+            if close_progress:
+                state["active"] = False
+            queue.put_nowait(("event", event))
+
+        async def pump() -> None:
+            token = _SEARCH_PROGRESS_CALLBACK.set(progress_callback)
+            try:
+                if native_plugin_fanout:
+                    async for event in stream_original(chain, *args, **kwargs):
+                        await emit(
+                            event,
+                            close_progress=isinstance(event, dict)
+                            and event.get("type") == "done",
+                        )
+                else:
+                    done_event = None
+                    async for event in stream_original(chain, *args, **kwargs):
+                        if isinstance(event, dict) and event.get("type") == "done":
+                            done_event = event
+                            continue
+                        await emit(event)
+
+                    plugin_items: List[Any] = []
+                    if legacy_plugin:
+                        try:
+                            plugin_items = await legacy_plugin.async_search_torrents(
+                                **_bridge_search_kwargs(kwargs)
+                            )
+                        except Exception as exc:
+                            legacy_plugin._logger.warning(
+                                "LunaTV 原生流式资源搜索追加失败：%s",
+                                exc,
+                            )
+
+                    if plugin_items:
+                        await emit(
+                            {
+                                "type": "append",
+                                "stage": "searching",
+                                "value": 100,
+                                "text": f"LunaTV 返回 {len(plugin_items)} 条资源",
+                                "site": "LunaTV",
+                                "site_id": None,
+                                "page": page,
+                                "finished": 0,
+                                "total": 0,
+                                "total_items": len(plugin_items),
+                                "items": plugin_items,
+                            }
+                        )
+                    final = dict(done_event or {})
+                    final.update(
+                        {
+                            "type": "done",
+                            "stage": final.get("stage", "searching"),
+                            "value": 100,
+                            "items": [],
+                        }
+                    )
+                    if plugin_items:
+                        final["text"] = (
+                            f"资源搜索完成，LunaTV 返回 {len(plugin_items)} 条资源"
+                        )
+                    await emit(final, close_progress=True)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                owner._logger.warning("LunaTV 原生流式资源搜索失败：%s", exc)
+                queue.put_nowait(("error", exc))
+            finally:
+                _SEARCH_PROGRESS_CALLBACK.reset(token)
+                state["active"] = False
+                queue.put_nowait(("end", None))
+
+        pump_task = asyncio.create_task(pump())
+        try:
+            while True:
+                kind, payload = await queue.get()
+                if kind == "end":
+                    break
+                if kind == "error":
+                    raise payload
+                yield payload
+        finally:
+            state["active"] = False
+            state["closed"] = True
+            if not pump_task.done():
+                pump_task.cancel()
+            try:
+                await pump_task
+            except asyncio.CancelledError:
+                pass
+
+    return stream_wrapper
+
+
 def _install_search_bridge(owner: "LunaTVSource") -> None:
-    _SEARCH_BRIDGE["owner"] = owner
     try:
         from app.chain.search import SearchChain
     except Exception as exc:  # pragma: no cover - MoviePilot runtime only
         owner._logger.warning("LunaTV 原生资源搜索桥接不可用：%s", exc)
         return
-    # Newer MoviePilot V3 releases dispatch plugin resource providers once via
-    # SearchChain.search_plugin_torrents/async_search_plugin_torrents. Wrapping
-    # the private fan-out methods there would query this plugin twice. Keep the
-    # reversible wrapper only for early V3 releases that lacked that native
-    # dispatch path.
-    if (
+
+    native_plugin_fanout = (
         callable(getattr(SearchChain, "search_plugin_torrents", None))
         and callable(getattr(SearchChain, "async_search_plugin_torrents", None))
-    ):
-        _restore_search_bridge(owner, force=True)
-        owner._logger.info("MoviePilot 已原生支持插件资源搜索，无需启用兼容桥")
-        return
+    )
+    mode = "native_stream" if native_plugin_fanout else "legacy"
     if _SEARCH_BRIDGE.get("chain") is SearchChain and _SEARCH_BRIDGE.get("originals"):
-        return
+        if _SEARCH_BRIDGE.get("mode") == mode:
+            _SEARCH_BRIDGE["owner"] = owner
+            return
+        _restore_search_bridge(owner, force=True)
+    elif _SEARCH_BRIDGE.get("chain") is not None and _SEARCH_BRIDGE.get("originals"):
+        _restore_search_bridge(owner, force=True)
 
-    originals: Dict[str, Callable[..., Any]] = {}
+    _SEARCH_BRIDGE["owner"] = owner
     sync_name = "_SearchChain__search_all_sites"
     async_name = "_SearchChain__async_search_all_sites"
     stream_name = "_SearchChain__async_search_all_sites_stream"
+    stream_original = getattr(SearchChain, stream_name, None)
 
+    if native_plugin_fanout:
+        if not _is_compatible_search_stream(stream_original):
+            owner._logger.info(
+                "MoviePilot 原生插件资源搜索已启用，但搜索流接口不兼容；保持原生行为"
+            )
+            return
+        originals = {stream_name: stream_original}
+        setattr(
+            SearchChain,
+            stream_name,
+            _make_search_stream_wrapper(
+                owner,
+                stream_original,
+                native_plugin_fanout=True,
+            ),
+        )
+        _SEARCH_BRIDGE.update(
+            {
+                "chain": SearchChain,
+                "originals": originals,
+                "mode": mode,
+            }
+        )
+        owner._logger.info("LunaTV 已接入 MoviePilot 原生搜索流进度")
+        return
+
+    originals: Dict[str, Callable[..., Any]] = {}
     sync_original = getattr(SearchChain, sync_name, None)
     if callable(sync_original):
         originals[sync_name] = sync_original
 
         @wraps(sync_original)
-        def sync_wrapper(chain, *args, **kwargs):
+        def sync_wrapper(chain: Any, *args: Any, **kwargs: Any) -> List[Any]:
             native = list(sync_original(chain, *args, **kwargs) or [])
             plugin = _bridge_owner()
             if plugin:
@@ -222,70 +438,66 @@ def _install_search_bridge(owner: "LunaTVSource") -> None:
         originals[async_name] = async_original
 
         @wraps(async_original)
-        async def async_wrapper(chain, *args, **kwargs):
+        async def async_wrapper(chain: Any, *args: Any, **kwargs: Any) -> List[Any]:
             native = list(await async_original(chain, *args, **kwargs) or [])
             plugin = _bridge_owner()
             if plugin:
                 try:
-                    native.extend(await plugin.async_search_torrents(**_bridge_search_kwargs(kwargs)))
+                    native.extend(
+                        await plugin.async_search_torrents(
+                            **_bridge_search_kwargs(kwargs)
+                        )
+                    )
                 except Exception as exc:
                     plugin._logger.warning("LunaTV 原生异步资源搜索追加失败：%s", exc)
             return native
 
         setattr(SearchChain, async_name, async_wrapper)
 
-    stream_original = getattr(SearchChain, stream_name, None)
-    if callable(stream_original):
+    if _is_compatible_search_stream(stream_original):
         originals[stream_name] = stream_original
+        setattr(
+            SearchChain,
+            stream_name,
+            _make_search_stream_wrapper(
+                owner,
+                stream_original,
+                native_plugin_fanout=False,
+            ),
+        )
+    elif callable(stream_original):
+        owner._logger.warning(
+            "LunaTV 原生流式资源搜索桥接未安装：目标不是异步生成器"
+        )
 
-        @wraps(stream_original)
-        async def stream_wrapper(chain, *args, **kwargs):
-            done_event = None
-            async for event in stream_original(chain, *args, **kwargs):
-                if event.get("type") == "done":
-                    done_event = event
-                    continue
-                yield event
-            plugin = _bridge_owner()
-            plugin_items = []
-            if plugin:
-                try:
-                    plugin_items = await plugin.async_search_torrents(
-                        **_bridge_search_kwargs(kwargs)
-                    )
-                except Exception as exc:
-                    plugin._logger.warning("LunaTV 原生流式资源搜索追加失败：%s", exc)
-            if plugin_items:
-                yield {
-                    "type": "append", "stage": "searching", "value": 100,
-                    "text": f"LunaTV 返回 {len(plugin_items)} 条资源",
-                    "items": plugin_items, "site": "LunaTV", "site_id": None,
-                    "page": kwargs.get("page") or 0, "finished": 0, "total": 0,
-                    "total_items": len(plugin_items),
-                }
-            final = dict(done_event or {})
-            final.update({"type": "done", "stage": final.get("stage", "searching"),
-                          "value": 100, "items": []})
-            if plugin_items:
-                final["text"] = f"资源搜索完成，LunaTV 返回 {len(plugin_items)} 条资源"
-            yield final
-
-        setattr(SearchChain, stream_name, stream_wrapper)
-
-    _SEARCH_BRIDGE.update({"chain": SearchChain, "originals": originals})
-    if originals:
-        owner._logger.info("LunaTV 原生资源搜索桥接已启用（%s）", ", ".join(originals))
+    if not originals:
+        return
+    _SEARCH_BRIDGE.update(
+        {
+            "chain": SearchChain,
+            "originals": originals,
+            "mode": mode,
+        }
+    )
+    owner._logger.info("LunaTV 已启用 MoviePilot 搜索兼容桥：%s", ", ".join(originals))
 
 
 def _restore_search_bridge(owner: "LunaTVSource", force: bool = False) -> None:
     if not force and _SEARCH_BRIDGE.get("owner") is not owner:
         return
     chain = _SEARCH_BRIDGE.get("chain")
-    for name, original in dict(_SEARCH_BRIDGE.get("originals") or {}).items():
-        if chain is not None:
+    originals = dict(_SEARCH_BRIDGE.get("originals") or {})
+    if chain:
+        for name, original in originals.items():
             setattr(chain, name, original)
-    _SEARCH_BRIDGE.update({"owner": None, "chain": None, "originals": {}})
-
+    _SEARCH_BRIDGE.update(
+        {
+            "owner": None,
+            "chain": None,
+            "originals": {},
+            "mode": None,
+        }
+    )
 
 def _bool(value: Any, default: bool = False) -> bool:
     if isinstance(value, str):
@@ -328,8 +540,8 @@ class LunaTVSource(_PluginBase):
 
     plugin_name = "LunaTV 资源订阅"
     plugin_desc = "接入 LunaTV/MoonTV 苹果 CMS 资源，复用 MoviePilot 原生搜索、订阅、目录、整理与媒体库链路。"
-    plugin_icon = "lunatvsource.png"
-    plugin_version = "0.4.38"
+    plugin_icon = "https://raw.githubusercontent.com/OneBigMoon/moviepilot-v3-lunatv-source/master/icons/lunatvsource.png"
+    plugin_version = "0.4.39"
     plugin_author = "OneBigMoon"
     author_url = "https://github.com/OneBigMoon"
     plugin_config_prefix = "lunatvsource_"
@@ -374,7 +586,10 @@ class LunaTVSource(_PluginBase):
             on_complete=self._record_completion,
         )
         with self._tmdb_cache_lock:
-            self._tmdb_cache = dict(self.get_data("tmdb_match_cache_v1") or {})
+            loaded_tmdb_cache = dict(self.get_data("tmdb_match_cache_v1") or {})
+            self._tmdb_cache = dict(
+                list(loaded_tmdb_cache.items())[-_TMDB_CACHE_MAX_ENTRIES:]
+            )
         with self._resource_search_lock:
             self._resource_search_cache = {}
         if self._enabled:
@@ -475,6 +690,16 @@ class LunaTVSource(_PluginBase):
                             "model": "source_allowlist",
                             "label": "启用资源站（逗号分隔）",
                             "placeholder": DEFAULT_SOURCE_ALLOWLIST,
+                        },
+                    },
+                    {
+                        "component": "VTextField",
+                        "props": {
+                            "model": "probe_allowed_private_ranges",
+                            "label": "清晰度探测允许网段（可选）",
+                            "placeholder": "10.0.0.0/8,192.168.0.0/16",
+                            "hint": "默认拒绝内网播放地址；仅当可信 CMS 返回内网媒体时填写 CIDR。",
+                            "persistentHint": True,
                         },
                     },
                     {
@@ -595,6 +820,7 @@ class LunaTVSource(_PluginBase):
             "enabled": False,
             "config_url": DEFAULT_CONFIG_URL,
             "source_allowlist": "",
+            "probe_allowed_private_ranges": "",
             "mode": "download",
             "source_strategy": "first",
             "download_root": "",
@@ -634,6 +860,16 @@ class LunaTVSource(_PluginBase):
                         },
                     },
                     {
+                        "component": "VTextField",
+                        "props": {
+                            "model": "probe_allowed_private_ranges",
+                            "label": "清晰度探测允许网段（可选）",
+                            "placeholder": "10.0.0.0/8,192.168.0.0/16",
+                            "hint": "默认拒绝内网播放地址；仅当可信 CMS 返回内网媒体时填写 CIDR。",
+                            "persistentHint": True,
+                        },
+                    },
+                    {
                         "component": "VAlert",
                         "props": {
                             "type": "info",
@@ -647,6 +883,7 @@ class LunaTVSource(_PluginBase):
             "enabled": False,
             "config_url": DEFAULT_CONFIG_URL,
             "source_allowlist": "",
+            "probe_allowed_private_ranges": "",
             "source_strategy": "first",
             "download_root": "",
             "use_moviepilot_dirs": True,
@@ -952,9 +1189,17 @@ class LunaTVSource(_PluginBase):
                 key = (result.source_key, result.source_name, title, result.year, season)
                 group = groups.get(key)
                 if group is None:
-                    group = {"result": result, "episodes": {}}
+                    group = {
+                        "result": result,
+                        "episodes": {},
+                        "season_ambiguous": bool(result.season_ambiguous),
+                    }
                     groups[key] = group
                     order.append(("group", key))
+                else:
+                    group["season_ambiguous"] = bool(
+                        group["season_ambiguous"] and result.season_ambiguous
+                    )
                 for episode in result.episodes:
                     if season and (not episode.season_known or episode.season != season):
                         continue
@@ -990,7 +1235,7 @@ class LunaTVSource(_PluginBase):
                     episodes=episodes,
                     detail=base.detail,
                     season_range=(season, season) if season else (0, 0),
-                    season_ambiguous=base.season_ambiguous,
+                    season_ambiguous=bool(group["season_ambiguous"]),
                 )
             )
         return cards
@@ -1136,9 +1381,7 @@ class LunaTVSource(_PluginBase):
                 candidates = self._search_tmdb_candidates(query, result.year, result.media_type)
                 if candidates:
                     association["candidates"] = candidates
-                    with self._tmdb_cache_lock:
-                        self._tmdb_cache[cache_key] = dict(association)
-                        self.save_data("tmdb_match_cache_v1", dict(self._tmdb_cache))
+                    self._store_tmdb_cache_entry(cache_key, association)
             return association
         if _HostMediaChain is None or _HostMetaInfo is None or self._tmdb_source() is None:
             return {"status": "unavailable", "query": query}
@@ -1180,10 +1423,22 @@ class LunaTVSource(_PluginBase):
         except Exception as exc:
             self._logger.debug("TMDB 默认关联失败 title=%s: %s", query, exc)
             association = {"status": "error", "query": query, "message": str(exc)}
-        with self._tmdb_cache_lock:
-            self._tmdb_cache[cache_key] = dict(association)
-            self.save_data("tmdb_match_cache_v1", dict(self._tmdb_cache))
+        self._store_tmdb_cache_entry(cache_key, association)
         return association
+
+    def _store_tmdb_cache_entry(
+        self,
+        cache_key: str,
+        association: Dict[str, Any],
+    ) -> None:
+        with self._tmdb_cache_lock:
+            self._tmdb_cache.pop(cache_key, None)
+            self._tmdb_cache[cache_key] = dict(association)
+            overflow = len(self._tmdb_cache) - _TMDB_CACHE_MAX_ENTRIES
+            for key in list(self._tmdb_cache)[:max(0, overflow)]:
+                self._tmdb_cache.pop(key, None)
+            snapshot = dict(self._tmdb_cache)
+        self.save_data("tmdb_match_cache_v1", snapshot)
 
     @staticmethod
     def _media_candidate(media: Any) -> Optional[Dict[str, Any]]:
@@ -1591,8 +1846,26 @@ class LunaTVSource(_PluginBase):
                 str(payload.get("year") or ""),
                 str(payload.get("media_type") or ""),
             )
-            results = self._client().search(search_query, stop_after_first_source=True)
-            return {"success": True, "data": [self._result_payload(item) for item in results]}
+            results = self._season_media_cards(
+                self._client().search(search_query, stop_after_first_source=True)
+            )
+            data = []
+            for result in results:
+                item = self._result_payload(result)
+                if result.media_type == "tv":
+                    seasons = sorted(
+                        {
+                            int(episode.season or 1)
+                            for episode in result.episodes
+                            if episode.season_known
+                        }
+                    )
+                    if len(seasons) == 1:
+                        item["title"] = (
+                            f"{normalize_media_title(result.title)} · 第{seasons[0]}季"
+                        )
+                data.append(item)
+            return {"success": True, "data": data}
         except Exception as exc:
             self._logger.warning("LunaTV search failed: %s", exc)
             return {"success": False, "message": f"搜索失败：{exc}", "data": []}
@@ -1694,10 +1967,12 @@ class LunaTVSource(_PluginBase):
         )
         if not queue.enqueue(task):
             return {"success": False, "message": "任务重复，或未配置下载目录", "data": {}}
+        self._start_queue()
         return {"success": True, "message": "已加入串行下载队列", "data": {"task_id": task.task_id}}
 
     def _record_completion(self, task: DownloadTask, output: str) -> None:
-        organize_state = self._native_transfer(task, output)
+        if self._config.get("moviepilot_organize", True):
+            self._native_transfer(task, output)
         # 下载历史始终记录 ffmpeg 的原始产物。若原生整理成功，TransferChain
         # 会自行记录 TransferHistory；这里不能把整理目标伪装成下载源文件。
         self._record_native_history(task, output)
@@ -1964,6 +2239,8 @@ class LunaTVSource(_PluginBase):
                         continue
                     if queue.enqueue(task):
                         queued += 1
+        if queued:
+            self._start_queue()
         return {
             "subscriptions": len(active_subscribes),
             "queued": queued,
@@ -1975,19 +2252,14 @@ class LunaTVSource(_PluginBase):
     def run_queue(self) -> Dict[str, Any]:
         if not self._queue:
             return {"processed": 0}
-        return self._queue.run_one()
+        return {"processed": 0, "scheduled": self._queue.wake()}
 
     def _start_queue(self) -> bool:
         """立即唤醒一次串行队列，避免原生继续操作等待下个定时周期。"""
         queue = self._queue
         if queue is None:
             return False
-        threading.Thread(
-            target=queue.run_one,
-            name="lunatvsource-download",
-            daemon=True,
-        ).start()
-        return True
+        return queue.wake()
 
     def get_media_source(self) -> List[Dict[str, Any]]:
         """LunaTV participates in the global search instead of adding an empty Explore tab."""
@@ -2335,9 +2607,20 @@ class LunaTVSource(_PluginBase):
 
         first = results[0] if results else None
         requested_type = _enum_value(mtype)
+        explicit_type = requested_type in {
+            "电视剧",
+            "tv",
+            "series",
+            "show",
+            "tvshow",
+            "电影",
+            "movie",
+            "film",
+            "movies",
+        }
         media_type = (
             _media_type_value(mtype)
-            if requested_type
+            if explicit_type
             else (first.media_type if first else "movie")
         )
         return CmsResult(
@@ -2366,6 +2649,7 @@ class LunaTVSource(_PluginBase):
 
         now = time.monotonic()
         with self._quality_cache_lock:
+            self._prune_quality_cache(now)
             cached = self._quality_cache.get(url)
             if cached and now - cached[0] < (3600 if cached[1] else 300):
                 return cached[1]
@@ -2377,10 +2661,56 @@ class LunaTVSource(_PluginBase):
             url,
             ffmpeg_path=str(self._config.get("ffmpeg_path") or "ffmpeg"),
             timeout=timeout,
+            allowed_private_ranges=self._probe_allowed_private_ranges(),
         )
         with self._quality_cache_lock:
             self._quality_cache[url] = (time.monotonic(), height)
+            self._prune_quality_cache(time.monotonic())
         return height
+
+    def _probe_allowed_private_ranges(self) -> Tuple[str, ...]:
+        configured = self._config.get("probe_allowed_private_ranges")
+        if isinstance(configured, str):
+            values = re.split(r"[,;\s]+", configured)
+        elif isinstance(configured, (list, tuple, set)):
+            values = list(configured)
+        else:
+            values = []
+        return tuple(str(value).strip() for value in values if str(value).strip())
+
+    def _prune_quality_cache(self, now: float) -> None:
+        expired = [
+            key
+            for key, (created_at, height) in self._quality_cache.items()
+            if now - created_at >= (3600 if height else 300)
+        ]
+        for key in expired:
+            self._quality_cache.pop(key, None)
+        overflow = len(self._quality_cache) - _QUALITY_CACHE_MAX_ENTRIES
+        if overflow > 0:
+            oldest = sorted(
+                self._quality_cache,
+                key=lambda key: self._quality_cache[key][0],
+            )[:overflow]
+            for key in oldest:
+                self._quality_cache.pop(key, None)
+
+    def _prune_resource_search_cache(self, now: float) -> None:
+        expired = [
+            key
+            for key, (created_at, _) in self._resource_search_cache.items()
+            if now - created_at >= _RESOURCE_SEARCH_CACHE_TTL
+        ]
+        for key in expired:
+            self._resource_search_cache.pop(key, None)
+        overflow = len(self._resource_search_cache) - _RESOURCE_SEARCH_CACHE_MAX_ENTRIES
+        if overflow > 0:
+            oldest = sorted(
+                self._resource_search_cache,
+                key=lambda key: self._resource_search_cache[key][0],
+            )[:overflow]
+            for key in oldest:
+                self._resource_search_cache.pop(key, None)
 
     def _probe_resource_urls(self, urls: List[str]) -> Dict[str, int]:
         unique_urls = list(dict.fromkeys(url for url in urls if url))
@@ -2429,7 +2759,12 @@ class LunaTVSource(_PluginBase):
         )
         return [item for _, item in ranked]
 
-    def _resource_torrents(self, keyword: str, mtype: Any = None) -> List[Any]:
+    def _resource_torrents(
+        self,
+        keyword: str,
+        mtype: Any = None,
+        progress_callback: Optional[Callable[..., None]] = None,
+    ) -> List[Any]:
         """把 CMS m3u8 条目投影为 MoviePilot 原生 TorrentInfo。"""
         torrent_info_type = _HostTorrentInfo or (
             getattr(_schemas, "TorrentInfo", None) if _schemas is not None else None
@@ -2445,21 +2780,43 @@ class LunaTVSource(_PluginBase):
         )
         now = time.monotonic()
         with self._resource_search_lock:
+            self._prune_resource_search_cache(now)
             cached = self._resource_search_cache.get(cache_key)
-            if cached and now - cached[0] < 30:
+            # A progress callback requires a real source pass; cached results
+            # cannot truthfully report per-source completion.
+            if (
+                progress_callback is None
+                and cached
+                and now - cached[0] < _RESOURCE_SEARCH_CACHE_TTL
+            ):
                 return list(cached[1])
 
         # 第三方 CMS、AI 与 TMDB 请求可能较慢，不能在请求期间占用缓存锁；
         # 否则插件更新/停用时会一直等待正在进行的原生资源搜索。
         search_query, _ = (self._ai or AiTitleNormalizer(False)).normalize(keyword)
-        results = self._client().search(
-            search_query,
-            limit=50,
-            source_limit=3,
-            stop_after_first_source=False,
-            require_playable=True,
-            max_workers=8,
-        )
+        def on_progress(*, finished: int, total: int, text: str) -> None:
+            if progress_callback is None:
+                return
+            try:
+                progress_callback(
+                    finished=int(finished),
+                    total=int(total),
+                    text=f"LunaTV 正在搜索源 {int(finished)}/{int(total)}",
+                )
+            except Exception:
+                # Host progress handlers must never break CMS search.
+                pass
+
+        search_kwargs: Dict[str, Any] = {
+            "limit": 50,
+            "source_limit": 3,
+            "stop_after_first_source": False,
+            "require_playable": True,
+            "max_workers": 8,
+        }
+        if progress_callback is not None:
+            search_kwargs["progress_callback"] = on_progress
+        results = self._client().search(search_query, **search_kwargs)
         requested_media_type = (
             "tv"
             if requested_type in {"电视剧", "tv", "series", "show", "tvshow"}
@@ -2616,27 +2973,22 @@ class LunaTVSource(_PluginBase):
         for row in single_rows:
             row["probe_url"] = row["payload"]["url"]
 
-        sampled_urls: List[str] = []
+        season_probe_urls: List[str] = []
         for group in group_rows:
-            group_episodes = group["sorted_episodes"]
-            sample_indexes = (
-                range(len(group_episodes))
-                if len(group_episodes) <= 5
-                else (0, len(group_episodes) // 2, len(group_episodes) - 1)
+            season_probe_urls.extend(
+                episode["url"]
+                for episode in group["sorted_episodes"]
+                if episode["url"]
             )
-            seen_sample_urls: set[str] = set()
-            for index in sample_indexes:
-                episode = group_episodes[index]
-                url = episode["url"]
-                if not url or url in seen_sample_urls:
-                    continue
-                seen_sample_urls.add(url)
-                sampled_urls.append(url)
 
         quality_heights = dict(conflict_heights)
         quality_heights.update(
             self._probe_resource_urls(
-                [url for url in dict.fromkeys(sampled_urls) if url not in quality_heights]
+                [
+                    url
+                    for url in dict.fromkeys(season_probe_urls)
+                    if url not in quality_heights
+                ]
             )
         )
         quality_heights.update(
@@ -2649,27 +3001,19 @@ class LunaTVSource(_PluginBase):
             )
         )
 
-        season_probed_urls = set(conflict_probe_urls)
-        season_probed_urls.update(sampled_urls)
         for group in group_rows:
             episode_heights: List[int] = []
-            sampled_episodes: List[int] = []
+            probed_episodes: List[int] = []
             for episode in group["sorted_episodes"]:
-                if episode["url"] in season_probed_urls:
-                    episode_height = quality_heights.get(episode["url"], 0)
-                    episode["resolution"] = stream_quality_label(episode_height)
-                    episode["resolution_height"] = episode_height
-                    episode_heights.append(episode_height)
-                    sampled_episodes.append(int(episode["episode"]))
-                else:
-                    episode["resolution"] = "未探测"
-                    episode["resolution_height"] = 0
+                episode_height = quality_heights.get(episode["url"], 0)
+                episode["resolution"] = stream_quality_label(episode_height)
+                episode["resolution_height"] = episode_height
+                episode_heights.append(episode_height)
+                probed_episodes.append(int(episode["episode"]))
             group["resolution_height"] = min(episode_heights, default=0)
-            group["resolution_scope"] = (
-                "full" if len(group["sorted_episodes"]) <= 5 else "sampled"
-            )
-            group["resolution_sample_count"] = len(sampled_episodes)
-            group["resolution_sampled_episodes"] = sampled_episodes
+            group["resolution_scope"] = "full"
+            group["resolution_probed_episode_count"] = len(probed_episodes)
+            group["resolution_probed_episodes"] = probed_episodes
 
         torrents: List[Any] = []
         for group in group_rows:
@@ -2684,19 +3028,15 @@ class LunaTVSource(_PluginBase):
             payload["resolution"] = quality
             payload["resolution_height"] = height
             payload["resolution_scope"] = group["resolution_scope"]
-            payload["resolution_sample_count"] = group["resolution_sample_count"]
-            payload["resolution_sampled_episodes"] = group[
-                "resolution_sampled_episodes"
+            payload["resolution_probed_episode_count"] = group[
+                "resolution_probed_episode_count"
             ]
+            payload["resolution_probed_episodes"] = group["resolution_probed_episodes"]
             title = group["title"]
             if group["year"]:
                 title = f"{title} ({group['year']})"
             title = f"{title} · 第{season}季 · {quality}"
-            measurement = (
-                f"全{count}集实测"
-                if group["resolution_sample_count"] == count
-                else f"抽样{group['resolution_sample_count']}集实测"
-            )
+            measurement = f"全{count}集实测"
             torrents.append(torrent_info_type(
                 site_name=group["site_name"],
                 title=title,
@@ -2746,6 +3086,7 @@ class LunaTVSource(_PluginBase):
         torrents.sort(key=lambda item: int(getattr(item, "pri_order", 0) or 0), reverse=True)
         with self._resource_search_lock:
             self._resource_search_cache[cache_key] = (time.monotonic(), torrents)
+            self._prune_resource_search_cache(time.monotonic())
         return list(torrents)
 
     def search_torrents(
@@ -2754,6 +3095,7 @@ class LunaTVSource(_PluginBase):
         keyword: str,
         mtype: Any = None,
         page: Optional[int] = 0,
+        progress_callback: Optional[Callable[..., None]] = None,
         **_: Any,
     ) -> List[Any]:
         """参与每次原生站点搜索；固定站点名使多站点调用结果可由宿主去重。"""
@@ -2761,12 +3103,22 @@ class LunaTVSource(_PluginBase):
         if not self._enabled or int(page or 0) > 0 or not str(keyword or "").strip():
             return []
         try:
-            return self._resource_torrents(str(keyword).strip(), mtype=mtype)
+            if progress_callback is None:
+                return self._resource_torrents(str(keyword).strip(), mtype=mtype)
+            return self._resource_torrents(
+                str(keyword).strip(),
+                mtype=mtype,
+                progress_callback=progress_callback,
+            )
         except Exception as exc:
             self._logger.warning("LunaTV 原生资源搜索失败：%s", exc)
             return []
 
     async def async_search_torrents(self, **kwargs: Any) -> List[Any]:
+        if "progress_callback" not in kwargs:
+            progress_callback = _SEARCH_PROGRESS_CALLBACK.get()
+            if progress_callback is not None:
+                kwargs["progress_callback"] = progress_callback
         return await asyncio.to_thread(self.search_torrents, **kwargs)
 
     def download(
@@ -2855,6 +3207,7 @@ class LunaTVSource(_PluginBase):
             if invalid_count:
                 return "LunaTVSource", None, None, "LunaTV 下载参数无效"
             return "LunaTVSource", None, None, "任务已在串行队列或历史记录中"
+        self._start_queue()
         total = len(enqueued_ids)
         message = f"已排队 {total} 集" if total > 1 else ""
         if duplicate_count:

--- a/plugins.v3/lunatvsource/cms.py
+++ b/plugins.v3/lunatvsource/cms.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+import http.client
+import ipaddress
 import json
 import re
+import socket
+import ssl
 import subprocess
+import tempfile
+import time
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field, replace
@@ -27,12 +33,55 @@ _CN_SEASON_RE = re.compile(
     r"(?:第\s*)(?P<season>[一二两三四五六七八九十百千万]+)\s*季",
     re.IGNORECASE,
 )
+_TV_TYPE_NAMES = frozenset(
+    {
+        "电视剧",
+        "连续剧",
+        "剧集",
+        "国产剧",
+        "大陆剧",
+        "内地剧",
+        "华语剧",
+        "欧美剧",
+        "美剧",
+        "英剧",
+        "韩剧",
+        "日剧",
+        "泰剧",
+        "港剧",
+        "香港剧",
+        "台剧",
+        "台湾剧",
+        "日韩剧",
+        "海外剧",
+        "其他剧",
+        "短剧",
+        "微短剧",
+        "网络剧",
+        "情景剧",
+        "动画剧",
+    }
+)
 _SEASON_RANGE_RE = re.compile(
     r"(?:第\s*)?(?P<start>\d{1,3})\s*[-~至]\s*(?P<end>\d{1,3})\s*季|"
     r"S(?P<sstart>\d{1,3})\s*[-~至]\s*S?(?P<send>\d{1,3})",
     re.IGNORECASE,
 )
 _STREAM_RESOLUTION_RE = re.compile(r"(?P<width>\d{2,5})x(?P<height>\d{2,5})", re.IGNORECASE)
+_MASTER_RESOLUTION_RE = re.compile(
+    r"^#EXT-X-STREAM-INF:[^\r\n]*\bRESOLUTION\s*=\s*"
+    r"(?P<width>\d{2,5})x(?P<height>\d{2,5})",
+    re.IGNORECASE | re.MULTILINE,
+)
+_HLS_URI_RE = re.compile(
+    r"\bURI\s*=\s*(?:\"(?P<quoted>[^\"]+)\"|(?P<plain>[^,\s]+))",
+    re.IGNORECASE,
+)
+_HLS_BANDWIDTH_RE = re.compile(r"\bBANDWIDTH\s*=\s*(?P<value>\d+)", re.IGNORECASE)
+_PROBE_REDIRECT_CODES = {301, 302, 303, 307, 308}
+_PROBE_MAX_REDIRECTS = 5
+_PROBE_PLAYLIST_BYTES = 256 * 1024
+_PROBE_MEDIA_BYTES = 4 * 1024 * 1024
 
 
 def _season_range(label: str) -> Tuple[int, int]:
@@ -86,7 +135,9 @@ def stream_quality_label(height: int) -> str:
     """Return a compact quality label from the actual video height."""
 
     value = max(0, int(height or 0))
-    if value >= 2160:
+    if value == 4320:
+        return "8K"
+    if value == 2160:
         return "4K"
     if value > 0:
         return f"{value}P"
@@ -102,19 +153,240 @@ def _resolution_height(value: str) -> int:
     return max(heights, default=0)
 
 
-def _playlist_resolution_height(url: str, timeout: float) -> int:
-    request = urllib.request.Request(
-        url,
-        headers={
-            "User-Agent": "LunaTVSource/0.1 MoviePilot",
-            "Accept": "application/vnd.apple.mpegurl, application/x-mpegURL, */*",
-        },
+def _master_playlist_height(playlist: str) -> int:
+    heights = [
+        int(match.group("height"))
+        for match in _MASTER_RESOLUTION_RE.finditer(playlist or "")
+        if 100 <= int(match.group("height")) <= 10000
+    ]
+    return max(heights, default=0)
+
+
+def _resolve_public_probe_target(
+    url: str,
+    allowed_private_ranges: Iterable[str] = (),
+) -> Tuple[urllib.parse.ParseResult, str, int]:
+    parsed = urllib.parse.urlparse(str(url or "").strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("unsupported probe URL")
+    if parsed.username or parsed.password:
+        raise ValueError("probe URL credentials are not allowed")
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError as exc:
+        raise ValueError("invalid probe URL port") from exc
+
+    hostname = parsed.hostname.split("%", 1)[0]
+    try:
+        addresses = [ipaddress.ip_address(hostname)]
+    except ValueError:
+        try:
+            address_infos = socket.getaddrinfo(
+                hostname,
+                port,
+                type=socket.SOCK_STREAM,
+            )
+        except OSError as exc:
+            raise ValueError("probe host cannot be resolved") from exc
+        addresses = []
+        for address_info in address_infos:
+            candidate = str(address_info[4][0]).split("%", 1)[0]
+            try:
+                address = ipaddress.ip_address(candidate)
+            except ValueError:
+                continue
+            if address not in addresses:
+                addresses.append(address)
+    private_networks = []
+    for value in allowed_private_ranges or ():
+        try:
+            private_networks.append(ipaddress.ip_network(str(value).strip(), strict=False))
+        except ValueError:
+            continue
+    allowed_addresses = [address for address in addresses if address.is_global]
+    allowed_addresses.extend(
+        address
+        for address in addresses
+        if any(address in network for network in private_networks)
+        and address not in allowed_addresses
     )
-    with urllib.request.urlopen(request, timeout=min(max(timeout, 1.0), 3.0)) as response:
-        playlist = response.read(256 * 1024).decode("utf-8", errors="replace")
+    if not allowed_addresses:
+        raise ValueError("probe URL resolves to a non-public address")
+    return parsed, str(allowed_addresses[0]), port
+
+
+def _is_public_probe_url(url: str, allowed_private_ranges: Iterable[str] = ()) -> bool:
+    try:
+        _resolve_public_probe_target(url, allowed_private_ranges)
+    except ValueError:
+        return False
+    return True
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPS connection pinned to the address already approved by DNS policy."""
+
+    def __init__(self, hostname: str, address: str, port: int, timeout: float):
+        super().__init__(
+            hostname,
+            port=port,
+            timeout=timeout,
+            context=ssl.create_default_context(),
+        )
+        self._probe_address = address
+
+    def connect(self) -> None:
+        self.sock = socket.create_connection(
+            (self._probe_address, self.port),
+            self.timeout,
+        )
+        self.sock = self._context.wrap_socket(self.sock, server_hostname=self.host)
+
+
+def _probe_host_header(parsed: urllib.parse.ParseResult, port: int) -> str:
+    hostname = parsed.hostname or ""
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    default_port = 443 if parsed.scheme == "https" else 80
+    return hostname if port == default_port else f"{hostname}:{port}"
+
+
+def _fetch_public_url(
+    url: str,
+    timeout: float,
+    limit: int,
+    allowed_private_ranges: Iterable[str] = (),
+) -> Tuple[bytes, str]:
+    """Fetch a bounded public URL while pinning DNS and validating redirects."""
+
+    current_url = str(url or "").strip()
+    request_timeout = min(max(float(timeout or 8.0), 1.0), 15.0)
+    for _ in range(_PROBE_MAX_REDIRECTS + 1):
+        parsed, address, port = _resolve_public_probe_target(
+            current_url,
+            allowed_private_ranges,
+        )
+        connection: http.client.HTTPConnection
+        if parsed.scheme == "https":
+            connection = _PinnedHTTPSConnection(
+                parsed.hostname or "",
+                address,
+                port,
+                request_timeout,
+            )
+        else:
+            connection = http.client.HTTPConnection(address, port, timeout=request_timeout)
+        path = urllib.parse.urlunparse(
+            ("", "", parsed.path or "/", parsed.params, parsed.query, "")
+        )
+        try:
+            connection.request(
+                "GET",
+                path,
+                headers={
+                    "Host": _probe_host_header(parsed, port),
+                    "User-Agent": "LunaTVSource/0.1 MoviePilot",
+                    "Accept": "application/vnd.apple.mpegurl, application/x-mpegURL, */*",
+                    "Connection": "close",
+                },
+            )
+            response = connection.getresponse()
+            if response.status in _PROBE_REDIRECT_CODES:
+                location = response.getheader("Location")
+                if not location:
+                    raise OSError("probe redirect has no target")
+                current_url = urllib.parse.urljoin(current_url, location)
+                continue
+            if response.status < 200 or response.status >= 400:
+                raise OSError(f"probe request returned HTTP {response.status}")
+            return response.read(max(1, int(limit)) + 1)[:limit], current_url
+        finally:
+            connection.close()
+    raise OSError("too many probe redirects")
+
+
+def _playlist_followup_urls(playlist: str, base_url: str) -> Tuple[List[str], bool]:
+    lines = [line.strip() for line in (playlist or "").splitlines()]
+    variants: List[Tuple[int, str]] = []
+    for index, line in enumerate(lines):
+        if not line.upper().startswith("#EXT-X-STREAM-INF:"):
+            continue
+        bandwidth_match = _HLS_BANDWIDTH_RE.search(line)
+        bandwidth = int(bandwidth_match.group("value")) if bandwidth_match else 0
+        for candidate in lines[index + 1:]:
+            if not candidate or candidate.startswith("#"):
+                continue
+            variants.append((bandwidth, urllib.parse.urljoin(base_url, candidate)))
+            break
+    if variants:
+        return [max(variants, key=lambda item: item[0])[1]], True
+
+    urls: List[str] = []
+    for line in lines:
+        if line.upper().startswith("#EXT-X-MAP:"):
+            match = _HLS_URI_RE.search(line)
+            if match:
+                urls.append(
+                    urllib.parse.urljoin(
+                        base_url,
+                        match.group("quoted") or match.group("plain") or "",
+                    )
+                )
+            break
+    for line in lines:
+        if line and not line.startswith("#"):
+            urls.append(urllib.parse.urljoin(base_url, line))
+            break
+    return list(dict.fromkeys(url for url in urls if url)), False
+
+
+def _probe_media_sample(
+    url: str,
+    timeout: float,
+    depth: int = 0,
+    allowed_private_ranges: Iterable[str] = (),
+) -> Tuple[int, bytes, str]:
+    payload, final_url = _fetch_public_url(
+        url,
+        timeout,
+        _PROBE_PLAYLIST_BYTES,
+        allowed_private_ranges,
+    )
+    playlist = payload.decode("utf-8", errors="replace")
     if "#EXTM3U" not in playlist:
-        return 0
-    return _resolution_height(playlist)
+        suffix = urllib.parse.urlparse(final_url).path.rpartition(".")[2]
+        return 0, payload, f".{suffix}" if suffix else ".bin"
+
+    height = _master_playlist_height(playlist)
+    if height:
+        return height, b"", ""
+    followups, is_variant = _playlist_followup_urls(playlist, final_url)
+    if is_variant:
+        if depth >= 1 or not followups:
+            return 0, b"", ""
+        return _probe_media_sample(
+            followups[0],
+            timeout,
+            depth + 1,
+            allowed_private_ranges,
+        )
+    if not followups:
+        return 0, b"", ""
+
+    chunks: List[bytes] = []
+    suffix = ".bin"
+    for media_url in followups[:2]:
+        chunk, final_media_url = _fetch_public_url(
+            media_url,
+            timeout,
+            _PROBE_MEDIA_BYTES,
+            allowed_private_ranges,
+        )
+        chunks.append(chunk)
+        extension = urllib.parse.urlparse(final_media_url).path.rpartition(".")[2]
+        if extension:
+            suffix = f".{extension}"
+    return 0, b"".join(chunks), suffix
 
 
 def _ffprobe_path(ffmpeg_path: str) -> str:
@@ -128,7 +400,12 @@ def _ffprobe_path(ffmpeg_path: str) -> str:
     return "ffprobe"
 
 
-def probe_stream_height(url: str, ffmpeg_path: str = "ffmpeg", timeout: float = 8.0) -> int:
+def probe_stream_height(
+    url: str,
+    ffmpeg_path: str = "ffmpeg",
+    timeout: float = 8.0,
+    allowed_private_ranges: Iterable[str] = (),
+) -> int:
     """Read an HLS master playlist or the first video stream to get its height.
 
     Apple CMS metadata rarely carries a trustworthy quality field.  Reading the
@@ -136,63 +413,71 @@ def probe_stream_height(url: str, ffmpeg_path: str = "ffmpeg", timeout: float = 
     the first segment to expose the video dimensions without saving a frame.
     """
 
-    parsed = urllib.parse.urlparse(str(url or "").strip())
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+    value = str(url or "").strip()
+    if not _is_public_probe_url(value, allowed_private_ranges):
         return 0
     try:
-        height = _playlist_resolution_height(parsed.geturl(), timeout)
+        height, media_sample, suffix = _probe_media_sample(
+            value,
+            timeout,
+            allowed_private_ranges=allowed_private_ranges,
+        )
         if height:
             return height
     except Exception:
-        pass
+        return 0
+    if not media_sample:
+        return 0
 
     probe_timeout = min(max(float(timeout or 8.0), 3.0), 15.0)
-    try:
-        result = subprocess.run(
-            [
-                _ffprobe_path(ffmpeg_path),
-                "-v",
-                "error",
-                "-rw_timeout",
-                str(int(probe_timeout * 1_000_000)),
-                "-analyzeduration",
-                "1000000",
-                "-probesize",
-                "1000000",
-                "-select_streams",
-                "v:0",
-                "-show_entries",
-                "stream=width,height",
-                "-of",
-                "csv=s=x:p=0",
-                parsed.geturl(),
-            ],
-            capture_output=True,
-            text=True,
-            timeout=probe_timeout,
-            check=False,
-        )
-    except subprocess.TimeoutExpired:
-        return 0
-    except (OSError, subprocess.SubprocessError, ValueError):
-        result = None
-    height = _resolution_height(result.stdout if result else "")
-    if height:
-        return height
+    with tempfile.NamedTemporaryFile(prefix="lunatv-probe-", suffix=suffix) as sample:
+        sample.write(media_sample)
+        sample.flush()
+        try:
+            result = subprocess.run(
+                [
+                    _ffprobe_path(ffmpeg_path),
+                    "-v",
+                    "error",
+                    "-protocol_whitelist",
+                    "file,pipe",
+                    "-analyzeduration",
+                    "1000000",
+                    "-probesize",
+                    "1000000",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=width,height",
+                    "-of",
+                    "csv=s=x:p=0",
+                    sample.name,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=probe_timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return 0
+        except (OSError, subprocess.SubprocessError, ValueError):
+            result = None
+        height = _resolution_height(result.stdout if result else "")
+        if height:
+            return height
 
-    # Some HLS servers expose dimensions only after the first frame is
-    # decoded.  Decode one frame to the null muxer; no image is persisted.
-    try:
-        frame = subprocess.run(
+        # Some streams expose dimensions only after the first frame is decoded.
+        try:
+            frame = subprocess.run(
             [
                 str(ffmpeg_path or "ffmpeg"),
                 "-hide_banner",
                 "-loglevel",
                 "info",
-                "-rw_timeout",
-                str(int(probe_timeout * 1_000_000)),
+                "-protocol_whitelist",
+                "file,pipe",
                 "-i",
-                parsed.geturl(),
+                sample.name,
                 "-map",
                 "0:v:0",
                 "-frames:v",
@@ -205,10 +490,10 @@ def probe_stream_height(url: str, ffmpeg_path: str = "ffmpeg", timeout: float = 
             text=True,
             timeout=probe_timeout,
             check=False,
-        )
-    except (OSError, subprocess.SubprocessError, ValueError):
-        return 0
-    return _resolution_height(frame.stderr)
+            )
+        except (OSError, subprocess.SubprocessError, ValueError):
+            return 0
+        return _resolution_height(frame.stderr)
 
 
 def _split_player_values(value: str) -> List[str]:
@@ -420,9 +705,15 @@ class CmsResult:
 
 
 def _media_type(item: Mapping[str, Any]) -> str:
-    value = f"{item.get('type_name', '')} {item.get('vod_class', '')}".lower()
+    type_name = _text(item.get("type_name")).strip().lower()
+    value = f"{type_name} {_text(item.get('vod_class'))}".lower()
     if "电影" in value and "电视剧" not in value:
         return "movie"
+    # Regional drama categories such as 欧美剧/韩剧 are used by some CMS
+    # providers without the literal 电视剧 label. Use an explicit type-name
+    # allowlist so movie categories such as 喜剧/悲剧 remain movies.
+    if type_name in _TV_TYPE_NAMES:
+        return "tv"
     if any(token in value for token in ("电视剧", "连续剧", "tv", "剧集", "综艺", "儿童", "少儿")):
         return "tv"
     # 动漫/动画/纪录片在 CMS 中同时承载电影和剧集。 只有出现季集
@@ -665,77 +956,126 @@ class AppleCmsClient:
         require_playable: bool = False,
         source_limit: Optional[int] = None,
         max_workers: int = 1,
+        progress_callback: Optional[Callable[..., None]] = None,
     ) -> List[CmsResult]:
+        ordered_sources = list(self.sources)
+        total_sources = len(ordered_sources)
+        results: List[CmsResult] = []
+        seen: set[Tuple[str, str]] = set()
+        completed_sources: set[int] = set()
+        finished = 0
+
+        def notify_progress() -> None:
+            if progress_callback is None:
+                return
+            try:
+                progress_callback(
+                    finished=finished,
+                    total=total_sources,
+                    text=f"正在搜索源 {finished}/{total_sources}",
+                )
+            except Exception:
+                # UI/event handlers must not affect third-party CMS search.
+                pass
+
+        def settle_source(index: int) -> None:
+            nonlocal finished
+            if index in completed_sources:
+                return
+            completed_sources.add(index)
+            finished += 1
+            notify_progress()
+
+        def settle_unfinished_sources() -> None:
+            for index in range(total_sources):
+                settle_source(index)
+            if total_sources == 0:
+                notify_progress()
+
+        def merge_source_results(source_results: Iterable[CmsResult]) -> None:
+            for result in source_results:
+                key = (result.source_key, result.vod_id)
+                if result.title and key not in seen:
+                    seen.add(key)
+                    results.append(result)
+
         if limit <= 0:
+            settle_unfinished_sources()
             return []
         per_source_limit = max(1, min(int(source_limit or limit), int(limit)))
-        results: List[CmsResult] = []
-        ordered_sources = list(self.sources)
-        seen: set[Tuple[str, str]] = set()
         max_workers = max(1, int(max_workers))
         if stop_after_first_source or max_workers == 1 or len(ordered_sources) <= 1:
-            for source in ordered_sources:
+            for index, source in enumerate(ordered_sources):
                 source_result_count = len(results)
-                for result in self._search_source(
-                    source,
+                try:
+                    source_results = self._search_source(
+                        source,
+                        query=query,
+                        limit=per_source_limit,
+                        enrich=enrich,
+                        require_playable=require_playable,
+                    )
+                except Exception:
+                    source_results = []
+                finally:
+                    settle_source(index)
+                merge_source_results(source_results)
+                if stop_after_first_source and len(results) > source_result_count:
+                    # The remaining sources are intentionally skipped; settle
+                    # each one so progress always reaches total/total.
+                    settle_unfinished_sources()
+                    break
+            settle_unfinished_sources()
+            return results[:limit]
+
+        futures: Dict[Any, int] = {}
+        pending_futures = set()
+        source_results: Dict[int, List[CmsResult]] = {}
+        executor = ThreadPoolExecutor(max_workers=min(max_workers, len(ordered_sources)))
+        try:
+            for idx, source in enumerate(ordered_sources):
+                future = executor.submit(
+                    self._search_source,
+                    source=source,
                     query=query,
                     limit=per_source_limit,
                     enrich=enrich,
                     require_playable=require_playable,
-                ):
-                    key = (result.source_key, result.vod_id)
-                    if result.title and key not in seen:
-                        seen.add(key)
-                        results.append(result)
-                if stop_after_first_source and len(results) > source_result_count:
-                    break
-            return results[:limit]
-
-        futures = []
-        executor = ThreadPoolExecutor(max_workers=min(max_workers, len(ordered_sources)))
-        try:
-            for idx, source in enumerate(ordered_sources):
-                futures.append(
-                    (
-                        idx,
-                        source,
-                        executor.submit(
-                            self._search_source,
-                            source=source,
-                            query=query,
-                            limit=per_source_limit,
-                            enrich=enrich,
-                            require_playable=require_playable,
-                        ),
-                    )
                 )
-            done_futures, pending_futures = wait(
-                [future for _, _, future in futures],
-                timeout=self._parallel_wait_seconds(),
-            )
+                futures[future] = idx
+                pending_futures.add(future)
+
+            deadline = time.monotonic() + self._parallel_wait_seconds()
+            while pending_futures:
+                done_futures, pending_futures = wait(
+                    pending_futures,
+                    timeout=max(0.0, deadline - time.monotonic()),
+                    return_when=FIRST_COMPLETED,
+                )
+                if not done_futures:
+                    break
+                for future in done_futures:
+                    idx = futures[future]
+                    try:
+                        source_results[idx] = future.result()
+                    except Exception:
+                        source_results[idx] = []
+                    finally:
+                        settle_source(idx)
+
             # Do not leave queued sources running after the total search
             # budget expires. Running requests cannot be forcefully stopped,
             # but queued futures can be cancelled before executor shutdown.
             for future in pending_futures:
                 future.cancel()
-            source_results: Dict[int, List[CmsResult]] = {}
-            for idx, source, future in futures:
-                if future not in done_futures:
-                    continue
-                try:
-                    source_results[idx] = future.result()
-                except Exception:
-                    source_results[idx] = []
+            settle_unfinished_sources()
             for idx in sorted(source_results):
-                for result in source_results[idx]:
-                    key = (result.source_key, result.vod_id)
-                    if result.title and key not in seen:
-                        seen.add(key)
-                        results.append(result)
-                        if len(results) >= limit:
-                            return results
+                merge_source_results(source_results[idx])
+                if len(results) >= limit:
+                    return results[:limit]
             return results[:limit]
         finally:
-            # ``wait=False`` is intentional: a slow third-party source must
+            settle_unfinished_sources()
+            # ``wait=False`` is intentional: slow third-party source calls do
             # not hold up the native search response after the budget.
             executor.shutdown(wait=False, cancel_futures=True)

--- a/plugins.v3/lunatvsource/downloader.py
+++ b/plugins.v3/lunatvsource/downloader.py
@@ -71,6 +71,8 @@ class _SegmentProxy:
         proxy = self
 
         class Handler(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
             def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
                 token = self.path.partition("?")[0].removeprefix("/segment/")
                 remote_url = proxy._urls.get(token)
@@ -86,13 +88,22 @@ class _SegmentProxy:
                         prefix = response.read(4096)
                         offset = _mpegts_payload_offset(prefix)
                         length = response.headers.get("Content-Length")
+                        content_length = (
+                            int(length)
+                            if length is not None and str(length).isdigit()
+                            else None
+                        )
                         self.send_response(200)
                         self.send_header("Content-Type", "video/mp2t" if offset else (
                             response.headers.get("Content-Type") or "application/octet-stream"
                         ))
-                        if length and str(length).isdigit():
-                            self.send_header("Content-Length", str(max(0, int(length) - offset)))
-                        self.send_header("Connection", "close")
+                        if content_length is not None and content_length >= offset:
+                            self.send_header("Content-Length", str(content_length - offset))
+                        else:
+                            # HTTP/1.1 responses without a length must close so
+                            # ffmpeg can delimit the segment body.
+                            self.send_header("Connection", "close")
+                            self.close_connection = True
                         self.end_headers()
                         self.wfile.write(prefix[offset:])
                         while True:
@@ -220,9 +231,14 @@ class DownloadQueue:
         self._lock = threading.RLock()
         self._stop = False
         self._running = False
+        self._drain_running = False
+        self._drain_wakeup = threading.Event()
         self._current_task_id = ""
+        self._active_owner_id: Optional[int] = None
         self._control_action = ""
         self._control_event = threading.Event()
+        self._idle_event = threading.Event()
+        self._idle_event.set()
         self._delete_file_tasks: set[str] = set()
         self._recover_interrupted_tasks()
 
@@ -361,12 +377,159 @@ class DownloadQueue:
             return f"{task.title} S{int(task.season):02d}E{int(task.episode):02d}"
         return task.title
 
-    def run_one(self) -> Dict[str, Any]:
+    def _clear_active_state(self, *, keep_control: bool = False) -> None:
+        """Clear transient active-task state while ``_lock`` is held."""
+        self._running = False
+        self._active_owner_id = None
+        if not keep_control:
+            self._current_task_id = ""
+            self._control_action = ""
+        self._control_event.clear()
+        self._idle_event.set()
+
+    def wake(self) -> bool:
+        """Run pending tasks in one background worker without fan-out."""
         with self._lock:
+            if self._stop:
+                return False
+            self._drain_wakeup.set()
+            if self._drain_running:
+                return True
+            self._drain_running = True
+        try:
+            threading.Thread(
+                target=self._drain,
+                name="lunatvsource-download",
+                daemon=True,
+            ).start()
+        except RuntimeError:
+            with self._lock:
+                self._drain_running = False
+                self._drain_wakeup.clear()
+            return False
+        return True
+
+    def _drain(self) -> None:
+        control_retry_used = False
+        while True:
+            self._drain_wakeup.clear()
+            failed = False
+            try:
+                self._drain_until_idle()
+            except Exception:
+                # A wake arriving during a transient persistence failure must
+                # get one retry instead of being lost behind the live worker.
+                failed = True
+
+            with self._lock:
+                if self._drain_wakeup.is_set():
+                    continue
+                pending_control = (
+                    self._control_action in {"pause", "remove"}
+                    and bool(self._current_task_id)
+                )
+                if failed and pending_control and not control_retry_used:
+                    control_retry_used = True
+                    continue
+                self._drain_running = False
+                if self._stop:
+                    self._drain_wakeup.clear()
+                return
+
+    def _drain_until_idle(self) -> None:
+        """Continue serial work until no pending task remains.
+
+        The idle check and worker hand-off share ``_lock`` with enqueue(), so
+        a task added as another task finishes cannot lose its wake-up.
+        """
+        while True:
+            result = self.run_one()
+            if result.get("processed"):
+                continue
+
+            with self._lock:
+                stopped = self._stop
+                active_elsewhere = self._running
+            if stopped:
+                return
+            if active_elsewhere:
+                # A legacy/direct run_one() call owns the active task. Keep
+                # this worker alive until it finishes, then drain its wake-up.
+                self._idle_event.wait()
+                continue
+
+            with self._lock:
+                if any(task.state == "pending" for task in self._read()):
+                    continue
+                return
+
+    def _replay_control_intent(
+        self,
+        tasks: List[DownloadTask],
+    ) -> Optional[Dict[str, Any]]:
+        """Persist an interrupted pause/remove before any task can restart.
+
+        Must be called with ``_lock`` held. The intent is cleared only after
+        its durable state transition succeeds, so a transient save failure
+        cannot resurrect a paused or removed download.
+        """
+        action = self._control_action
+        task_id = self._current_task_id
+        if action not in {"pause", "remove"} or not task_id:
+            return None
+
+        task = next((item for item in tasks if item.task_id == task_id), None)
+        if action == "remove":
+            delete_file = task_id in self._delete_file_tasks
+            if task is not None and delete_file:
+                self._delete_task_files(task)
+            if task is not None:
+                self._write([item for item in tasks if item.task_id != task_id])
+            self._delete_file_tasks.discard(task_id)
+        else:
+            if task is not None:
+                task.state = "paused"
+                task.progress = 0.0
+                task.error = ""
+                self._write(tasks)
+
+        self._clear_active_state()
+        return {
+            "processed": 1 if task is not None else 0,
+            "task_id": task_id,
+            "state": action,
+        }
+
+    def run_one(self) -> Dict[str, Any]:
+        owner_id = threading.get_ident()
+        try:
+            return self._run_one(owner_id)
+        except Exception:
+            with self._lock:
+                if self._active_owner_id == owner_id:
+                    keep_control = (
+                        self._control_action in {"pause", "remove"}
+                        and bool(self._current_task_id)
+                    )
+                    self._clear_active_state(keep_control=keep_control)
+            raise
+
+    def _run_one(self, owner_id: int) -> Dict[str, Any]:
+        with self._lock:
+            if self._running:
+                return {"processed": 0, "stopped": True}
             tasks = self._read()
-            if self._stop or self._running:
+            replayed = self._replay_control_intent(tasks)
+            if replayed is not None:
+                return replayed
+            if self._stop:
                 return {"processed": 0, "stopped": True}
             task = next((item for item in tasks if item.state == "pending"), None)
+            if task is None:
+                task = next((item for item in tasks if item.state == "running"), None)
+                if task is not None:
+                    task.progress = 0.0
+                    task.error = "上次队列执行异常，已恢复排队"
             if task is None:
                 return {"processed": 0}
             task.state = "running"
@@ -374,8 +537,10 @@ class DownloadQueue:
             task.attempts += 1
             self._running = True
             self._current_task_id = task.task_id
+            self._active_owner_id = owner_id
             self._control_action = ""
             self._control_event.clear()
+            self._idle_event.clear()
             self._write(tasks)
         try:
             output = self._execute(task)
@@ -386,20 +551,16 @@ class DownloadQueue:
                 current = next((item for item in tasks if item.task_id == task.task_id), None)
                 if action == "remove":
                     delete_file = task.task_id in self._delete_file_tasks
-                    self._delete_file_tasks.discard(task.task_id)
                     if delete_file:
                         self._delete_task_files(task)
                     tasks = [item for item in tasks if item.task_id != task.task_id]
                 elif current is not None:
-                    self._delete_file_tasks.discard(task.task_id)
                     current.state = "paused"
                     current.progress = 0.0
                     current.error = ""
                 self._write(tasks)
-                self._running = False
-                self._current_task_id = ""
-                self._control_action = ""
-                self._control_event.clear()
+                self._delete_file_tasks.discard(task.task_id)
+                self._clear_active_state()
             return {"processed": 1, "task_id": task.task_id, "state": action}
         except Exception as exc:
             with self._lock:
@@ -409,30 +570,44 @@ class DownloadQueue:
                     and self._current_task_id == task.task_id
                 ):
                     delete_file = task.task_id in self._delete_file_tasks
-                    self._delete_file_tasks.discard(task.task_id)
                     if delete_file:
                         self._delete_task_files(task)
                     self._write(
                         [item for item in tasks if item.task_id != task.task_id]
                     )
-                    self._running = False
-                    self._current_task_id = ""
-                    self._control_action = ""
-                    self._control_event.clear()
+                    self._delete_file_tasks.discard(task.task_id)
+                    self._clear_active_state()
                     return {
                         "processed": 1,
                         "task_id": task.task_id,
                         "state": "remove",
+                    }
+                if (
+                    self._control_action == "pause"
+                    and self._current_task_id == task.task_id
+                ):
+                    current = next(
+                        (item for item in tasks if item.task_id == task.task_id),
+                        None,
+                    )
+                    if current is not None:
+                        current.state = "paused"
+                        current.progress = 0.0
+                        current.error = ""
+                        self._write(tasks)
+                    self._delete_file_tasks.discard(task.task_id)
+                    self._clear_active_state()
+                    return {
+                        "processed": 1,
+                        "task_id": task.task_id,
+                        "state": "pause",
                     }
                 self._delete_file_tasks.discard(task.task_id)
                 current = next((item for item in tasks if item.task_id == task.task_id), task)
                 current.state = "failed"
                 current.error = str(exc)
                 self._write(tasks)
-                self._running = False
-                self._current_task_id = ""
-                self._control_action = ""
-                self._control_event.clear()
+                self._clear_active_state()
             self._notify("LunaTV 下载失败", f"{self._notification_text(task)}：{exc}")
             return {"processed": 1, "task_id": task.task_id, "state": "failed", "error": str(exc)}
 
@@ -444,16 +619,13 @@ class DownloadQueue:
             ):
                 task.output = output
                 delete_file = task.task_id in self._delete_file_tasks
-                self._delete_file_tasks.discard(task.task_id)
                 if delete_file:
                     self._delete_task_files(task)
                 self._write(
                     [item for item in tasks if item.task_id != task.task_id]
                 )
-                self._running = False
-                self._current_task_id = ""
-                self._control_action = ""
-                self._control_event.clear()
+                self._delete_file_tasks.discard(task.task_id)
+                self._clear_active_state()
                 return {
                     "processed": 1,
                     "task_id": task.task_id,
@@ -469,10 +641,6 @@ class DownloadQueue:
             task.output = output
             task.completed_at = current.completed_at
             self._write(tasks)
-            self._running = False
-            self._current_task_id = ""
-            self._control_action = ""
-            self._control_event.clear()
         if self._on_complete is not None:
             try:
                 self._on_complete(task, output)
@@ -480,6 +648,8 @@ class DownloadQueue:
                 # History/host integration must never turn a completed file
                 # into a failed download.
                 pass
+        with self._lock:
+            self._clear_active_state()
         self._notify("LunaTV 已完成", self._notification_text(task))
         return {"processed": 1, "task_id": task.task_id, "state": "completed", "output": output}
 
@@ -675,6 +845,12 @@ class DownloadQueue:
                 "0",
                 "-seg_max_retry",
                 "2",
+                "-http_persistent",
+                "1",
+                "-http_multiple",
+                "1",
+                "-http_seekable",
+                "0",
                 "-i",
                 input_url,
                 "-c",

--- a/plugins.v3/lunatvsource/package-lock.json
+++ b/plugins.v3/lunatvsource/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moviepilot-lunatvsource-plugin",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moviepilot-lunatvsource-plugin",
-      "version": "0.4.38",
+      "version": "0.4.39",
       "dependencies": {
         "vue": "^3.5.13",
         "vuetify": "3.7.3"

--- a/plugins.v3/lunatvsource/package.json
+++ b/plugins.v3/lunatvsource/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moviepilot-lunatvsource-plugin",
   "private": true,
-  "version": "0.4.38",
+  "version": "0.4.39",
   "type": "module",
   "scripts": {"build": "vite build"},
   "dependencies": {"vue": "^3.5.13", "vuetify": "3.7.3"},

--- a/tests/v3/lunatvsource/test_cms.py
+++ b/tests/v3/lunatvsource/test_cms.py
@@ -1,9 +1,15 @@
 import json
+import socket
 import time
+
+import pytest
 
 from app.plugins.lunatvsource.cms import (
     AppleCmsClient,
     CmsSource,
+    _fetch_public_url,
+    _is_public_probe_url,
+    _master_playlist_height,
     _parse_play_urls,
     _result_from_item,
     apply_season_counts,
@@ -14,6 +20,8 @@ from app.plugins.lunatvsource.cms import (
 
 
 def test_stream_quality_label_uses_actual_video_height():
+    assert stream_quality_label(4320) == "8K"
+    assert stream_quality_label(2304) == "2304P"
     assert stream_quality_label(2160) == "4K"
     assert stream_quality_label(1080) == "1080P"
     assert stream_quality_label(720) == "720P"
@@ -23,63 +31,179 @@ def test_stream_quality_label_uses_actual_video_height():
     assert stream_quality_label(0) == "未知"
 
 
-def test_probe_stream_height_reads_master_playlist_resolution(monkeypatch):
-    class Response:
-        def __enter__(self):
-            return self
+def test_master_playlist_height_only_reads_stream_inf_resolution():
+    playlist = (
+        "#EXTM3U\n"
+        "#EXT-X-STREAM-INF:BANDWIDTH=3000000,RESOLUTION=1920x1080\n"
+        "https://cdn.example/video-3840x2160.m3u8\n"
+    )
 
-        def __exit__(self, *_args):
+    assert _master_playlist_height(playlist) == 1080
+    assert _master_playlist_height(
+        "#EXTM3U\n#EXTINF:6,\nsegment-3840x2160.ts\n"
+    ) == 0
+
+
+def test_public_probe_url_rejects_private_and_mixed_dns(monkeypatch):
+    assert _is_public_probe_url("http://127.0.0.1/metadata") is False
+    assert _is_public_probe_url("http://169.254.169.254/latest/meta-data") is False
+    assert _is_public_probe_url("http://192.168.1.10/video.m3u8") is False
+    assert _is_public_probe_url("http://[::1]/video.m3u8") is False
+    assert _is_public_probe_url(
+        "http://10.0.0.8/video.m3u8",
+        ("10.0.0.0/8",),
+    ) is True
+
+    monkeypatch.setattr(
+        "app.plugins.lunatvsource.cms.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+        ],
+    )
+    assert _is_public_probe_url("https://video.example/media.m3u8") is True
+
+    monkeypatch.setattr(
+        "app.plugins.lunatvsource.cms.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.8", 443)),
+        ],
+    )
+    assert _is_public_probe_url("https://video.example/media.m3u8") is True
+
+    monkeypatch.setattr(
+        "app.plugins.lunatvsource.cms.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("198.18.2.148", 443)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("fdfe:dcba:9876::241", 443, 0, 0)),
+        ],
+    )
+    assert _is_public_probe_url("https://video.example/media.m3u8") is False
+    assert _is_public_probe_url(
+        "https://video.example/media.m3u8",
+        ("198.18.0.0/15", "fdfe:dcba:9876::/48"),
+    ) is True
+    assert _is_public_probe_url("http://video.example/media.m3u8") is False
+
+    monkeypatch.setattr(
+        "app.plugins.lunatvsource.cms.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.8", 443)),
+        ],
+    )
+    assert _is_public_probe_url("https://video.example/media.m3u8") is False
+
+
+def test_public_fetch_pins_dns_and_rejects_private_redirect(monkeypatch):
+    requests = []
+    responses = iter(
+        [
+            type(
+                "RedirectResponse",
+                (),
+                {
+                    "status": 302,
+                    "getheader": lambda self, name: (
+                        "http://127.0.0.1/metadata" if name == "Location" else None
+                    ),
+                },
+            )(),
+        ]
+    )
+
+    class Connection:
+        def __init__(self, address, port, timeout):
+            requests.append({"address": address, "port": port, "timeout": timeout})
+
+        def request(self, method, path, headers):
+            requests[-1].update({"method": method, "path": path, "headers": headers})
+
+        def getresponse(self):
+            return next(responses)
+
+        def close(self):
             return None
 
-        def read(self, _limit):
-            return (
-                b"#EXTM3U\n"
-                b"#EXT-X-STREAM-INF:BANDWIDTH=800000,RESOLUTION=1280x720\n720.m3u8\n"
-                b"#EXT-X-STREAM-INF:BANDWIDTH=3000000,RESOLUTION=1920x1080\n1080.m3u8\n"
-            )
+    monkeypatch.setattr(
+        "app.plugins.lunatvsource.cms.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80)),
+        ],
+    )
+    monkeypatch.setattr("app.plugins.lunatvsource.cms.http.client.HTTPConnection", Connection)
 
-    monkeypatch.setattr("app.plugins.lunatvsource.cms.urllib.request.urlopen", lambda *_args, **_kwargs: Response())
+    with pytest.raises(ValueError, match="non-public"):
+        _fetch_public_url("http://video.example/start.m3u8", 3.0, 1024)
+
+    assert requests == [
+        {
+            "address": "93.184.216.34",
+            "port": 80,
+            "timeout": 3.0,
+            "method": "GET",
+            "path": "/start.m3u8",
+            "headers": {
+                "Host": "video.example",
+                "User-Agent": "LunaTVSource/0.1 MoviePilot",
+                "Accept": "application/vnd.apple.mpegurl, application/x-mpegURL, */*",
+                "Connection": "close",
+            },
+        }
+    ]
+
+
+def test_probe_stream_height_reads_master_playlist_resolution(monkeypatch):
+    monkeypatch.setattr("app.plugins.lunatvsource.cms._is_public_probe_url", lambda *_args: True)
+    monkeypatch.setattr(
+        "app.plugins.lunatvsource.cms._probe_media_sample",
+        lambda *_args, **_kwargs: (1080, b"", ""),
+    )
     assert probe_stream_height("https://example.test/master.m3u8") == 1080
 
 
 def test_probe_stream_height_falls_back_to_first_video_stream(monkeypatch):
-    class Response:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args):
-            return None
-
-        def read(self, _limit):
-            return b"#EXTM3U\n#EXTINF:6,\nsegment-001.ts\n"
-
     class ProcessResult:
         stdout = "854x480\n"
 
-    monkeypatch.setattr("app.plugins.lunatvsource.cms.urllib.request.urlopen", lambda *_args, **_kwargs: Response())
-    monkeypatch.setattr("app.plugins.lunatvsource.cms.subprocess.run", lambda *_args, **_kwargs: ProcessResult())
+    def run(args, **_kwargs):
+        assert "-protocol_whitelist" in args
+        assert args[args.index("-protocol_whitelist") + 1] == "file,pipe"
+        assert not args[-1].startswith(("http://", "https://"))
+        return ProcessResult()
+
+    monkeypatch.setattr("app.plugins.lunatvsource.cms._is_public_probe_url", lambda *_args: True)
+    monkeypatch.setattr(
+        "app.plugins.lunatvsource.cms._probe_media_sample",
+        lambda *_args, **_kwargs: (0, b"segment", ".ts"),
+    )
+    monkeypatch.setattr("app.plugins.lunatvsource.cms.subprocess.run", run)
     assert probe_stream_height("https://example.test/media.m3u8") == 480
 
 
 def test_probe_stream_height_decodes_one_frame_when_ffprobe_has_no_dimensions(monkeypatch):
-    class Response:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args):
-            return None
-
-        def read(self, _limit):
-            return b"#EXTM3U\n#EXTINF:6,\nsegment-001.ts\n"
-
     results = iter([
         type("ProbeResult", (), {"stdout": "", "stderr": ""})(),
         type("FrameResult", (), {"stdout": "", "stderr": "Video: h264, 1280x720"})(),
     ])
-    monkeypatch.setattr("app.plugins.lunatvsource.cms.urllib.request.urlopen", lambda *_args, **_kwargs: Response())
-    monkeypatch.setattr("app.plugins.lunatvsource.cms.subprocess.run", lambda *_args, **_kwargs: next(results))
+    calls = []
+
+    def run(args, **_kwargs):
+        calls.append(args)
+        return next(results)
+
+    monkeypatch.setattr("app.plugins.lunatvsource.cms._is_public_probe_url", lambda *_args: True)
+    monkeypatch.setattr(
+        "app.plugins.lunatvsource.cms._probe_media_sample",
+        lambda *_args, **_kwargs: (0, b"segment", ".ts"),
+    )
+    monkeypatch.setattr("app.plugins.lunatvsource.cms.subprocess.run", run)
 
     assert probe_stream_height("https://example.test/media.m3u8") == 720
+    assert len(calls) == 2
+    for args in calls:
+        assert "-protocol_whitelist" in args
+        assert args[args.index("-protocol_whitelist") + 1] == "file,pipe"
+        assert not any(str(value).startswith(("http://", "https://")) for value in args)
 
 
 def test_parse_config_filters_by_api_host():
@@ -478,8 +602,191 @@ def test_animation_is_treated_as_series_for_season_naming():
             "vod_id": "cartoon",
             "vod_name": "示例动画",
             "type_name": "动漫",
-            "vod_play_from": "在线播放",
-            "vod_play_url": "01$https://example.test/01.m3u8#02$https://example.test/02.m3u8",
+           "vod_play_from": "在线播放",
+           "vod_play_url": "01$https://example.test/01.m3u8#02$https://example.test/02.m3u8",
+       },
+   )
+    assert result.media_type == "tv"
+
+
+def test_result_from_item_recognizes_regional_drama_category_without_movie_class_leak():
+    result = _result_from_item(
+        CmsSource("demo", "演示", "https://cms.example/vod"),
+        {
+            "vod_id": "green-lantern-corps",
+            "vod_name": "绿灯军团",
+            "type_name": "欧美剧",
+            "vod_class": "剧情",
+            "vod_remarks": "更新至02集",
+            "vod_play_url": "第01集$https://example.test/01.m3u8#第02集$https://example.test/02.m3u8",
         },
     )
     assert result.media_type == "tv"
+
+    movie = _result_from_item(
+        CmsSource("demo", "演示", "https://cms.example/vod"),
+        {
+            "vod_id": "drama-movie",
+            "vod_name": "剧情片",
+            "type_name": "剧情片",
+            "vod_class": "剧情",
+            "vod_play_url": "正片$https://example.test/movie.m3u8",
+        },
+    )
+    assert movie.media_type == "movie"
+
+@pytest.mark.parametrize("type_name", ("喜剧", "悲剧", "戏剧", "舞台剧"))
+def test_result_from_item_does_not_treat_generic_drama_labels_as_tv(type_name: str):
+    result = _result_from_item(
+        CmsSource("demo", "演示", "https://cms.example/vod"),
+        {
+            "vod_id": f"movie-{type_name}",
+            "vod_name": type_name,
+            "type_name": type_name,
+            "vod_class": type_name,
+            "vod_play_url": "正片$https://example.test/movie.m3u8",
+        },
+    )
+
+    assert result.media_type == "movie"
+
+@pytest.mark.parametrize("type_name", ("欧美剧", "韩剧", "日剧", "泰剧", "港剧", "台剧"))
+def test_result_from_item_recognizes_explicit_regional_tv_categories(type_name: str):
+    result = _result_from_item(
+        CmsSource("demo", "演示", "https://cms.example/vod"),
+        {
+            "vod_id": f"series-{type_name}",
+            "vod_name": type_name,
+            "type_name": type_name,
+            "vod_class": "剧情",
+            "vod_play_url": "第01集$https://example.test/01.m3u8",
+        },
+    )
+
+    assert result.media_type == "tv"
+
+def test_search_progress_reports_parallel_completion_before_total_budget():
+    from threading import Barrier, Event
+
+    sources = [
+        CmsSource(key="slow", name="slow", api="https://slow.example/vod"),
+        CmsSource(key="fast", name="fast", api="https://fast.example/vod"),
+    ]
+    client = AppleCmsClient(sources, parallel_wait_timeout=1)
+    rendezvous = Barrier(2, timeout=1)
+    progress_reached = Event()
+    slow_observed_progress = Event()
+    release_slow = Event()
+    progress = []
+
+    def fake_search_source(source, **_params):
+        rendezvous.wait()
+        if source.key == "slow":
+            if progress_reached.wait(0.75):
+                slow_observed_progress.set()
+            release_slow.wait(1)
+        return []
+
+    def on_progress(**event):
+        progress.append(event)
+        if event["finished"] == 1:
+            progress_reached.set()
+            release_slow.set()
+
+    client._search_source = fake_search_source
+    assert client.search("demo", max_workers=2, progress_callback=on_progress) == []
+
+    assert slow_observed_progress.is_set()
+    assert [(event["finished"], event["total"]) for event in progress] == [(1, 2), (2, 2)]
+    assert [event["text"] for event in progress] == ["正在搜索源 1/2", "正在搜索源 2/2"]
+
+def test_search_progress_advances_after_parallel_source_error_and_callback_error():
+    sources = [
+        CmsSource(key="bad", name="bad", api="https://bad.example/vod"),
+        CmsSource(key="good", name="good", api="https://good.example/vod"),
+    ]
+    client = AppleCmsClient(sources)
+    progress = []
+
+    def fake_search_source(source, **_params):
+        if source.key == "bad":
+            raise RuntimeError("bad source")
+        return []
+
+    def on_progress(**event):
+        progress.append(event)
+        if event["finished"] == 1:
+            raise RuntimeError("broken UI callback")
+
+    client._search_source = fake_search_source
+    assert client.search("demo", max_workers=2, progress_callback=on_progress) == []
+    assert [(event["finished"], event["total"]) for event in progress] == [(1, 2), (2, 2)]
+
+def test_search_progress_settles_timeout_once_without_late_worker_callback():
+    from threading import Event
+
+    sources = [
+        CmsSource(key="slow", name="slow", api="https://slow.example/vod"),
+        CmsSource(key="fast", name="fast", api="https://fast.example/vod"),
+    ]
+    client = AppleCmsClient(sources, parallel_wait_timeout=0.05)
+    slow_started = Event()
+    release_slow = Event()
+    slow_finished = Event()
+    progress = []
+
+    def fake_search_source(source, **_params):
+        if source.key == "slow":
+            slow_started.set()
+            release_slow.wait(1)
+            slow_finished.set()
+        return []
+
+    client._search_source = fake_search_source
+    try:
+        assert client.search(
+            "demo",
+            max_workers=2,
+            progress_callback=lambda **event: progress.append(event),
+        ) == []
+        assert slow_started.is_set()
+        assert [(event["finished"], event["total"]) for event in progress] == [(1, 2), (2, 2)]
+    finally:
+        release_slow.set()
+
+    assert slow_finished.wait(1)
+    assert len(progress) == 2
+
+def test_search_progress_settles_skipped_sources_after_stop_after_first_source():
+    sources = [
+        CmsSource(key="first", name="first", api="https://first.example/vod"),
+        CmsSource(key="second", name="second", api="https://second.example/vod"),
+    ]
+    client = AppleCmsClient(sources)
+    called = []
+    progress = []
+
+    def fake_search_source(source, **_params):
+        called.append(source.key)
+        return [] if source.key == "second" else [
+            _result_from_item(
+                source,
+                {
+                    "vod_id": "first",
+                    "vod_name": "demo",
+                    "type_name": "movie",
+                    "vod_play_url": "main$https://first.example/demo.m3u8",
+                },
+            )
+        ]
+
+    client._search_source = fake_search_source
+    results = client.search(
+        "demo",
+        stop_after_first_source=True,
+        progress_callback=lambda **event: progress.append(event),
+    )
+
+    assert [result.source_key for result in results] == ["first"]
+    assert called == ["first"]
+    assert [(event["finished"], event["total"]) for event in progress] == [(1, 2), (2, 2)]

--- a/tests/v3/lunatvsource/test_completion_edges.py
+++ b/tests/v3/lunatvsource/test_completion_edges.py
@@ -1,0 +1,139 @@
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.plugins.lunatvsource import LunaTVSource
+import app.plugins.lunatvsource as plugin_module
+from app.plugins.lunatvsource.cms import CmsSource, _result_from_item
+from app.plugins.lunatvsource.downloader import DownloadQueue, DownloadTask
+
+
+class _PluginData:
+    def __init__(self):
+        self.values = {}
+
+    def get_data(self, _plugin_id, key):
+        return self.values.get(key)
+
+    def save(self, _plugin_id, key, value):
+        self.values[key] = value
+
+
+def _plugin(config=None):
+    plugin = object.__new__(LunaTVSource)
+    plugin.plugindata = _PluginData()
+    plugin._logger = plugin_module.LOGGER
+    plugin._download_metrics_lock = threading.Lock()
+    plugin._download_metrics = {}
+    plugin._quality_cache_lock = threading.Lock()
+    plugin._quality_cache = {}
+    plugin.init_plugin(config)
+    return plugin
+
+def test_api_search_collapses_tv_episode_rows_into_season_result(monkeypatch):
+    source = CmsSource("demo", "演示源", "https://cms.example/vod")
+    rows = [
+        _result_from_item(
+            source,
+            {
+                "vod_id": f"episode-{episode}",
+                "vod_name": f"示例剧 第{episode}集",
+                "vod_year": "2026",
+                "type_name": "电视剧",
+                "vod_play_url": (
+                    f"第{episode}集$https://video.example/s01e{episode:02d}.m3u8"
+                ),
+            },
+        )
+        for episode in (1, 2)
+    ]
+
+    class Client:
+        def search(self, *_args, **_kwargs):
+            return rows
+
+    plugin = _plugin({"enabled": True, "ai_enabled": False})
+    monkeypatch.setattr(plugin, "_client", lambda: Client())
+    monkeypatch.setattr(plugin, "_associate_tmdb", lambda *_args, **_kwargs: {})
+
+    response = plugin.api_search({"query": "示例剧", "media_type": "tv"})
+
+    assert response["success"] is True
+    assert len(response["data"]) == 1
+    assert response["data"][0]["title"].endswith("第1季")
+    assert "集" not in response["data"][0]["title"]
+    assert [item["episode"] for item in response["data"][0]["episodes"]] == [1, 2]
+
+
+def test_record_completion_respects_disabled_moviepilot_organize(monkeypatch):
+    plugin = _plugin({"enabled": True, "moviepilot_organize": False})
+    calls = []
+
+    monkeypatch.setattr(
+        plugin,
+        "_native_transfer",
+        lambda *_args: calls.append("transfer") or "moviepilot",
+    )
+    monkeypatch.setattr(
+        plugin,
+        "_record_native_history",
+        lambda _task, output: calls.append(("history", output)),
+    )
+    monkeypatch.setattr(plugin, "_sync_media_server", lambda: calls.append("sync"))
+
+    plugin._record_completion(SimpleNamespace(), "/downloads/movie.mp4")
+
+    assert calls == [("history", "/downloads/movie.mp4"), "sync"]
+
+
+def test_queue_stays_serial_during_completion_callback(tmp_path: Path):
+    data = {}
+    callback_entered = threading.Event()
+    release_callback = threading.Event()
+    completed = []
+
+    def load(key, default=None):
+        return data.get(key, default)
+
+    def save(key, value):
+        data[key] = value
+
+    def on_complete(task, _output):
+        completed.append(task.episode)
+        if task.episode == 1:
+            callback_entered.set()
+            assert release_callback.wait(timeout=2)
+
+    queue = DownloadQueue(load, save, lambda *_args: None, on_complete=on_complete)
+    for episode in (1, 2):
+        assert queue.enqueue(
+            DownloadTask(
+                task_id=f"task-{episode}",
+                source_key="demo",
+                media_id="demo:series",
+                title="示例剧",
+                year="2026",
+                media_type="tv",
+                season=1,
+                episode=episode,
+                url=f"https://video.example/s01e{episode:02d}.m3u8",
+                root=str(tmp_path),
+            )
+        )
+
+    queue._execute = lambda task: str(tmp_path / f"episode-{task.episode}.mp4")
+    first_result = []
+    first_thread = threading.Thread(target=lambda: first_result.append(queue.run_one()))
+    first_thread.start()
+
+    assert callback_entered.wait(timeout=2)
+    overlapping_result = queue.run_one()
+    assert overlapping_result == {"processed": 0, "stopped": True}
+
+    release_callback.set()
+    first_thread.join(timeout=2)
+    assert not first_thread.is_alive()
+    assert first_result[0]["state"] == "completed"
+
+    assert queue.run_one()["state"] == "completed"
+    assert completed == [1, 2]

--- a/tests/v3/lunatvsource/test_manifest.py
+++ b/tests/v3/lunatvsource/test_manifest.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+from app.plugins.lunatvsource import LunaTVSource
+
+
+def test_manifest_and_plugin_icons_use_https_url():
+    project_root = Path(__file__).resolve().parents[3]
+    package = json.loads((project_root / "package.v3.json").read_text(encoding="utf-8"))
+
+    manifest_icon = package["LunaTVSource"]["icon"]
+    plugin_icon = LunaTVSource.plugin_icon
+    parsed_icon = urlparse(manifest_icon)
+
+    assert manifest_icon == plugin_icon
+    assert parsed_icon.scheme == "https"
+    assert Path(parsed_icon.path).name == "lunatvsource.png"
+    assert (project_root / "icons" / "lunatvsource.png").is_file()
+
+
+def test_version_consistency_across_manifest_backend_and_frontend():
+    project_root = Path(__file__).resolve().parents[3]
+    manifest = json.loads(
+        (project_root / "package.v3.json").read_text(encoding="utf-8")
+    )["LunaTVSource"]
+    package = json.loads(
+        (
+            project_root
+            / "plugins.v3"
+            / "lunatvsource"
+            / "package.json"
+        ).read_text(encoding="utf-8")
+    )
+    lockfile = json.loads(
+        (
+            project_root
+            / "plugins.v3"
+            / "lunatvsource"
+            / "package-lock.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert manifest["version"] == "0.4.39"
+    assert {
+        manifest["version"],
+        LunaTVSource.plugin_version,
+        package["version"],
+        lockfile["version"],
+        lockfile["packages"][""]["version"],
+    } == {"0.4.39"}
+
+    history = manifest["history"]
+    assert next(iter(history)) == "0.4.39"
+    assert history["0.4.39"] == (
+        "搜索按实际 CMS 源显示 X/N 进度，修复欧美剧等分类导致的电视剧 0 结果；"
+        "电影与电视剧按实际分辨率降序展示，整季逐集探测并在同集多地址中选择最高画质；"
+        "下载入队后立即启动，HLS 分片启用 HTTP/1.1 多连接；"
+        "修正插件图标与整理关闭、完成回调串行等边界。"
+    )
+    assert history["0.4.38"] == (
+        "电视剧资源按季聚合，冲突同集自动选择最高画质；大季按首、中、末代表集实测并按该结果排序，"
+        "未抽样集明确标记，资源搜索按媒体类型过滤，季订阅不再只刷新首集。"
+    )

--- a/tests/v3/lunatvsource/test_plugin.py
+++ b/tests/v3/lunatvsource/test_plugin.py
@@ -52,6 +52,17 @@ def _disable_external_quality_probe(monkeypatch):
     )
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _disable_background_download_execution():
+    """Plugin tests exercise queue wiring, never a real HLS transfer."""
+    original_execute = plugin_module.DownloadQueue._execute
+    plugin_module.DownloadQueue._execute = (
+        lambda _queue, task: str(Path(task.root) / f"{task.task_id}.mp4")
+    )
+    yield
+    plugin_module.DownloadQueue._execute = original_execute
+
+
 def test_status_exposes_serial_queue_and_ai_fallback():
     plugin = _plugin()
     plugin.init_plugin({"enabled": True, "ai_enabled": False})
@@ -388,6 +399,7 @@ def test_global_media_search_returns_lunatv_cards_without_explore_tab(monkeypatc
     plugin.init_plugin({"enabled": True})
     monkeypatch.setattr(plugin, "_client", lambda: Client())
     monkeypatch.setattr(plugin, "_prepare_result", lambda result: (result, {}))
+    monkeypatch.setattr(plugin, "_probe_resource_urls", lambda _urls: {})
     monkeypatch.setattr(plugin, "_media_info", lambda result, association: result)
     meta = type("Meta", (), {"name": "示例电影", "year": "", "type": "电影"})()
     results = plugin.search_medias(meta=meta)
@@ -1011,8 +1023,8 @@ def test_resource_torrents_choose_highest_url_for_conflicting_episode(monkeypatc
         for episode in payload["episodes"]
     ] == [("1080P", 1080), ("480P", 480)]
     assert payload["resolution_scope"] == "full"
-    assert payload["resolution_sample_count"] == 2
-    assert payload["resolution_sampled_episodes"] == [1, 2]
+    assert payload["resolution_probed_episode_count"] == 2
+    assert payload["resolution_probed_episodes"] == [1, 2]
     assert "https://video.example/480-e2.m3u8" in probed
 
 
@@ -1063,7 +1075,7 @@ def test_resource_torrents_marks_season_unknown_when_any_episode_probe_fails(mon
     ] == [("1080P", 1080), ("未知", 0)]
 
 
-def test_resource_torrents_samples_large_seasons_at_first_middle_and_last(monkeypatch):
+def test_resource_torrents_probes_all_episodes_in_large_seasons(monkeypatch):
     class TorrentInfo:
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
@@ -1075,7 +1087,7 @@ def test_resource_torrents_samples_large_seasons_at_first_middle_and_last(monkey
         def search(self, *_args, **_kwargs):
             return [self._result]
 
-    for count, expected_episodes in ((52, [1, 27, 52]), (208, [1, 105, 208])):
+    for count in (52, 208):
         result = CmsResult(
             source_key=f"sample-{count}",
             source_name="抽样源",
@@ -1109,30 +1121,27 @@ def test_resource_torrents_samples_large_seasons_at_first_middle_and_last(monkey
 
         item = plugin._resource_torrents(f"抽样剧{count}")[0]
         payload = plugin._decode_resource_token(item.enclosure)
+        expected_episodes = list(range(1, count + 1))
         expected_urls = [
             f"https://video.example/sample-{count}-e{episode}.m3u8"
             for episode in expected_episodes
         ]
 
         assert [urls for urls in probe_calls if urls] == [expected_urls]
-        assert len(expected_urls) <= 3
+        assert len(expected_urls) == count
         assert item.pri_order == 1080
-        assert "抽样3集实测" in item.description
-        assert payload["resolution_scope"] == "sampled"
-        assert payload["resolution_sample_count"] == 3
-        assert payload["resolution_sampled_episodes"] == expected_episodes
+        assert f"全{count}集实测" in item.description
+        assert payload["resolution_scope"] == "full"
+        assert payload["resolution_probed_episode_count"] == count
+        assert payload["resolution_probed_episodes"] == expected_episodes
         assert [
             (payload["episodes"][episode - 1]["resolution"],
              payload["episodes"][episode - 1]["resolution_height"])
             for episode in expected_episodes
-        ] == [("1080P", 1080)] * 3
-        assert (
-            payload["episodes"][1]["resolution"],
-            payload["episodes"][1]["resolution_height"],
-        ) == ("未探测", 0)
+        ] == [("1080P", 1080)] * count
 
 
-def test_resource_torrents_probes_all_conflicts_and_marks_large_samples(monkeypatch):
+def test_resource_torrents_probes_all_conflicts_and_large_seasons(monkeypatch):
     class TorrentInfo:
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
@@ -1202,8 +1211,7 @@ def test_resource_torrents_probes_all_conflicts_and_marks_large_samples(monkeypa
             for url in urls
         }
 
-    plugin = _plugin()
-    plugin.init_plugin({"enabled": True})
+    plugin = _plugin({"enabled": True})
     monkeypatch.setattr(plugin_module, "_HostTorrentInfo", TorrentInfo)
     monkeypatch.setattr(plugin, "_client", lambda: Client())
     monkeypatch.setattr(plugin, "_associate_tmdb", lambda *_args, **_kwargs: {})
@@ -1219,14 +1227,14 @@ def test_resource_torrents_probes_all_conflicts_and_marks_large_samples(monkeypa
     assert payload["resolution"] == "未知"
     assert payload["resolution_height"] == item.pri_order == 0
     assert "未知" in item.title
-    assert "抽样3集实测" in item.description
-    assert payload["resolution_scope"] == "sampled"
-    assert payload["resolution_sample_count"] == 3
-    assert payload["resolution_sampled_episodes"] == [1, 27, 52]
+    assert "全52集实测" in item.description
+    assert payload["resolution_scope"] == "full"
+    assert payload["resolution_probed_episode_count"] == 52
+    assert payload["resolution_probed_episodes"] == list(range(1, 53))
     assert (
         payload["episodes"][1]["resolution"],
         payload["episodes"][1]["resolution_height"],
-    ) == ("未探测", 0)
+    ) == ("720P", 720)
     assert (
         payload["episodes"][26]["resolution"],
         payload["episodes"][26]["resolution_height"],
@@ -1434,7 +1442,10 @@ def test_plugin_search_bridge_defers_to_new_native_dispatch(monkeypatch):
     plugin.init_plugin({"enabled": True})
 
     assert SearchChain._SearchChain__search_all_sites is original
-    assert plugin_module._SEARCH_BRIDGE == {"owner": None, "chain": None, "originals": {}}
+    assert plugin_module._SEARCH_BRIDGE["owner"] is plugin
+    assert plugin_module._SEARCH_BRIDGE["chain"] is None
+    assert plugin_module._SEARCH_BRIDGE["originals"] == {}
+    assert plugin_module._SEARCH_BRIDGE["mode"] is None
 
 
 def test_native_download_is_enqueued_into_serial_queue(tmp_path: Path):
@@ -1691,7 +1702,7 @@ def test_native_resume_wakes_serial_queue(monkeypatch, tmp_path: Path):
         started.set()
         return {"processed": 1}
 
-    monkeypatch.setattr(plugin._queue, "run_one", run_one)
+    monkeypatch.setattr(plugin._queue, "wake", run_one)
 
     assert plugin.start_torrents([task.task_id], downloader="下载器1") is True
     assert started.wait(timeout=1)
@@ -1795,9 +1806,10 @@ def test_active_queue_projection_clamps_fractional_progress_to_percent():
     assert plugin._active_download_torrent(task).progress == 0.0
 
 
-def test_resource_download_event_allows_native_chain_to_call_plugin_download(tmp_path: Path):
+def test_resource_download_event_allows_native_chain_to_call_plugin_download(monkeypatch, tmp_path: Path):
     plugin = _plugin()
     plugin.init_plugin({"enabled": True})
+    monkeypatch.setattr(plugin, "_start_queue", lambda: True)
     token = plugin._resource_token({
         "url": "https://example.test/event.m3u8",
         "title": "事件电影",
@@ -2244,6 +2256,7 @@ def test_refresh_plugin_season_subscription_researches_and_queues_whole_season(
 
     plugin = _plugin()
     plugin.init_plugin({"enabled": True, "download_root": str(tmp_path)})
+    monkeypatch.setattr(plugin, "_start_queue", lambda: True)
     monkeypatch.setattr(plugin, "_client", lambda: Client())
     monkeypatch.setattr(plugin, "_prepare_result", lambda result: (result, {}))
 
@@ -2319,6 +2332,7 @@ def test_refresh_plugin_season_subscription_queues_highest_resolution_for_same_e
 
     plugin = _plugin()
     plugin.init_plugin({"enabled": True, "download_root": str(tmp_path)})
+    monkeypatch.setattr(plugin, "_start_queue", lambda: True)
     monkeypatch.setattr(plugin, "_client", lambda: Client())
     monkeypatch.setattr(plugin, "_prepare_result", lambda result: (result, {}))
     monkeypatch.setattr(
@@ -2422,6 +2436,7 @@ def test_refresh_plugin_season_subscription_keeps_all_sources_seasons_separate(
             "source_strategy": "all",
         }
     )
+    monkeypatch.setattr(plugin, "_start_queue", lambda: True)
     monkeypatch.setattr(plugin, "_client", lambda: Client())
     monkeypatch.setattr(plugin, "_prepare_result", lambda result: (result, {}))
     monkeypatch.setattr(plugin, "_probe_resource_urls", probe)
@@ -2521,6 +2536,7 @@ def test_refresh_does_not_requeue_episode_kept_in_native_tmdb_history(monkeypatc
 
     plugin = _plugin()
     plugin.init_plugin({"enabled": True, "download_root": str(tmp_path)})
+    monkeypatch.setattr(plugin, "_start_queue", lambda: True)
     monkeypatch.setattr(plugin, "_client", lambda: Client())
     monkeypatch.setattr(
         plugin,
@@ -2609,6 +2625,7 @@ def test_refresh_routes_movie_and_tv_subscriptions_to_native_media_directories(m
 
     plugin = _plugin()
     plugin.init_plugin({"enabled": True})
+    monkeypatch.setattr(plugin, "_start_queue", lambda: True)
     monkeypatch.setattr(plugin_module, "_HostDirectoryHelper", DirectoryHelper)
     monkeypatch.setattr(plugin, "_client", lambda: Client())
     monkeypatch.setattr(plugin, "_prepare_result", lambda item: (item, {}))
@@ -2813,3 +2830,597 @@ def test_record_native_history_ignores_database_errors(monkeypatch, tmp_path: Pa
     )
 
     plugin._record_native_history(task, str(tmp_path / "movie.mp4"))
+
+def test_season_media_cards_are_not_order_dependent_when_precise_row_exists():
+    ambiguous = CmsResult(
+        source_key="demo",
+        source_name="演示源",
+        vod_id="bundle",
+        title="示例剧",
+        year="2024",
+        media_type="tv",
+        remark="",
+        episodes=(),
+        season_range=(1, 1),
+        season_ambiguous=True,
+    )
+    precise = CmsResult(
+        source_key="demo",
+        source_name="演示源",
+        vod_id="episode-1",
+        title="示例剧",
+        year="2024",
+        media_type="tv",
+        remark="",
+        episodes=(
+            CmsEpisode(1, 1, "第1集", "https://video.example/s01e01.m3u8"),
+        ),
+        season_range=(0, 0),
+        season_ambiguous=False,
+    )
+
+    for rows in ([ambiguous, precise], [precise, ambiguous]):
+        cards = LunaTVSource._season_media_cards(rows)
+
+        assert len(cards) == 1
+        assert cards[0].season_ambiguous is False
+        assert [(item.season, item.episode) for item in cards[0].episodes] == [(1, 1)]
+
+
+
+def test_quality_cache_prunes_expired_entries_and_enforces_capacity(monkeypatch):
+    plugin = _plugin({"enabled": True})
+    monkeypatch.setattr(plugin_module.time, "monotonic", lambda: 1000.0)
+    monkeypatch.setattr(plugin_module, "probe_stream_height", lambda *_args, **_kwargs: 1080)
+    plugin._quality_cache = {
+        "expired": (0.0, 1080),
+        **{
+            f"https://video.example/{index}.m3u8": (999.0 - index / 10000, 1080)
+            for index in range(plugin_module._QUALITY_CACHE_MAX_ENTRIES + 20)
+        },
+    }
+
+    assert plugin._probe_quality("https://video.example/new.m3u8") == 1080
+    assert "expired" not in plugin._quality_cache
+    assert len(plugin._quality_cache) <= plugin_module._QUALITY_CACHE_MAX_ENTRIES
+
+
+
+def test_quality_probe_passes_explicit_private_network_allowlist(monkeypatch):
+    captured = {}
+
+    def probe(*_args, **kwargs):
+        captured.update(kwargs)
+        return 1080
+
+    plugin = _plugin(
+        {
+            "enabled": True,
+            "probe_allowed_private_ranges": "10.0.0.0/8, 192.168.0.0/16",
+        }
+    )
+    monkeypatch.setattr(plugin_module, "probe_stream_height", probe)
+
+    assert plugin._probe_quality("http://10.0.0.8/video.m3u8") == 1080
+    assert captured["allowed_private_ranges"] == (
+        "10.0.0.0/8",
+        "192.168.0.0/16",
+    )
+
+
+
+def test_resource_search_cache_prunes_expired_entries_and_enforces_capacity():
+    plugin = _plugin({"enabled": True})
+    plugin._resource_search_cache = {
+        "expired": (0.0, []),
+        **{
+            f"fresh-{index}": (999.0 - index / 10000, [])
+            for index in range(plugin_module._RESOURCE_SEARCH_CACHE_MAX_ENTRIES + 20)
+        },
+    }
+
+    plugin._prune_resource_search_cache(1000.0)
+
+    assert "expired" not in plugin._resource_search_cache
+    assert (
+        len(plugin._resource_search_cache)
+        <= plugin_module._RESOURCE_SEARCH_CACHE_MAX_ENTRIES
+    )
+
+
+
+def test_tmdb_cache_enforces_capacity_and_keeps_latest_entry():
+    plugin = _plugin()
+    plugin._tmdb_cache = {
+        f"old-{index}": {"status": "matched", "media_id": str(index)}
+        for index in range(plugin_module._TMDB_CACHE_MAX_ENTRIES + 20)
+    }
+
+    plugin._store_tmdb_cache_entry(
+        "latest",
+        {"status": "matched", "media_id": "latest"},
+   )
+
+    assert len(plugin._tmdb_cache) == plugin_module._TMDB_CACHE_MAX_ENTRIES
+    assert "old-0" not in plugin._tmdb_cache
+    assert plugin._tmdb_cache["latest"]["media_id"] == "latest"
+
+
+def test_manual_download_wakes_queue_once_only_for_new_task(monkeypatch, tmp_path: Path):
+    plugin = _plugin()
+    plugin.init_plugin({"enabled": True, "download_root": str(tmp_path)})
+    wakeups = []
+    monkeypatch.setattr(plugin, "_start_queue", lambda: wakeups.append(True))
+    payload = {
+        "url": "https://example.test/manual.m3u8",
+        "title": "手动下载",
+        "year": "2026",
+        "media_type": "movie",
+    }
+
+    assert plugin.api_download(payload)["success"] is True
+    assert plugin.api_download(payload)["success"] is False
+    assert wakeups == [True]
+
+def test_resource_torrents_forwards_lunatv_progress_callback(monkeypatch):
+    class TorrentInfo:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    calls = []
+
+    class Client:
+        def search(self, query, **kwargs):
+            calls.append((query, kwargs))
+            callback = kwargs["progress_callback"]
+            callback(finished=1, total=2, text="CMS 1/2")
+            callback(finished=2, total=2, text="CMS 2/2")
+            return []
+
+    plugin = _plugin()
+    plugin.init_plugin({"enabled": True})
+    progress = []
+
+    def on_progress(**event):
+        progress.append(event)
+        if event["finished"] == 1:
+            raise RuntimeError("broken host callback")
+
+    monkeypatch.setattr(plugin_module, "_HostTorrentInfo", TorrentInfo)
+    monkeypatch.setattr(plugin, "_client", lambda: Client())
+    monkeypatch.setattr(plugin, "_associate_tmdb", lambda *_args, **_kwargs: {})
+
+    assert plugin._resource_torrents("progress demo", progress_callback=on_progress) == []
+    assert calls[0][0] == "progress demo"
+    assert set(calls[0][1]) == {
+        "limit",
+        "source_limit",
+        "stop_after_first_source",
+        "require_playable",
+        "max_workers",
+        "progress_callback",
+    }
+    assert [(event["finished"], event["total"], event["text"]) for event in progress] == [
+        (1, 2, "LunaTV 正在搜索源 1/2"),
+        (2, 2, "LunaTV 正在搜索源 2/2"),
+    ]
+
+def test_search_torrent_entrypoints_forward_progress_callback(monkeypatch):
+    import asyncio
+
+    plugin = _plugin()
+    plugin.init_plugin({"enabled": True})
+    received = []
+    callback = lambda **_event: None
+
+    def resource_torrents(keyword, mtype=None, progress_callback=None):
+        received.append((keyword, mtype, progress_callback))
+        return ["luna"]
+
+    monkeypatch.setattr(plugin, "_resource_torrents", resource_torrents)
+
+    assert plugin.search_torrents(
+        site={},
+        keyword="sync demo",
+        mtype="tv",
+        progress_callback=callback,
+    ) == ["luna"]
+    assert asyncio.run(
+        plugin.async_search_torrents(
+            site={},
+            keyword="async demo",
+            mtype="movie",
+            progress_callback=callback,
+        )
+    ) == ["luna"]
+    assert received == [
+        ("sync demo", "tv", callback),
+        ("async demo", "movie", callback),
+    ]
+
+@pytest.mark.parametrize(
+    ("mtype", "first_media_type", "expected_media_type"),
+    [
+        ("欧美剧", "tv", "tv"),
+        ("韩剧", "tv", "tv"),
+        ("movie", "tv", "movie"),
+        ("tv", "movie", "tv"),
+    ],
+)
+def test_resource_search_context_uses_first_result_for_noncanonical_type(
+    mtype: str,
+    first_media_type: str,
+    expected_media_type: str,
+):
+    first = CmsResult(
+        source_key="demo",
+        source_name="演示源",
+        vod_id="42",
+        title="示例作品",
+        year="2024",
+        media_type=first_media_type,
+        remark="",
+        episodes=(),
+    )
+
+    context = LunaTVSource._resource_search_context("示例作品", [first], mtype)
+
+    assert context.media_type == expected_media_type
+
+def _install_search_chain_module(monkeypatch, search_chain):
+    app_module = ModuleType("app")
+    app_module.__path__ = []
+    chain_module = ModuleType("app.chain")
+    chain_module.__path__ = []
+    search_module = ModuleType("app.chain.search")
+    search_module.SearchChain = search_chain
+    app_module.chain = chain_module
+    chain_module.search = search_module
+    monkeypatch.setitem(sys.modules, "app", app_module)
+    monkeypatch.setitem(sys.modules, "app.chain", chain_module)
+    monkeypatch.setitem(sys.modules, "app.chain.search", search_module)
+
+def test_plugin_search_bridge_augments_legacy_search_and_restores(monkeypatch):
+    import asyncio
+
+    class SearchChain:
+        def __search_all_sites(self, **_kwargs):
+            return ["native-sync"]
+
+        async def __async_search_all_sites(self, **_kwargs):
+            return ["native-async"]
+
+        async def __async_search_all_sites_stream(self, **_kwargs):
+            yield {"type": "heartbeat", "items": [], "text": "native heartbeat"}
+            yield {
+                "type": "done",
+                "stage": "searching",
+                "items": [],
+                "text": "native done",
+            }
+
+    _install_search_chain_module(monkeypatch, SearchChain)
+    plugin_module._SEARCH_BRIDGE.update(
+        {"owner": None, "chain": None, "originals": {}, "mode": None}
+    )
+    sync_original = SearchChain._SearchChain__search_all_sites
+    async_original = SearchChain._SearchChain__async_search_all_sites
+    stream_original = SearchChain._SearchChain__async_search_all_sites_stream
+    plugin = _plugin()
+    plugin.init_plugin({"enabled": True})
+    monkeypatch.setattr(plugin, "search_torrents", lambda **_kwargs: ["plugin-sync"])
+
+    async def plugin_async_search(**_kwargs):
+        return ["plugin-async"]
+
+    monkeypatch.setattr(plugin, "async_search_torrents", plugin_async_search)
+    try:
+        chain = SearchChain()
+        assert chain._SearchChain__search_all_sites(keyword="demo") == [
+            "native-sync",
+            "plugin-sync",
+        ]
+        assert asyncio.run(
+            chain._SearchChain__async_search_all_sites(keyword="demo")
+        ) == ["native-async", "plugin-async"]
+
+        async def collect_stream():
+            return [
+                event
+                async for event in chain._SearchChain__async_search_all_sites_stream(
+                    keyword="demo"
+                )
+            ]
+
+        events = asyncio.run(collect_stream())
+        assert [event["type"] for event in events] == ["heartbeat", "append", "done"]
+        assert events[1]["items"] == ["plugin-async"]
+        assert events[1]["text"] == "LunaTV 返回 1 条资源"
+        assert events[-1]["text"] == "资源搜索完成，LunaTV 返回 1 条资源"
+    finally:
+        plugin.init_plugin({"enabled": False})
+
+    assert SearchChain._SearchChain__search_all_sites is sync_original
+    assert SearchChain._SearchChain__async_search_all_sites is async_original
+    assert SearchChain._SearchChain__async_search_all_sites_stream is stream_original
+
+def test_async_search_torrents_uses_context_callback_unless_explicit(monkeypatch):
+    import asyncio
+
+    plugin = _plugin()
+    plugin.init_plugin({"enabled": True})
+    callbacks = []
+    context_callback = lambda **_event: None
+    explicit_callback = lambda **_event: None
+
+    def fake_search_torrents(**kwargs):
+        callbacks.append(kwargs.get("progress_callback"))
+        return []
+
+    monkeypatch.setattr(plugin, "search_torrents", fake_search_torrents)
+
+    async def run():
+        token = plugin_module._SEARCH_PROGRESS_CALLBACK.set(context_callback)
+        try:
+            await plugin.async_search_torrents(site={}, keyword="context")
+            await plugin.async_search_torrents(
+                site={},
+                keyword="explicit",
+                progress_callback=explicit_callback,
+            )
+        finally:
+            plugin_module._SEARCH_PROGRESS_CALLBACK.reset(token)
+
+    asyncio.run(run())
+    assert callbacks == [context_callback, explicit_callback]
+
+def test_native_search_stream_progress_precedes_native_append_and_done(monkeypatch):
+    import asyncio
+
+    native_calls = []
+    plugin_search_calls = []
+
+    class SearchChain:
+        def search_plugin_torrents(self, **_kwargs):
+            return ["native-plugin-sync"]
+
+        async def async_search_plugin_torrents(self, **kwargs):
+            native_calls.append(kwargs["keyword"])
+            return await plugin.async_search_torrents(
+                site={},
+                keyword=kwargs["keyword"],
+                page=kwargs.get("page", 0),
+            )
+
+        def __search_all_sites(self, **_kwargs):
+            return ["native-sync"]
+
+        async def __async_search_all_sites(self, **_kwargs):
+            return ["native-async"]
+
+        async def __async_search_all_sites_stream(self, **kwargs):
+            items = await self.async_search_plugin_torrents(**kwargs)
+            yield {"type": "append", "items": items, "text": "native append"}
+            yield {"type": "done", "items": [], "text": "native done"}
+
+    _install_search_chain_module(monkeypatch, SearchChain)
+    plugin_module._SEARCH_BRIDGE.update(
+        {"owner": None, "chain": None, "originals": {}, "mode": None}
+    )
+    native_sync_original = SearchChain.search_plugin_torrents
+    native_async_original = SearchChain.async_search_plugin_torrents
+    sync_original = SearchChain._SearchChain__search_all_sites
+    async_original = SearchChain._SearchChain__async_search_all_sites
+    stream_original = SearchChain._SearchChain__async_search_all_sites_stream
+    plugin = _plugin()
+    plugin.init_plugin({"enabled": True})
+
+    def fake_search_torrents(**kwargs):
+        plugin_search_calls.append(kwargs["keyword"])
+        callback = kwargs["progress_callback"]
+        callback(finished=1, total=2, text="LunaTV 正在搜索源 1/2")
+        callback(finished=2, total=2, text="LunaTV 正在搜索源 2/2")
+        return ["luna"]
+
+    monkeypatch.setattr(plugin, "search_torrents", fake_search_torrents)
+    try:
+        wrapped_stream = SearchChain._SearchChain__async_search_all_sites_stream
+        plugin.init_plugin({"enabled": True})
+        assert SearchChain._SearchChain__async_search_all_sites_stream is wrapped_stream
+        assert SearchChain.search_plugin_torrents is native_sync_original
+        assert SearchChain.async_search_plugin_torrents is native_async_original
+        assert SearchChain._SearchChain__search_all_sites is sync_original
+        assert SearchChain._SearchChain__async_search_all_sites is async_original
+
+        async def collect_stream():
+            return [
+                event
+                async for event in SearchChain()._SearchChain__async_search_all_sites_stream(
+                    keyword="demo",
+                    page=3,
+                )
+            ]
+
+        events = asyncio.run(collect_stream())
+        assert native_calls == ["demo"]
+        assert plugin_search_calls == ["demo"]
+        assert [event["type"] for event in events] == [
+            "progress",
+            "progress",
+            "append",
+            "done",
+        ]
+        assert [
+            (
+                event["finished"],
+                event["total"],
+                event["value"],
+                event["text"],
+                event["stage"],
+                event["items"],
+                event["site"],
+                event["site_id"],
+                event["page"],
+            )
+            for event in events[:2]
+        ] == [
+            (1, 2, 50, "LunaTV 正在搜索源 1/2", "searching", [], "LunaTV", None, 3),
+            (2, 2, 100, "LunaTV 正在搜索源 2/2", "searching", [], "LunaTV", None, 3),
+        ]
+        assert events[2] == {
+            "type": "append",
+            "items": ["luna"],
+            "text": "native append",
+        }
+        assert events[3] == {"type": "done", "items": [], "text": "native done"}
+    finally:
+        plugin.init_plugin({"enabled": False})
+
+    assert SearchChain.search_plugin_torrents is native_sync_original
+    assert SearchChain.async_search_plugin_torrents is native_async_original
+    assert SearchChain._SearchChain__search_all_sites is sync_original
+    assert SearchChain._SearchChain__async_search_all_sites is async_original
+    assert SearchChain._SearchChain__async_search_all_sites_stream is stream_original
+
+def test_native_search_stream_progress_isolated_between_requests(monkeypatch):
+    import asyncio
+
+    rendezvous = threading.Barrier(2, timeout=1)
+    plugin_search_calls = []
+
+    class SearchChain:
+        def search_plugin_torrents(self, **_kwargs):
+            return []
+
+        async def async_search_plugin_torrents(self, **kwargs):
+            return await plugin.async_search_torrents(
+                site={},
+                keyword=kwargs["keyword"],
+                page=kwargs.get("page", 0),
+            )
+
+        async def __async_search_all_sites_stream(self, **kwargs):
+            items = await self.async_search_plugin_torrents(**kwargs)
+            yield {"type": "append", "items": items, "text": kwargs["keyword"]}
+            yield {"type": "done", "items": [], "text": kwargs["keyword"]}
+
+    _install_search_chain_module(monkeypatch, SearchChain)
+    plugin_module._SEARCH_BRIDGE.update(
+        {"owner": None, "chain": None, "originals": {}, "mode": None}
+    )
+    plugin = _plugin()
+    plugin.init_plugin({"enabled": True})
+
+    def fake_search_torrents(**kwargs):
+        keyword = kwargs["keyword"]
+        plugin_search_calls.append(keyword)
+        callback = kwargs["progress_callback"]
+        callback(finished=1, total=2, text=f"{keyword} 1/2")
+        rendezvous.wait()
+        callback(finished=2, total=2, text=f"{keyword} 2/2")
+        return [keyword]
+
+    monkeypatch.setattr(plugin, "search_torrents", fake_search_torrents)
+    try:
+        async def collect(keyword):
+            return [
+                event
+                async for event in SearchChain()._SearchChain__async_search_all_sites_stream(
+                    keyword=keyword
+                )
+            ]
+
+        async def collect_both():
+            return await asyncio.gather(collect("first"), collect("second"))
+
+        first, second = asyncio.run(collect_both())
+    finally:
+        plugin.init_plugin({"enabled": False})
+
+    assert sorted(plugin_search_calls) == ["first", "second"]
+    for keyword, events in (("first", first), ("second", second)):
+        assert [event["type"] for event in events] == [
+            "progress",
+            "progress",
+            "append",
+            "done",
+        ]
+        assert [event["text"] for event in events[:2]] == [
+            f"{keyword} 1/2",
+            f"{keyword} 2/2",
+        ]
+        assert events[2]["items"] == [keyword]
+
+def test_native_search_stream_discards_late_progress_after_cancellation(monkeypatch):
+    import asyncio
+    from threading import Event
+
+    slow_started = Event()
+    release_slow = Event()
+    slow_finished = Event()
+
+    class SearchChain:
+        def search_plugin_torrents(self, **_kwargs):
+            return []
+
+        async def async_search_plugin_torrents(self, **kwargs):
+            return await plugin.async_search_torrents(
+                site={},
+                keyword=kwargs["keyword"],
+            )
+
+        async def __async_search_all_sites_stream(self, **kwargs):
+            items = await self.async_search_plugin_torrents(**kwargs)
+            yield {"type": "append", "items": items}
+            yield {"type": "done", "items": []}
+
+    _install_search_chain_module(monkeypatch, SearchChain)
+    plugin_module._SEARCH_BRIDGE.update(
+        {"owner": None, "chain": None, "originals": {}, "mode": None}
+    )
+    plugin = _plugin()
+    plugin.init_plugin({"enabled": True})
+
+    def fake_search_torrents(**kwargs):
+        callback = kwargs["progress_callback"]
+        callback(finished=1, total=2, text="LunaTV 正在搜索源 1/2")
+        slow_started.set()
+        release_slow.wait(1)
+        callback(finished=2, total=2, text="LunaTV 正在搜索源 2/2")
+        slow_finished.set()
+        return ["luna"]
+
+    monkeypatch.setattr(plugin, "search_torrents", fake_search_torrents)
+    try:
+        async def collect_until_cancelled():
+            events = []
+
+            async def consume():
+                async for event in SearchChain()._SearchChain__async_search_all_sites_stream(
+                    keyword="demo"
+                ):
+                    events.append(event)
+
+            consumer = asyncio.create_task(consume())
+            for _ in range(100):
+                if slow_started.is_set() and events:
+                    break
+                await asyncio.sleep(0.01)
+            assert [event["type"] for event in events] == ["progress"]
+            consumer.cancel()
+            try:
+                await consumer
+            except asyncio.CancelledError:
+                pass
+            release_slow.set()
+            assert await asyncio.to_thread(slow_finished.wait, 1)
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            return events
+
+        events = asyncio.run(collect_until_cancelled())
+    finally:
+        release_slow.set()
+        plugin.init_plugin({"enabled": False})
+
+    assert [event["type"] for event in events] == ["progress"]

--- a/tests/v3/lunatvsource/test_queue.py
+++ b/tests/v3/lunatvsource/test_queue.py
@@ -1,4 +1,5 @@
 import http.server
+import shutil
 import threading
 import urllib.request
 from pathlib import Path
@@ -559,6 +560,464 @@ def test_queue_remove_running_task_cleans_part_after_safe_stop(tmp_path: Path):
     assert not output.exists()
     assert not part.exists()
     assert queue.list_tasks() == []
+
+
+def test_queue_wake_drains_task_enqueued_while_run_one_is_active(tmp_path: Path):
+    data = {}
+    completed_second = threading.Event()
+    queue = DownloadQueue(
+        data.get,
+        data.__setitem__,
+        lambda *_: None,
+        on_complete=lambda task, _output: completed_second.set()
+        if task.task_id == "added-while-running" else None,
+    )
+    active_task = DownloadTask(
+        task_id="active",
+        source_key="lunatv",
+        media_id="site:active",
+        title="示例",
+        year="2026",
+        media_type="movie",
+        season=1,
+        episode=1,
+        url="https://example.test/active.m3u8",
+        root=str(tmp_path),
+    )
+    added_task = DownloadTask(
+        task_id="added-while-running",
+        source_key="lunatv",
+        media_id="site:added",
+        title="示例",
+        year="2026",
+        media_type="movie",
+        season=1,
+        episode=2,
+        url="https://example.test/added.m3u8",
+        root=str(tmp_path),
+    )
+    assert queue.enqueue(active_task) is True
+    active_started = threading.Event()
+    allow_active_finish = threading.Event()
+    execution_lock = threading.Lock()
+    active_count = 0
+    max_active_count = 0
+    executed = []
+
+    def execute(task: DownloadTask) -> str:
+        nonlocal active_count, max_active_count
+        with execution_lock:
+            active_count += 1
+            max_active_count = max(max_active_count, active_count)
+            executed.append(task.task_id)
+        try:
+            if task.task_id == active_task.task_id:
+                active_started.set()
+                assert allow_active_finish.wait(timeout=2)
+            return str(tmp_path / f"{task.task_id}.mp4")
+        finally:
+            with execution_lock:
+                active_count -= 1
+
+    queue._execute = execute
+    direct_worker = threading.Thread(target=queue.run_one)
+    direct_worker.start()
+    assert active_started.wait(timeout=2)
+    assert queue.enqueue(added_task) is True
+    assert queue.wake() is True
+    allow_active_finish.set()
+    direct_worker.join(timeout=2)
+
+    assert not direct_worker.is_alive()
+    assert completed_second.wait(timeout=2)
+    assert executed == ["active", "added-while-running"]
+    assert max_active_count == 1
+    assert queue.summary()["completed"] == 2
+
+def test_queue_recovers_after_running_state_persistence_failure(tmp_path: Path):
+    data = {}
+    running_save_failed = threading.Event()
+    completed = threading.Event()
+    fail_running_save = True
+
+    def save(key, value):
+        nonlocal fail_running_save
+        if fail_running_save and any(item["state"] == "running" for item in value):
+            fail_running_save = False
+            running_save_failed.set()
+            raise RuntimeError("temporary persistence failure")
+        data[key] = value
+
+    queue = DownloadQueue(
+        data.get,
+        save,
+        lambda *_: None,
+        on_complete=lambda *_: completed.set(),
+    )
+    task = DownloadTask(
+        task_id="recover-after-save-failure",
+        source_key="lunatv",
+        media_id="site:recover",
+        title="示例",
+        year="2026",
+        media_type="movie",
+        season=1,
+        episode=1,
+        url="https://example.test/recover.m3u8",
+        root=str(tmp_path),
+    )
+    assert queue.enqueue(task) is True
+    queue._execute = lambda current: str(tmp_path / f"{current.task_id}.mp4")
+
+    assert queue.wake() is True
+    assert running_save_failed.wait(timeout=2)
+    for _ in range(100):
+        with queue._lock:
+            if not queue._drain_running:
+                break
+        threading.Event().wait(0.01)
+
+    with queue._lock:
+        assert queue._drain_running is False
+        assert queue._running is False
+        assert queue._current_task_id == ""
+        assert queue._control_action == ""
+        assert queue._idle_event.is_set()
+    assert data[queue.DATA_KEY][0]["state"] == "pending"
+
+    assert queue.wake() is True
+    assert completed.wait(timeout=2)
+    assert queue.summary()["completed"] == 1
+
+def test_queue_wake_during_drain_failure_is_not_lost(tmp_path: Path):
+    data = {}
+    completed = threading.Event()
+    queue = DownloadQueue(
+        data.get,
+        data.__setitem__,
+        lambda *_: None,
+        on_complete=lambda *_: completed.set(),
+    )
+    task = DownloadTask(
+        task_id="wake-during-drain-failure",
+        source_key="lunatv",
+        media_id="site:wake-during-drain-failure",
+        title="示例",
+        year="2026",
+        media_type="movie",
+        season=1,
+        episode=1,
+        url="https://example.test/recover.m3u8",
+        root=str(tmp_path),
+    )
+    assert queue.enqueue(task) is True
+    queue._execute = lambda current: str(tmp_path / f"{current.task_id}.mp4")
+
+    first_attempt = threading.Event()
+    release_failure = threading.Event()
+    retried = threading.Event()
+    original_drain = queue._drain_until_idle
+    attempts = 0
+
+    def flaky_drain() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            first_attempt.set()
+            assert release_failure.wait(timeout=2)
+            raise RuntimeError("temporary drain failure")
+        retried.set()
+        original_drain()
+
+    queue._drain_until_idle = flaky_drain
+    assert queue.wake() is True
+    assert first_attempt.wait(timeout=2)
+    assert queue.wake() is True
+    release_failure.set()
+
+    assert retried.wait(timeout=2)
+    assert completed.wait(timeout=2)
+    assert queue.summary()["completed"] == 1
+
+def test_ffmpeg_uses_hls_http_options_and_mp4_muxer(monkeypatch, tmp_path: Path):
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        return type("Completed", (), {"returncode": 0, "stderr": "", "stdout": ""})()
+
+    monkeypatch.setattr(downloader_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(DownloadQueue, "_prepare_hls_input", lambda url, _temp, *_args: url)
+    DownloadQueue._run_ffmpeg("ffmpeg", "https://example.test/video.m3u8", tmp_path / "movie.mp4.part")
+    command = captured["command"]
+    assert command[command.index("-f") + 1] == "mp4"
+    assert command[command.index("-allowed_segment_extensions") + 1] == "ALL"
+    assert command[command.index("-extension_picky") + 1] == "0"
+    assert command[command.index("-seg_max_retry") + 1] == "2"
+    assert command[command.index("-http_persistent") + 1] == "1"
+    assert command[command.index("-http_multiple") + 1] == "1"
+    assert command[command.index("-http_seekable") + 1] == "0"
+    assert "-multiple_requests" not in command
+    assert "-seekable" not in command
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="requires ffmpeg")
+def test_run_ffmpeg_materializes_http_playlist_with_hls_http_options(
+    monkeypatch,
+    tmp_path: Path,
+):
+    ffmpeg_path = shutil.which("ffmpeg")
+    assert ffmpeg_path is not None
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_playlist = source_dir / "index.m3u8"
+    created = downloader_module.subprocess.run(
+        [
+            ffmpeg_path,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=1000:sample_rate=48000",
+            "-t",
+            "0.25",
+            "-c:a",
+            "aac",
+            "-f",
+            "hls",
+            "-hls_time",
+            "1",
+            "-hls_list_size",
+            "0",
+            str(source_playlist),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert created.returncode == 0, created.stderr
+
+    class SourceHandler(http.server.SimpleHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(source_dir), **kwargs)
+
+        def log_message(self, _format: str, *_args) -> None:
+            return
+
+    source = _LoopbackHTTPServer(("127.0.0.1", 0), SourceHandler)
+    source_thread = threading.Thread(target=source.serve_forever, daemon=True)
+    source_thread.start()
+    captured = {}
+    original_run = downloader_module.subprocess.run
+
+    def capture_run(command, **kwargs):
+        captured["command"] = list(command)
+        return original_run(command, **kwargs)
+
+    monkeypatch.setattr(downloader_module.subprocess, "run", capture_run)
+    output = tmp_path / "output.mp4"
+    try:
+        remote_url = f"http://127.0.0.1:{source.server_address[1]}/index.m3u8"
+        DownloadQueue._run_ffmpeg(ffmpeg_path, remote_url, output)
+    finally:
+        source.shutdown()
+        source.server_close()
+        source_thread.join(timeout=2)
+
+    command = captured["command"]
+    input_url = command[command.index("-i") + 1]
+    assert Path(input_url).name.startswith("playlist-")
+    assert input_url.endswith(".m3u8")
+    assert command[command.index("-http_persistent") + 1] == "1"
+    assert command[command.index("-http_multiple") + 1] == "1"
+    assert command[command.index("-http_seekable") + 1] == "0"
+    assert "-multiple_requests" not in command
+    assert "-seekable" not in command
+    assert output.stat().st_size > 0
+
+def test_segment_proxy_closes_http11_response_without_upstream_length():
+    payload = (b"\x47" + (b"a" * 187)) * 3
+
+    class SourceHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - stdlib handler contract
+            self.send_response(200)
+            self.send_header("Content-Type", "video/mp2t")
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):
+            return
+
+    source = _LoopbackHTTPServer(("127.0.0.1", 0), SourceHandler)
+    thread = threading.Thread(target=source.serve_forever, daemon=True)
+    thread.start()
+    try:
+        remote = f"http://127.0.0.1:{source.server_address[1]}/segment.ts"
+        with _SegmentProxy() as proxy, urllib.request.urlopen(proxy.url_for(remote), timeout=5) as response:
+            assert response.version == 11
+            assert response.headers.get("Content-Length") is None
+            assert response.headers.get("Connection") == "close"
+            assert response.read() == payload
+    finally:
+        source.shutdown()
+        source.server_close()
+        thread.join(timeout=2)
+
+@pytest.mark.parametrize(
+    ("action", "persist_before_error"),
+    [
+        ("pause", False),
+        ("pause", True),
+        ("remove", False),
+        ("remove", True),
+    ],
+    ids=[
+        "pause-write-before-error",
+        "pause-write-then-error",
+        "remove-write-before-error",
+        "remove-write-then-error",
+    ],
+)
+def test_queue_replays_control_after_target_persistence_failure(
+    tmp_path: Path,
+    action: str,
+    persist_before_error: bool,
+):
+    data = {}
+    started = threading.Event()
+    target_write_failed = threading.Event()
+    execute_calls = 0
+    task_id = f"control-save-{action}-{int(persist_before_error)}"
+
+    def targets_control_state(value):
+        current = next((item for item in value if item["task_id"] == task_id), None)
+        if action == "pause":
+            return current is not None and current["state"] == "paused"
+        return current is None
+
+    def save(key, value):
+        if targets_control_state(value) and not target_write_failed.is_set():
+            if persist_before_error:
+                data[key] = value
+            target_write_failed.set()
+            raise RuntimeError("temporary control-state persistence failure")
+        data[key] = value
+
+    queue = DownloadQueue(data.get, save, lambda *_: None)
+    task = DownloadTask(
+        task_id=task_id,
+        source_key="lunatv",
+        media_id=f"site:{task_id}",
+        title="示例",
+        year="2026",
+        media_type="movie",
+        season=1,
+        episode=1,
+        url="https://example.test/control.m3u8",
+        root=str(tmp_path),
+    )
+    assert queue.enqueue(task) is True
+
+    def controlled_execute(_current: DownloadTask) -> str:
+        nonlocal execute_calls
+        execute_calls += 1
+        started.set()
+        assert queue._control_event.wait(timeout=2)
+        raise downloader_module._QueueControl(action)
+
+    queue._execute = controlled_execute
+    assert queue.wake() is True
+    assert started.wait(timeout=2)
+    if action == "pause":
+        assert queue.pause(task.task_id) is True
+    else:
+        assert queue.remove(task.task_id, delete_file=True) is True
+    assert target_write_failed.wait(timeout=2)
+
+    for _ in range(200):
+        with queue._lock:
+            if not queue._drain_running:
+                break
+        threading.Event().wait(0.01)
+
+    with queue._lock:
+        assert queue._drain_running is False
+        assert queue._running is False
+        assert queue._control_action == ""
+        assert queue._current_task_id == ""
+        assert task.task_id not in queue._delete_file_tasks
+    assert execute_calls == 1
+    if action == "pause":
+        tasks = queue.list_tasks()
+        assert len(tasks) == 1
+        assert tasks[0]["state"] == "paused"
+    else:
+        assert queue.list_tasks() == []
+
+def test_queue_stop_retries_interrupted_pause_persistence(tmp_path: Path):
+    data = {}
+    started = threading.Event()
+    pause_write_failed = threading.Event()
+    execute_calls = 0
+    task_id = "stop-save-failure"
+
+    def save(key, value):
+        current = next((item for item in value if item["task_id"] == task_id), None)
+        if (
+            current is not None
+            and current["state"] == "paused"
+            and not pause_write_failed.is_set()
+        ):
+            pause_write_failed.set()
+            raise RuntimeError("temporary stop persistence failure")
+        data[key] = value
+
+    queue = DownloadQueue(data.get, save, lambda *_: None)
+    task = DownloadTask(
+        task_id=task_id,
+        source_key="lunatv",
+        media_id=f"site:{task_id}",
+        title="示例",
+        year="2026",
+        media_type="movie",
+        season=1,
+        episode=1,
+        url="https://example.test/stop.m3u8",
+        root=str(tmp_path),
+    )
+    assert queue.enqueue(task) is True
+
+    def controlled_execute(_current: DownloadTask) -> str:
+        nonlocal execute_calls
+        execute_calls += 1
+        started.set()
+        assert queue._control_event.wait(timeout=2)
+        raise downloader_module._QueueControl("pause")
+
+    queue._execute = controlled_execute
+    assert queue.wake() is True
+    assert started.wait(timeout=2)
+    queue.stop()
+    assert pause_write_failed.wait(timeout=2)
+
+    for _ in range(200):
+        with queue._lock:
+            if not queue._drain_running:
+                break
+        threading.Event().wait(0.01)
+
+    with queue._lock:
+        assert queue._drain_running is False
+        assert queue._control_action == ""
+        assert queue._current_task_id == ""
+    assert execute_calls == 1
+    tasks = queue.list_tasks()
+    assert len(tasks) == 1
+    assert tasks[0]["state"] == "paused"
+
 
 
 def test_queue_remove_running_task_wins_over_immediate_pause(tmp_path: Path):

--- a/tests/v3/lunatvsource/test_resource_download_flow.py
+++ b/tests/v3/lunatvsource/test_resource_download_flow.py
@@ -1,0 +1,244 @@
+import threading
+from pathlib import Path
+
+import app.plugins.lunatvsource as plugin_module
+from app.plugins.lunatvsource import LunaTVSource
+from app.plugins.lunatvsource.cms import CmsSource, _result_from_item
+
+
+class FakeTorrentInfo:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _configured_plugin(monkeypatch, results):
+    class Client:
+        def search(self, *_args, **_kwargs):
+            return list(results)
+
+    plugin = _plugin({"enabled": True})
+    monkeypatch.setattr(plugin_module, "_HostTorrentInfo", FakeTorrentInfo)
+    monkeypatch.setattr(plugin, "_client", lambda: Client())
+    monkeypatch.setattr(plugin, "_associate_tmdb", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        plugin_module,
+        "probe_stream_height",
+        lambda url, *_args, **_kwargs: 1080 if "1080" in url else 480,
+    )
+    return plugin
+
+
+class _PluginData:
+    def __init__(self):
+        self.values = {}
+
+    def get_data(self, _plugin_id, key):
+        return self.values.get(key)
+
+    def save(self, _plugin_id, key, value):
+        self.values[key] = value
+
+
+def _plugin(config=None):
+    plugin = object.__new__(LunaTVSource)
+    plugin.plugindata = _PluginData()
+    plugin._logger = plugin_module.LOGGER
+    plugin._download_metrics_lock = threading.Lock()
+    plugin._download_metrics = {}
+    plugin._quality_cache_lock = threading.Lock()
+    plugin._quality_cache = {}
+    plugin.init_plugin(config)
+    return plugin
+
+def test_search_movie_resources_are_sorted_and_download_queues_highest_resolution(
+    monkeypatch, tmp_path: Path
+):
+    source = CmsSource("demo", "演示源", "https://cms.example/vod")
+    low = _result_from_item(
+        source,
+        {
+            "vod_id": "movie-low",
+            "vod_name": "示例电影",
+            "type_name": "电影",
+            "vod_play_url": "正片$https://video.example/480.m3u8",
+        },
+    )
+    high = _result_from_item(
+        source,
+        {
+            "vod_id": "movie-high",
+            "vod_name": "示例电影",
+            "type_name": "电影",
+            "vod_play_url": "正片$https://video.example/1080.m3u8",
+        },
+    )
+    plugin = _configured_plugin(monkeypatch, [low, high])
+
+    resources = plugin.search_torrents(
+        {"id": "demo"}, "示例电影", mtype="电影"
+    )
+
+    assert [item.title for item in resources] == [
+        "示例电影 · 1080P",
+        "示例电影 · 480P",
+    ]
+    assert [item.pri_order for item in resources] == [1080, 480]
+    assert [
+        plugin._decode_resource_token(item.enclosure)["resolution"]
+        for item in resources
+    ] == ["1080P", "480P"]
+
+    monkeypatch.setattr(plugin, "_start_queue", lambda: None)
+    result = plugin.download(resources[0].enclosure, tmp_path)
+
+    assert result[0] == "LunaTVSource"
+    tasks = plugin._queue._read()
+    assert len(tasks) == 1
+    assert tasks[0].url == "https://video.example/1080.m3u8"
+
+
+def test_search_tv_resources_are_season_cards_and_download_runs_episodes_serially(
+    monkeypatch, tmp_path: Path
+):
+    source = CmsSource("demo", "演示源", "https://cms.example/vod")
+    low = _result_from_item(
+        source,
+        {
+            "vod_id": "season-low",
+            "vod_name": "示例剧 第一季",
+            "type_name": "电视剧",
+            "vod_play_url": (
+                "第1集$https://video.example/480-e1.m3u8#"
+                "第2集$https://video.example/480-e2.m3u8"
+            ),
+        },
+    )
+    high = _result_from_item(
+        source,
+        {
+            "vod_id": "season-high",
+            "vod_name": "示例剧 第一季",
+            "type_name": "电视剧",
+            "vod_play_url": (
+                "第1集$https://video.example/1080-e1.m3u8#"
+                "第2集$https://video.example/1080-e2.m3u8"
+            ),
+        },
+    )
+    plugin = _configured_plugin(monkeypatch, [low, high])
+    monkeypatch.setattr(plugin, "_start_queue", lambda: True)
+
+    resources = plugin.search_torrents(
+        {"id": "demo"}, "示例剧", mtype="电视剧"
+    )
+
+    assert [item.title for item in resources] == [
+        "示例剧 · 第1季 · 1080P",
+        "示例剧 · 第1季 · 480P",
+    ]
+    assert all("集" not in item.title for item in resources)
+    assert [item.pri_order for item in resources] == [1080, 480]
+    high_payload = plugin._decode_resource_token(resources[0].enclosure)
+    assert [episode["episode"] for episode in high_payload["episodes"]] == [1, 2]
+
+    result = plugin.download(resources[0].enclosure, tmp_path)
+
+    assert result[0] == "LunaTVSource"
+    queued = plugin._queue._read()
+    assert [(task.season, task.episode, task.url) for task in queued] == [
+        (1, 1, "https://video.example/1080-e1.m3u8"),
+        (1, 2, "https://video.example/1080-e2.m3u8"),
+    ]
+
+    executed = []
+
+    def fake_execute(task):
+        executed.append((task.episode, task.url))
+        return str(tmp_path / f"episode-{task.episode}.mp4")
+
+    plugin._queue._execute = fake_execute
+    assert plugin._queue.run_one()["state"] == "completed"
+    assert plugin._queue.run_one()["state"] == "completed"
+    assert executed == [
+        (1, "https://video.example/1080-e1.m3u8"),
+        (2, "https://video.example/1080-e2.m3u8"),
+    ]
+
+
+def test_long_season_cards_probe_every_episode_and_keep_full_hd_download(
+    monkeypatch, tmp_path: Path
+):
+    source = CmsSource("demo", "演示源", "https://cms.example/vod")
+    mixed_urls = [
+        f"https://video.example/mixed-{'480' if episode == 2 else '1080'}-e{episode}.m3u8"
+        for episode in range(1, 7)
+    ]
+    full_hd_urls = [
+        f"https://video.example/full-1080-e{episode}.m3u8"
+        for episode in range(1, 7)
+    ]
+    mixed = _result_from_item(
+        source,
+        {
+            "vod_id": "season-mixed",
+            "vod_name": "长季剧",
+            "type_name": "电视剧",
+            "vod_play_url": "#".join(
+                f"第{episode}集${url}" for episode, url in enumerate(mixed_urls, start=1)
+            ),
+        },
+    )
+    full_hd = _result_from_item(
+        source,
+        {
+            "vod_id": "season-full-hd",
+            "vod_name": "长季剧",
+            "type_name": "电视剧",
+            "vod_play_url": "#".join(
+                f"第{episode}集${url}"
+                for episode, url in enumerate(full_hd_urls, start=1)
+            ),
+        },
+    )
+    plugin = _configured_plugin(monkeypatch, [mixed, full_hd])
+    probed_urls = []
+
+    def probe(url, *_args, **_kwargs):
+        probed_urls.append(url)
+        return 480 if "mixed-480-e2" in url else 1080
+
+    monkeypatch.setattr(plugin_module, "probe_stream_height", probe)
+
+    resources = plugin.search_torrents(
+        {"id": "demo"}, "长季剧", mtype="电视剧"
+    )
+
+    assert [item.pri_order for item in resources] == [1080, 480]
+    assert [item.title for item in resources] == [
+        "长季剧 · 第1季 · 1080P",
+        "长季剧 · 第1季 · 480P",
+    ]
+    assert all("抽样" not in item.description for item in resources)
+    assert all("全6集实测" in item.description for item in resources)
+    assert sorted(probed_urls) == sorted(mixed_urls + full_hd_urls)
+
+    full_hd_payload = plugin._decode_resource_token(resources[0].enclosure)
+    mixed_payload = plugin._decode_resource_token(resources[1].enclosure)
+    assert full_hd_payload["resolution_scope"] == "full"
+    assert full_hd_payload["resolution_probed_episode_count"] == 6
+    assert mixed_payload["resolution_height"] == 480
+    assert [episode["resolution_height"] for episode in mixed_payload["episodes"]] == [
+        1080,
+        480,
+        1080,
+        1080,
+        1080,
+        1080,
+    ]
+    assert all("480" not in episode["url"] for episode in full_hd_payload["episodes"])
+
+    monkeypatch.setattr(plugin, "_start_queue", lambda: None)
+    result = plugin.download(resources[0].enclosure, tmp_path)
+
+    assert result[0] == "LunaTVSource"
+    assert all("480" not in task.url for task in plugin._queue._read())

--- a/tests/v3/lunatvsource/test_security_config.py
+++ b/tests/v3/lunatvsource/test_security_config.py
@@ -1,0 +1,38 @@
+import threading
+from app.plugins.lunatvsource import LunaTVSource
+import app.plugins.lunatvsource as plugin_module
+
+
+class _PluginData:
+    def __init__(self):
+        self.values = {}
+
+    def get_data(self, _plugin_id, key):
+        return self.values.get(key)
+
+    def save(self, _plugin_id, key, value):
+        self.values[key] = value
+
+
+def _plugin(config=None):
+    plugin = object.__new__(LunaTVSource)
+    plugin.plugindata = _PluginData()
+    plugin._logger = plugin_module.LOGGER
+    plugin._download_metrics_lock = threading.Lock()
+    plugin._download_metrics = {}
+    plugin._quality_cache_lock = threading.Lock()
+    plugin._quality_cache = {}
+    plugin.init_plugin(config)
+    return plugin
+
+def test_probe_allowlist_does_not_inherit_image_proxy_settings(monkeypatch):
+    monkeypatch.setattr(
+        plugin_module,
+        "_get_runtime_settings",
+        lambda: {"IMAGE_PROXY_ALLOWED_PRIVATE_RANGES": ["10.0.0.0/8"]},
+        raising=False,
+    )
+
+    plugin = _plugin({"enabled": True})
+
+    assert plugin._probe_allowed_private_ranges() == ()


### PR DESCRIPTION
## 更新

- 搜索按实际 CMS 源报告 X/N 进度，修复欧美剧、韩剧等分类的电视剧空结果与媒体类型关联错误
- 电影和电视剧显示实际分辨率并按清晰度降序排列，整季逐集探测，同集多地址选择最高画质
- 下载入队立即启动并保持整季串行，修复队列唤醒、异常恢复及暂停/删除/停止持久化竞态
- HLS 分片代理升级为 HTTP/1.1，FFmpeg 启用 HLS HTTP 多连接参数
- 更新 LunaTVSource 至 0.4.39，并补齐官方 V3 测试

## 验证

- LunaTVSource 专项：166 passed
- V3 全量：271 passed
- V2 全量：30 passed
- 仓库 CI 自测：41 passed，1 个 upstream/main 基线失败
- 插件版本门禁、联邦 CSS 门禁、新插件测试门禁：通过
- Python 编译、JSON 校验、git diff --check：通过

已知基线问题：upstream/main@91a4336 的 tests/ci/test_plugin_release_directory.py::test_release_workflow_preserves_all_generation_releases 要求 release.yml 包含 prev_tag="$tag"，但当前 release.yml 缺少该行；本 PR 未修改官方发布工作流。

源码 Release：OneBigMoon/moviepilot-v3-lunatv-source 的 LunaTVSource_v0.4.39。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at afca84b6d78ebfe5237b934c9d5e89b062ef5ed1

- 搜索流展示 CMS 实时进度
- 修复区域剧集类型识别
- 全季逐集探测实际清晰度
- 探测限制公网并支持白名单
- 下载入队后立即唤醒队列
- 限制缓存容量，降低内存风险
- 补充搜索、探测、下载测试
- 风险：全季探测增加搜索耗时
<!-- pr-agent-summary:end -->
