### PR TITLE
fix: isolate LunaTVSource ambiguous years

### DIFF
--- a/plugins.v3/lunatvsource/cms.py
+++ b/plugins.v3/lunatvsource/cms.py
@@ -1360,6 +1360,7 @@ class AppleCmsClient:
                 | selected_unknown_year_groups
                 | set(upgraded_unknown_groups)
             )
+            has_conflict = False
             for base_key in possible_unknown_groups:
                 known_years = {
                     *seen_explicit_years.get(base_key, set()),
@@ -1367,8 +1368,8 @@ class AppleCmsClient:
                 }
                 if len(known_years) > 1:
                     restore_upgraded_group(base_key)
-                    return True
-            return False
+                    has_conflict = True
+            return has_conflict
 
         def collect_results(
             page_results: Iterable[CmsResult], selected_group_only: bool = False
@@ -1377,17 +1378,21 @@ class AppleCmsClient:
 
             nonlocal selected_count
             conflict = False
-            playable_results = [
+            media_type_results = [
                 result
                 for result in page_results
                 if (not media_type_filter or result.media_type == media_type_filter)
-                and (not require_playable or result.episodes)
             ]
-            _, unknown_year_groups = remember_year_groups(playable_results)
+            playable_results = [
+                result
+                for result in media_type_results
+                if not require_playable or result.episodes
+            ]
+            _, unknown_year_groups = remember_year_groups(media_type_results)
             if (
                 selected_group_only
                 and selected_groups
-                and selected_group_year_conflict(playable_results)
+                and selected_group_year_conflict(media_type_results)
             ):
                 return True
             row_group_keys = set()

--- a/tests/v3/lunatvsource/test_cms.py
+++ b/tests/v3/lunatvsource/test_cms.py
@@ -1581,6 +1581,77 @@ def test_search_episode_row_expansion_does_not_upgrade_ambiguous_unknown_year():
     ]
 
 
+def test_search_episode_row_expansion_remembers_unplayable_year_candidates():
+    source = CmsSource(key="demo", name="演示", api="https://cms.example/vod")
+    client = AppleCmsClient([source])
+    unknown_year = _episode_row(1, year="")
+    unknown_year["vod_id"] = "episode-unknown"
+    year_2025 = _episode_row(1, year="2025")
+    year_2025["vod_id"] = "episode-2025"
+    year_2026 = _episode_row(1, year="2026")
+    year_2026["vod_id"] = "episode-2026"
+    year_2026["vod_play_url"] = "第1集$not-a-url"
+
+    def fake_request(_source, **params):
+        assert params.get("ac") == "list"
+        return {
+            "pagecount": "1",
+            "list": [unknown_year, year_2025, year_2026],
+        }
+
+    client._request = fake_request
+
+    results = client.search(
+        "长剧",
+        limit=1,
+        require_playable=True,
+        expand_tv_episode_rows=True,
+    )
+
+    assert [
+        (result.year, [episode.episode for episode in result.episodes])
+        for result in results
+    ] == [("", [1])]
+
+
+def test_search_episode_row_expansion_restores_all_conflicting_unknown_groups():
+    source = CmsSource(key="demo", name="演示", api="https://cms.example/vod")
+    client = AppleCmsClient([source])
+
+    def row(index, *, title, year):
+        item = _episode_row(index, title=title, year=year)
+        item["vod_id"] = f"{title}-{year or 'unknown'}-{index}"
+        return item
+
+    pages = {
+        1: [
+            row(1, title="长剧甲", year=""),
+            row(1, title="长剧乙", year=""),
+        ],
+        2: [
+            row(2, title="长剧甲", year="2025"),
+            row(2, title="长剧乙", year="2025"),
+        ],
+        3: [
+            row(3, title="长剧甲", year="2026"),
+            row(3, title="长剧乙", year="2026"),
+        ],
+    }
+
+    def fake_request(_source, **params):
+        page = int(params["pg"])
+        return {"pagecount": "3", "list": pages[page]}
+
+    client._request = fake_request
+
+    results = client.search("长剧", limit=2, expand_tv_episode_rows=True)
+
+    assert [
+        (result.year, [episode.episode for episode in result.episodes])
+        for result in results
+    ] == [("", [1]), ("", [1])]
+
+
 @pytest.mark.parametrize(
     "years",
     (("2025", "2026"), ("2026", "2025")),


### PR DESCRIPTION
跟进已合并的 #1180；该 PR 合并后，PR-Agent 又指出两处年份聚合边界问题。

- 年份歧义预检纳入媒体类型匹配但不可播放的候选，实际资源选择仍保持可播放过滤
- 同一批次检测到多个冲突组时全部恢复未知年份状态，再停止分页
- 新增两个精确回归测试
- 版本保持已授权的 0.4.41

验证：源仓库 227 passed；官方版本门禁、联邦 CSS 门禁、新插件测试检查及 Python 3.14 语法检查均通过。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at f7b3641c24c2c94cbcf3c866738a684487d2afe3

- 修复年份冲突电视剧分集聚合
  - 将不可播放的同类型条目纳入年份冲突检测
  - 同时恢复所有冲突的未知年份分组
- 保持实际结果仅选择可播放资源
- 新增两项分页聚合回归测试
<!-- pr-agent-summary:end -->
