### PR TITLE
Improve IqiyiDiscover poster clarity and bump to v1.0.1

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -1290,12 +1290,13 @@
     "name": "爱奇艺探索",
     "description": "让探索支持爱奇艺的数据浏览。",
     "labels": "探索",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "icon": "https://raw.githubusercontent.com/jxxghp/MoviePilot-Plugins/main/icons/iqiyi_A.png",
     "author": "LLL001a",
     "v3": false,
     "level": 1,
     "history": {
+      "v1.0.1": "优化海报清晰度，优先使用高清海报字段",
       "v1.0.0": "发布"
     }
   }

--- a/plugins.v2/iqiyidiscover/__init__.py
+++ b/plugins.v2/iqiyidiscover/__init__.py
@@ -158,7 +158,7 @@ class IqiyiDiscover(_PluginBase):
     # 插件图标
     plugin_icon = "https://raw.githubusercontent.com/jxxghp/MoviePilot-Plugins/main/icons/iqiyi_A.png"
     # 插件版本
-    plugin_version = "1.0.0"
+    plugin_version = "1.0.1"
     # 插件作者
     plugin_author = "LLL001a"
     # 作者主页
@@ -328,7 +328,7 @@ class IqiyiDiscover(_PluginBase):
                 title_year=self.__get_title_year(movie_info),
                 mediaid_prefix="iqiyi",
                 media_id=str(movie_info.get("album_id") or movie_info.get("entity_id")),
-                poster_path=movie_info.get("image_cover"),
+                poster_path=self.__get_poster(movie_info),
             )
 
         def __series_to_media(series_info: dict) -> schemas.MediaInfo:
@@ -342,7 +342,7 @@ class IqiyiDiscover(_PluginBase):
                 title_year=self.__get_title_year(series_info),
                 mediaid_prefix="iqiyi",
                 media_id=str(series_info.get("album_id") or series_info.get("entity_id")),
-                poster_path=series_info.get("image_cover"),
+                poster_path=self.__get_poster(series_info),
             )
 
         try:
@@ -414,6 +414,33 @@ class IqiyiDiscover(_PluginBase):
         if title and year:
             return f"{title} ({year})"
         return title
+
+    @staticmethod
+    def __get_poster(media_info: dict) -> Optional[str]:
+        """
+        获取高清海报地址。
+
+        优先使用接口返回的高清字段 image_url_2x（318x424），
+        其次从 image_cover 基础地址构造 300x450 高清竖版海报（JPEG），
+        最后回退到 image_cover（120x160）。
+
+        :param media_info: 爱奇艺媒体数据
+        :return: 海报地址
+        """
+        # 优先使用接口直接返回的高清海报
+        poster = media_info.get("image_url_2x") or media_info.get("image_url_normal")
+        if poster:
+            return poster
+        # 从 image_cover 基础地址构造高清竖版海报
+        cover = media_info.get("image_cover")
+        if cover:
+            import re
+            # 去掉尺寸后缀和格式后缀，例如 a_xxx_m_601_m7.avif -> a_xxx_m_601_m7
+            base = re.sub(r"_\d+_\d+\.\w+$", "", cover)
+            base = re.sub(r"\.\w+$", "", base)
+            if base:
+                return f"{base}_300_450.jpg"
+        return cover
 
     @staticmethod
     def iqiyi_filter_ui() -> List[dict]:


### PR DESCRIPTION
## 优化爱奇艺探索海报清晰度并升级版本

修复爱奇艺探索海报不清晰的问题，版本升级到 1.0.1。

### 变更内容
- 新增  方法，优先使用接口返回的高清海报字段 （318x424）
- 回退到从  基础地址构造 300x450 高清竖版海报（JPEG）
- 最后回退到 （120x160）
- 版本号从 1.0.0 升级到 1.0.1

### 效果
海报分辨率从 120x160 提升到 318x424 或 300x450，清晰度大幅提升。