### PR TITLE
fix(lunatv): group same-season sources

### DIFF
--- a/package.v3.json
+++ b/package.v3.json
@@ -482,13 +482,14 @@
     "name": "LunaTV 资源订阅",
     "description": "接入 LunaTV/MoonTV 苹果 CMS 资源，复用 MoviePilot 原生搜索、订阅、目录、整理与媒体库链路。",
     "labels": "订阅,苹果CMS,m3u8,下载,媒体库",
-    "version": "0.4.46",
+ "version": "0.4.47",
     "icon": "https://raw.githubusercontent.com/OneBigMoon/moviepilot-v3-lunatv-source/master/icons/lunatvsource.png",
     "author": "OneBigMoon",
     "project_url": "https://github.com/OneBigMoon/moviepilot-v3-lunatv-source",
     "level": 1,
     "release": true,
-    "history": {
+ "history": {
+ "0.4.47": "电视剧搜索结果统一使用同一次匹配得到的标准作品标题与年份，使同一作品同一季的不同来源与不同分辨率归入同一 MoviePilot 资源卡；仍按分辨率从高到低排序，最高分辨率作为主项，其余归入“更多来源”；不同季和不同作品/年份保持隔离。",
       "0.4.46": "将受管二进制真实性校验改为代码内固定可执行摘要；完善凭据脱敏、可取消且有总时限的引擎安装，以及受目录文件描述符保护的陈旧输出清理；强化 POSIX 进程组有界终止与外部进程看门狗，仅在引擎明确进入封装阶段后停用下载停滞检查，并先消费本轮进度与缓存活动再判断停滞，不再把单轨 100% 或缓存文件数当作整体完成证据；修复残留管道、日志绕过停滞及长时间封装误杀；跨文件系统提交兼容接近文件名上限的目标，且提交后的源清理失败不再反转成功状态。",
       "0.4.45": "修复双引擎发布阶段的容器、缓存和权限边界：N_m3u8DL-RE 固定混流 MP4，VSD 删除任务时清理阶段目录，跨文件系统移动保留源文件权限。",
       "0.4.44": "电视剧整季资源改为每个来源只抽测一个代表集，并移除全季实测提示；接入受管 N_m3u8DL-RE 与 VSD 双引擎，失败时回退 ffmpeg，支持缓存续传、进度、暂停与安全清理；固定 LunaTV 下载器及插件下载目录展示元数据。",

--- a/plugins.v3/lunatvsource/__init__.py
+++ b/plugins.v3/lunatvsource/__init__.py
@@ -556,7 +556,7 @@ class LunaTVSource(_PluginBase):
     plugin_name = "LunaTV 资源订阅"
     plugin_desc = "接入 LunaTV/MoonTV 苹果 CMS 资源，复用 MoviePilot 原生搜索、订阅、目录、整理与媒体库链路。"
     plugin_icon = "https://raw.githubusercontent.com/OneBigMoon/moviepilot-v3-lunatv-source/master/icons/lunatvsource.png"
-    plugin_version = "0.4.46"
+    plugin_version = "0.4.47"
     plugin_author = "OneBigMoon"
     author_url = "https://github.com/OneBigMoon"
     plugin_config_prefix = "lunatvsource_"
@@ -2994,6 +2994,17 @@ class LunaTVSource(_PluginBase):
         if results:
             context = self._resource_search_context(search_query, results, mtype)
             association = self._associate_tmdb(context, include_candidates=False)
+        canonical_tv_title = ""
+        canonical_tv_year = ""
+        if requested_media_type == "tv":
+            if use_target_tv_identity:
+                canonical_tv_title = target_media_title_value
+                canonical_tv_year = target_media_year_value
+            elif association.get("status") == "matched":
+                canonical_tv_title = normalize_media_title(
+                    str(association.get("title") or "").strip()
+                )
+                canonical_tv_year = str(association.get("year") or "").strip()
         # TV resources are presented as one native download item per
         # source/season.  The enclosure carries the ordered episode list and
         # ``download`` expands it back into the plugin's serial queue.  This
@@ -3033,6 +3044,11 @@ class LunaTVSource(_PluginBase):
                 association.get("media_source") or PLUGIN_MEDIA_SOURCE
             )
             host_media_id = str(association.get("media_id") or identity)
+            group_title = normalize_media_title(result.title)
+            group_year = result.year
+            if result.media_type == "tv":
+                group_title = canonical_tv_title or group_title
+                group_year = canonical_tv_year or group_year
             episodes = result.episodes or [CmsEpisode(1, 1, "正片", "")]
             season_episode_numbers: Dict[int, set[int]] = {}
             season_urls: Dict[int, set[str]] = {}
@@ -3063,8 +3079,8 @@ class LunaTVSource(_PluginBase):
                     group_key = (
                         result.source_key,
                         result.source_name,
-                        normalize_media_title(result.title),
-                        result.year,
+                        group_title,
+                        group_year,
                         season,
                         season_variant,
                     )
@@ -3072,8 +3088,8 @@ class LunaTVSource(_PluginBase):
                         group_key,
                         {
                             "site_name": result.source_name or "LunaTV",
-                            "title": normalize_media_title(result.title),
-                            "year": result.year,
+                            "title": group_title,
+                            "year": group_year,
                             "season": season,
                             "source_key": result.source_key,
                             "source_name": result.source_name,

--- a/plugins.v3/lunatvsource/package-lock.json
+++ b/plugins.v3/lunatvsource/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moviepilot-lunatvsource-plugin",
-  "version": "0.4.46",
+ "version": "0.4.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moviepilot-lunatvsource-plugin",
-      "version": "0.4.46",
+      "version": "0.4.47",
       "dependencies": {
         "vue": "^3.5.13",
         "vuetify": "3.7.3"

--- a/plugins.v3/lunatvsource/package.json
+++ b/plugins.v3/lunatvsource/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moviepilot-lunatvsource-plugin",
   "private": true,
-  "version": "0.4.46",
+ "version": "0.4.47",
   "type": "module",
   "scripts": {"build": "vite build"},
   "dependencies": {"vue": "^3.5.13", "vuetify": "3.7.3"},

--- a/tests/v3/lunatvsource/test_manifest.py
+++ b/tests/v3/lunatvsource/test_manifest.py
@@ -41,24 +41,21 @@ def test_version_consistency_across_manifest_backend_and_frontend():
         ).read_text(encoding="utf-8")
     )
 
-    assert manifest["version"] == "0.4.46"
+    assert manifest["version"] == "0.4.47"
     assert {
         manifest["version"],
         LunaTVSource.plugin_version,
         package["version"],
         lockfile["version"],
         lockfile["packages"][""]["version"],
-    } == {"0.4.46"}
+    } == {"0.4.47"}
 
     history = manifest["history"]
