### PR TITLE
chore(ci): 跟随稳定工具链版本

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const issue = context.payload.issue;
@@ -67,7 +67,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const labelRules = [
@@ -127,7 +127,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v11
         with:
           # 标记 stale 标签时间
           days-before-issue-stale: 30

--- a/.github/workflows/plugin-gate.yml
+++ b/.github/workflows/plugin-gate.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
+          version-file: MoviePilot/pyproject.toml
           python-version: '3.14'
           enable-cache: true
           cache-dependency-glob: |

--- a/.github/workflows/plugin-gate.yml
+++ b/.github/workflows/plugin-gate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -35,21 +35,20 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout plugin repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: MoviePilot-Plugins-Official
 
       - name: Checkout MoviePilot V3 backend
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: jxxghp/MoviePilot
           ref: v3
           path: MoviePilot
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: '0.12.5'
           python-version: '3.14'
           enable-cache: true
           cache-dependency-glob: |
@@ -91,7 +90,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout plugin repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -112,9 +111,8 @@ jobs:
 
       - name: Set up uv
         if: steps.dependency-scope.outputs.run == 'true'
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: '0.12.5'
           python-version: '3.14'
           enable-cache: true
           cache-dependency-glob: plugins.v3/*/pyproject.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## 背景

官方插件仓 workflow 同时保留旧 Action 大版本和 uv 精确 patch 固定，增加了周期性人工升级成本。

## 调整

- `actions/checkout` 更新到稳定 `v7`。
- `actions/github-script` 更新到稳定 `v9`，`actions/stale` 更新到稳定 `v11`。
- `setup-uv` 使用稳定 `v10.0.1` Action，不再在插件仓固定 uv `0.12.5`；后端测试环境从已 checkout 的 MoviePilot `pyproject.toml` 读取兼容版本，主仓策略调整前后均可独立通过。
- 不修改插件源码、版本或发布行为。

## 验证

- CI focused：`30 passed`
- actionlint：通过
- 插件版本与联邦 CSS pre-push 门禁：通过
- GitHub Actions 首轮验证发现并修复跨仓 uv 版本约束后，test gate 已重新触发
- `git diff --check`：通过
