### PR TITLE
chore(release): 启用全部 V3 插件 Release

### DIFF
--- a/package.v3.json
+++ b/package.v3.json
@@ -34,6 +34,7 @@
     "icon": "clean.png",
     "author": "thsrite",
     "level": 2,
+    "release": true,
     "history": {
       "v3.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
       "v3.0.0": "V3 独立大版本：按媒体来源和媒体 ID 归组下载历史。",
@@ -51,6 +52,7 @@
     "icon": "bangumi_b.png",
     "author": "Attente",
     "level": 1,
+    "release": true,
     "history": {
       "v2.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
       "v2.0.0": "V3 独立大版本：订阅与历史统计改用 Bangumi 来源和媒体 ID。",
@@ -177,6 +179,7 @@
     "icon": "movie.jpg",
     "author": "jxxghp",
     "level": 2,
+    "release": true,
     "history": {
       "v3.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
       "v3.0.0": "V3 独立大版本：统一媒体身份，拒绝零值或未知来源，在合法回填后迁移旧媒体 ID 字段，并通过统一身份转换到 TMDB。",
@@ -193,6 +196,7 @@
     "icon": "douban.png",
     "author": "jxxghp,dwhmofly",
     "level": 2,
+    "release": true,
     "history": {
       "v3.1.1": "修复全局媒体识别源为 TMDB 时，豆瓣条目无法映射到 TMDB 会直接跳过的问题，增加豆瓣数据识别回退。",
       "v3.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
@@ -211,6 +215,7 @@
     "icon": "Youtube-dl_B.png",
     "author": "叮叮当",
     "level": 1,
+    "release": true,
     "history": {
       "v3.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
       "v3.0.0": "V3 独立大版本：下载历史识别改用媒体来源和媒体 ID。",
@@ -230,6 +235,7 @@
     "icon": "Element_A.png",
     "author": "叮叮当",
     "level": 1,
+    "release": true,
     "history": {
       "v3.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
       "v3.0.0": "V3 独立大版本：剧集组匹配改用媒体来源和媒体 ID，拒绝零值且仅在合法新 key 保存后清理旧记录。",
@@ -251,6 +257,7 @@
     "icon": "Moviepilot_A.png",
     "author": "jxxghp",
     "level": 1,
+    "release": true,
     "history": {
       "v2.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
       "v2.0.0": "V3 独立大版本：从 MoviePilot V1 迁移整理历史至当前 V3，统一媒体身份并拒绝零值或无效 pair。",
@@ -266,6 +273,7 @@
     "icon": "IMDb_IOS-OSX_App.png",
     "author": "wumode",
     "level": 1,
+    "release": true,
     "system_version": ">=3.0.0",
     "history": {
       "v2.1.4": "中文转换改用 MoviePilot 文本 SDK，兼容 Python 3.14t。",
@@ -317,6 +325,7 @@
     "icon": "scraper.png",
     "author": "jxxghp",
     "level": 1,
+    "release": true,
     "history": {
       "v3.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
       "v3.0.0": "V3 独立大版本：识别与整理历史查询改用媒体来源和媒体 ID，NFO 拒绝零值，刮削交由 ScrapingChain。",
@@ -338,6 +347,7 @@
     "color": "#fefefe",
     "author": "逗猫",
     "level": 1,
+    "release": true,
     "system_version": ">=3.0.0",
     "history": {
       "v4.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
@@ -399,6 +409,7 @@
     "icon": "NeoDB.jpeg",
     "author": "hcplantern",
     "level": 2,
+    "release": true,
     "history": {
       "v2.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
       "v2.0.0": "V3 独立大版本：统一媒体身份，拒绝零值或未知来源，并在合法回填后迁移插件历史中的旧媒体 ID 字段。",
@@ -414,6 +425,7 @@
     "icon": "actor.png",
     "author": "jxxghp",
     "level": 1,
+    "release": true,
     "system_version": ">=3.0.0",
     "history": {
       "v3.1.1": "中文转换改用 MoviePilot 文本 SDK，兼容 Python 3.14t。",
@@ -439,6 +451,7 @@
     "icon": "rss.png",
     "author": "jxxghp",
     "level": 2,
+    "release": true,
     "history": {
       "v3.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
       "v3.0.0": "V3 独立大版本：统一媒体身份，拒绝零值或未知来源，并在合法回填后迁移插件历史中的旧媒体 ID 字段。",
@@ -455,6 +468,7 @@
     "icon": "TheTVDB_A.png",
     "author": "jxxghp",
     "level": 1,
+    "release": true,
     "history": {
       "v2.1.1": "插件探索 API 显式返回统一响应，避免依赖宿主隐式包装。",
       "v2.1.0": "适配 V3 SDK 导入规范：插件内部导入全面迁移至 app.sdk 体系，去除对旧版兼容层的依赖。",
@@ -559,6 +573,7 @@
     "version": "1.0.0",
     "author": "annanygy",
     "level": 1,
+    "release": true,
     "system_version": ">=3.0.0",
     "history": {
       "v1.0.0": "V3 独立版本：在重命名模板渲染前读取 MediaInfo 并注入技术字段。"


### PR DESCRIPTION
## 背景与目标

`package.v3.json` 中有 15 个 V3 插件未显式启用 `release`。这些插件可以通过市场源码被发现，但不会进入现有 `Plugin Release` 工作流，因而缺少与当前版本对应的 tag、GitHub Release 和安装包。

## 解决方案

为缺失的 15 个 V3 条目补充 `"release": true`，使 `package.v3.json` 中的 22 个插件统一进入现有发布流程。

本 PR 不修改插件源码或版本号。新增条目的当前版本 tag 均不存在，合并到 `main` 后，现有工作流会为它们生成首次 Release；已有 Release 的其他 V3 插件在目录内容未变化时会被跳过。

## 影响与风险

- 合并后会触发一次 `Plugin Release`，生成 15 个当前版本的 V3 插件 Release 及 ZIP 资产。
- 不改变插件运行时行为、市场版本选择或 V2 插件发布。
- 后续插件载荷发生变化时仍应正常 bump 版本，不依赖覆盖同名 Release。

## 验证

- 插件版本门禁通过。
- `package.v3.json` JSON 解析通过。
- 22 个 V3 Release 条目均可映射到对应插件目录。
- 15 个新增条目的当前版本 tag 均不存在。
- 15 个新增条目的本地 ZIP 打包探针通过。
- `git diff --check` 通过。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 3d98dd93413a820701861a6fb36e279d79d97f0e

- 为 15 个 V3 插件启用 `release`
- 纳入现有插件发布与打包流程
- 不修改插件代码、版本或运行行为
- 合并后将首次发布对应版本资产
- 风险：触发新增 GitHub Release 与 ZIP
<!-- pr-agent-summary:end -->