-    assert next(iter(history)) == "0.4.46"
-    assert history["0.4.46"] == (
-        "将受管二进制真实性校验改为代码内固定可执行摘要；完善凭据脱敏、可取消且有总时限"
-        "的引擎安装，以及受目录文件描述符保护的陈旧输出清理；强化 POSIX 进程组有界终止"
-        "与外部进程看门狗，仅在引擎明确进入封装阶段后停用下载停滞检查，并先消费本轮进度"
-        "与缓存活动再判断停滞，不再把单轨 100% 或缓存文件数当作整体完成证据；修复残留"
-        "管道、日志绕过停滞及长时间封装误杀；跨文件系统提交兼容接近文件名上限的目标，"
-        "且提交后的源清理失败不再反转成功状态。"
+    assert next(iter(history)) == "0.4.47"
+    assert history["0.4.47"] == (
+        "电视剧搜索结果统一使用同一次匹配得到的标准作品标题与年份，使同一作品同一季的"
+        "不同来源与不同分辨率归入同一 MoviePilot 资源卡；仍按分辨率从高到低排序，最高分辨率"
+        "作为主项，其余归入“更多来源”；不同季和不同作品/年份保持隔离。"
     )
     assert history["0.4.45"] == (
         "修复双引擎发布阶段的容器、缓存和权限边界：N_m3u8DL-RE 固定混流 MP4，"

--- a/tests/v3/lunatvsource/test_plugin.py
+++ b/tests/v3/lunatvsource/test_plugin.py
@@ -1033,7 +1033,7 @@ def test_resource_torrents_filters_by_requested_media_type(monkeypatch):
     ) == ["movie", "tv"]
 
 
-def test_resource_torrents_keep_complete_season_quality_variants_separate(monkeypatch):
+def test_resource_torrents_keep_complete_season_quality_variants_as_more_sources(monkeypatch):
     class TorrentInfo:
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
@@ -1091,6 +1091,97 @@ def test_resource_torrents_keep_complete_season_quality_variants_separate(monkey
         len({episode["url"] for episode in payload["episodes"]}) == 2
         for payload in payloads
     )
+
+
+def test_resource_torrents_tv_sources_share_matched_identity_card_and_rank_resolution(
+    monkeypatch,
+):
+    class TorrentInfo:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    results = [
+        CmsResult(
+            source_key="high",
+            source_name="高清源",
+            vod_id="high-s04",
+            title="侠探杰克",
+            year="0",
+            media_type="tv",
+            remark="",
+            episodes=(
+                CmsEpisode(4, 1, "第1集", "https://video.example/1080-s04e01.m3u8"),
+            ),
+            detail="https://high.example/detail/high-s04",
+        ),
+        CmsResult(
+            source_key="middle",
+            source_name="中清源",
+            vod_id="middle-s04",
+            title="侠探杰克",
+            year="2026",
+            media_type="tv",
+            remark="",
+            episodes=(
+                CmsEpisode(4, 1, "第1集", "https://video.example/960-s04e01.m3u8"),
+            ),
+            detail="https://middle.example/detail/middle-s04",
+        ),
+        CmsResult(
+            source_key="low",
+            source_name="标清源",
+            vod_id="low-s04",
+            title="侠探杰克",
+            year="0",
+            media_type="tv",
+            remark="",
+            episodes=(
+                CmsEpisode(4, 1, "第1集", "https://video.example/720-s04e01.m3u8"),
+            ),
+            detail="https://low.example/detail/low-s04",
+        ),
+    ]
+
+    class Client:
+        def search(self, *_args, **_kwargs):
+            return results
+
+    plugin = _plugin()
+    plugin.init_plugin({"enabled": True})
+    monkeypatch.setattr(plugin_module, "_HostTorrentInfo", TorrentInfo)
+    monkeypatch.setattr(plugin, "_client", lambda: Client())
+    monkeypatch.setattr(
+        plugin,
+        "_associate_tmdb",
+        lambda *_args, **_kwargs: {
+            "status": "matched",
+            "media_source": "themoviedb",
+            "media_id": "343611",
+            "title": "侠探杰克",
+            "year": "2022",
+        },
+    )
+    monkeypatch.setattr(
+        plugin,
+        "_probe_resource_urls",
+        lambda urls: {
+            url: 1080 if "/1080-" in url else 960 if "/960-" in url else 720
+            for url in urls
+        },
+    )
+
+    items = plugin._resource_torrents("侠探杰克", mtype="tv")
+
+    assert [item.pri_order for item in items] == [108, 96, 72]
+    assert [
+        item.title.rsplit(" · ", 1)[0]
+        for item in items
+    ] == ["侠探杰克 (2022) · 第4季"] * 3
+    assert [
+        plugin._decode_resource_token(item.enclosure)["resolution"]
+        for item in items
+    ] == ["1080P", "960P", "720P"]
+    assert [item.media_id for item in items] == ["343611"] * 3
 
 
 def test_resource_torrents_choose_highest_url_for_conflicting_episode(monkeypatch):


### PR DESCRIPTION
## Changes
- normalize matched TV title and year across LunaTV sources so the same series season is grouped into one MoviePilot resource card
- preserve every source and quality as selectable alternatives while ranking the highest resolution first
- keep different seasons and different media identities isolated
- bump LunaTVSource metadata to v0.4.47
- leave downloader.py, m3u8_engine.py, N_m3u8DL-RE, VSD, and ffmpeg fallback behavior unchanged

## Validation
- 291 standalone LunaTVSource tests passed
- 297 tests passed in the official MoviePilot plugin tree
- 14 official plugin release-gate tests passed
- Python compilation and git diff --check passed

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 622de68e0cab553c23d7546ce2e47b6d4883d3b0

- 统一电视剧同季资源卡
- 复用匹配标题年份并保持分辨率排序
- 电影逻辑不变，误匹配可能合并资源
- 新增跨来源归并测试并升级版本
<!-- pr-agent-summary:end -->
