### PR TITLE
迁移 MoviePilotUpdateNotify 与 TvFirstWatch 到 V3

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -489,6 +489,7 @@
     }
   },
   "MoviePilotUpdateNotify": {
+    "v3": false,
     "name": "MoviePilot更新推送",
     "description": "MoviePilot推送release更新通知、自动重启。",
     "labels": "消息通知,自动更新",
@@ -830,6 +831,7 @@
     }
   },
   "TvFirstWatch": {
+    "v3": false,
     "name": "首播试看",
     "description": "定时抓取RSS,只下载电视剧前N集,自动跳过合集和过大文件。",
     "labels": "订阅,RSS",

--- a/package.v3.json
+++ b/package.v3.json
@@ -274,6 +274,34 @@
     },
     "system_version": ">=3.0.0"
   },
+  "MoviePilotUpdateNotify": {
+    "name": "MoviePilot更新推送",
+    "description": "MoviePilot 推送 V3 release 更新通知、自动重启。",
+    "labels": "消息通知,自动更新",
+    "version": "3.0.0",
+    "icon": "Moviepilot_A.png",
+    "author": "thsrite",
+    "level": 1,
+    "release": true,
+    "history": {
+      "v3.0.0": "V3 独立版本：迁移至 plugins.v3，按 V3 发布线检查后端与前端更新，并使用稳定 SDK 入口。"
+    },
+    "system_version": ">=3.0.0"
+  },
+  "TvFirstWatch": {
+    "name": "首播试看",
+    "description": "定时抓取 RSS，只下载电视剧前 N 集，自动跳过合集和过大文件。",
+    "labels": "订阅,RSS",
+    "version": "2.0.0",
+    "icon": "rss.png",
+    "author": "Raymond38324",
+    "level": 2,
+    "release": true,
+    "history": {
+      "v2.0.0": "V3 独立大版本：迁移至 plugins.v3，使用稳定媒体上下文与下载链，并将第三方依赖声明迁移至 pyproject.toml。"
+    },
+    "system_version": ">=3.0.0"
+  },
   "HistoryToV2": {
     "name": "V1历史记录迁移至V3",
     "description": "将 MoviePilot V1 的整理历史记录迁移至当前 MoviePilot V3。",

--- a/plugins.v3/moviepilotupdatenotify/__init__.py
+++ b/plugins.v3/moviepilotupdatenotify/__init__.py
@@ -1,0 +1,375 @@
+import datetime
+import re
+from typing import Any, List, Dict, Tuple, Optional
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from app.chain.system import SystemChain
+from app.sdk.config import settings
+from app.sdk.logging import logger
+from app.sdk.network import RequestUtils
+from app.sdk.services import SystemHelper
+from app.plugins import _PluginBase
+from app.schemas import NotificationType
+
+
+class MoviePilotUpdateNotify(_PluginBase):
+    # 插件名称
+    plugin_name = "MoviePilot更新推送"
+    # 插件描述
+    plugin_desc = "MoviePilot推送release更新通知、自动重启。"
+    # 插件图标
+    plugin_icon = "Moviepilot_A.png"
+    # 插件版本
+    plugin_version = "3.0.0"
+    # 插件作者
+    plugin_author = "thsrite"
+    # 作者主页
+    author_url = "https://github.com/thsrite"
+    # 插件配置项ID前缀
+    plugin_config_prefix = "moviepilotupdatenotify_"
+    # 加载顺序
+    plugin_order = 25
+    # 可使用的用户级别
+    auth_level = 1
+
+    # 私有属性
+    _enabled = False
+    # 任务执行间隔
+    _cron = None
+    _restart = False
+    _notify = False
+    _update_types = []
+
+    # 定时器
+    _scheduler: Optional[BackgroundScheduler] = None
+
+    def init_plugin(self, config: dict = None):
+        # 停止现有任务
+        self.stop_service()
+
+        if config:
+            self._enabled = config.get("enabled")
+            self._cron = config.get("cron")
+            self._restart = config.get("restart")
+            self._notify = config.get("notify")
+            self._update_types = config.get("update_types") or []
+
+    def __check_update(self):
+        """
+        检查MoviePilot更新
+        """
+        # 检查后端更新
+        server_update = self.__check_server_update() if self._update_types and "后端" in self._update_types else False
+
+        # 检查前端更新
+        front_update = self.__check_front_update() if self._update_types and "前端" in self._update_types else False
+
+        # 自动重启
+        if (server_update or front_update) and self._restart:
+            logger.info("开始执行自动重启…")
+            SystemHelper.restart()
+
+    def __check_server_update(self):
+        """
+        检查后端更新
+        """
+        release_version, description, update_time = self.__get_backend_latest()
+        if not release_version:
+            logger.error("后端最新版本获取失败")
+            return False
+
+        # 本地版本
+        local_version = SystemChain().get_server_local_version()
+        if local_version and list(map(int, re.findall(r'\d+', release_version))) <= list(map(int, re.findall(r'\d+', local_version))):
+            logger.info(f"当前后端版本：{local_version} 远程版本：{release_version} 停止运行")
+            return False
+
+        logger.info(f"发现MoviePilot后端更新：{release_version} {description} {update_time}")
+
+        # 推送更新消息
+        self.__notify_update(update_time=update_time,
+                             release_version=release_version,
+                             description=description,
+                             mtype="后端")
+
+        return True
+
+    def __check_front_update(self):
+        """
+        检查前端更新
+        """
+        release_version, description, update_time = self.__get_front_latest()
+        if not release_version:
+            logger.error("前端最新版本获取失败")
+            return False
+
+        # 本地版本
+        local_version = SystemChain().get_frontend_version()
+        if local_version and list(map(int, re.findall(r'\d+', release_version))) <= list(map(int, re.findall(r'\d+', local_version))):
+            logger.info(f"当前前端版本：{local_version} 远程版本：{release_version} 停止运行")
+            return False
+
+        logger.info(f"发现MoviePilot前端更新：{release_version} {description} {update_time}")
+
+        # 推送更新消息
+        self.__notify_update(update_time=update_time,
+                             release_version=release_version,
+                             description=description,
+                             mtype="前端")
+
+        return True
+
+    def __notify_update(self, update_time, release_version, description, mtype):
+        """
+        推送更新消息
+        """
+        # 推送更新消息
+        if self._notify:
+            # 将时间字符串转为datetime对象
+            dt = datetime.datetime.strptime(update_time, "%Y-%m-%dT%H:%M:%SZ")
+            # 设置时区
+            timezone = pytz.timezone(settings.TZ)
+            dt = dt.replace(tzinfo=timezone)
+            # 将datetime对象转换为带时区的字符串
+            update_time = dt.strftime("%Y-%m-%d %H:%M:%S")
+            if not description.startswith(release_version):
+                description = f"{release_version}\n\n{description}"
+            self.post_message(
+                mtype=NotificationType.SiteMessage,
+                title=f"【MoviePilot{mtype}更新通知】",
+                text=f"{description}\n\n{update_time}")
+
+    @staticmethod
+    def __get_latest_version(repo_url: str) -> Optional[dict]:
+        """
+        获取最新版本
+        """
+        # 获取所有发布的版本列表
+        response = RequestUtils(
+            proxies=settings.PROXY,
+            headers=settings.GITHUB_HEADERS
+        ).get_res(repo_url)
+        if response:
+            v3_releases = [r for r in response.json() if re.match(r"^v3\.", r['tag_name'])]
+            if not v3_releases:
+                logger.warn("未获取到最新版本号！")
+                return None
+            # 只比较当前 V3 发布线，避免 V2 与 V3 版本号交叉误判。
+            latest_v3 = sorted(v3_releases, key=lambda s: list(map(int, re.findall(r'\d+', s['tag_name']))))[-1]
+            logger.info(f"获取到最新版本：{latest_v3}")
+            return latest_v3
+        else:
+            logger.error("无法获取版本信息，请检查网络连接或GitHub API请求。")
+            return None
+
+    def __get_backend_latest(self) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        """
+        获取最新版本
+        """
+        result = self.__get_latest_version("https://api.github.com/repos/jxxghp/MoviePilot/releases")
+        if result:
+            return result['tag_name'], f"{result['body'] or ''}", result['published_at']
+        return None, None, None
+
+    def __get_front_latest(self):
+        """
+        获取前端最新版本
+        """
+        result = self.__get_latest_version("https://api.github.com/repos/jxxghp/MoviePilot-Frontend/releases")
+        if result:
+            return result['tag_name'], f"{result['body'] or ''}", result['published_at']
+        return None, None, None
+
+    def get_state(self) -> bool:
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        pass
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        pass
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """
+        注册插件公共服务
+        [{
+            "id": "服务ID",
+            "name": "服务名称",
+            "trigger": "触发器：cron/interval/date/CronTrigger.from_crontab()",
+            "func": self.xxx,
+            "kwargs": {} # 定时器参数
+        }]
+        """
+        if self._enabled and self._cron:
+            return [
+                {
+                    "id": "MoviePilotUpdateNotify",
+                    "name": "MoviePilot更新检查服务",
+                    "trigger": CronTrigger.from_crontab(self._cron),
+                    "func": self.__check_update,
+                    "kwargs": {}
+                }
+            ]
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """
+        拼装插件配置页面，需要返回两块数据：1、页面配置；2、数据结构
+        """
+        return [
+            {
+                'component': 'VForm',
+                'content': [
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'enabled',
+                                            'label': '启用插件',
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'restart',
+                                            'label': '自动重启',
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'notify',
+                                            'label': '发送通知',
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCronField',
+                                        'props': {
+                                            'model': 'cron',
+                                            'label': '检查周期',
+                                            'placeholder': '5位cron表达式'
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'multiple': True,
+                                            'chips': True,
+                                            'model': 'update_types',
+                                            'label': '更新类型',
+                                            'items': [
+                                                {
+                                                    "title": "后端",
+                                                    "vale": "后端"
+                                                },
+                                                {
+                                                    "title": "前端",
+                                                    "vale": "前端"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal',
+                                            'text': '如要开启自动重启，请确认MOVIEPILOT_AUTO_UPDATE设置为true，重启即更新。'
+                                        }
+                                    }
+                                ]
+                            },
+                        ]
+                    }
+                ]
+            }
+        ], {
+            "enabled": False,
+            "restart": False,
+            "notify": False,
+            "cron": "0 9 * * *",
+            "update_types": ["后端", "前端"]
+        }
+
+    def get_page(self) -> List[dict]:
+        pass
+
+    def stop_service(self):
+        """
+        退出插件
+        """
+        try:
+            if self._scheduler:
+                self._scheduler.remove_all_jobs()
+                if self._scheduler.running:
+                    self._scheduler.shutdown()
+                self._scheduler = None
+        except Exception as e:
+            logger.error("退出插件失败：%s" % str(e))

--- a/plugins.v3/moviepilotupdatenotify/__init__.py
+++ b/plugins.v3/moviepilotupdatenotify/__init__.py
@@ -132,7 +132,7 @@ class MoviePilotUpdateNotify(_PluginBase):
             dt = datetime.datetime.strptime(update_time, "%Y-%m-%dT%H:%M:%SZ")
             # 设置时区
             timezone = pytz.timezone(settings.TZ)
-            dt = dt.replace(tzinfo=timezone)
+            dt = dt.replace(tzinfo=datetime.timezone.utc).astimezone(timezone)
             # 将datetime对象转换为带时区的字符串
             update_time = dt.strftime("%Y-%m-%d %H:%M:%S")
             if not description.startswith(release_version):

--- a/plugins.v3/tvfirstwatch/__init__.py
+++ b/plugins.v3/tvfirstwatch/__init__.py
@@ -1,0 +1,843 @@
+import datetime
+import json
+import re
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+import feedparser
+import requests
+
+from app.chain.download import DownloadChain
+from app.sdk.config import settings
+from app.sdk.logging import logger
+from app.sdk.media import Context, MediaInfo, MetaInfo, TorrentInfo
+from app.plugins import _PluginBase
+from app.sdk.events import eventmanager
+from app.schemas.types import MediaType, EventType
+
+lock = Lock()
+
+EPISODE_PATTERNS = [
+    re.compile(r"[Ss]\d{1,2}[Ee](\d{1,3})", re.IGNORECASE),
+    re.compile(r"\bEP?\.?(\d{1,3})\b", re.IGNORECASE),
+    re.compile(r"第\s*(\d{1,3})\s*集"),
+    re.compile(r"[【\[(（](\d{1,3})[】\])）]"),
+    re.compile(r"\b(\d{1,3})\s*of\s*\d+\b", re.IGNORECASE),
+]
+
+TV_HINTS = re.compile(
+    r"\b(S\d{1,2}E\d{1,3}|EP?\d{1,3}|第\d+集|Season|Complete|HDTV|WEB-?DL)\b",
+    re.IGNORECASE,
+)
+
+COMPLETE_HINTS = re.compile(
+    r"\b(Complete|全集|全季|Season\s*\d+\s*Complete|S\d+\s*Complete)\b",
+    re.IGNORECASE,
+)
+
+
+class TvFirstWatch(_PluginBase):
+    plugin_name = "首播试看"
+    plugin_desc = "定时抓取 RSS, 只下载剧集前 N 集（首播试看），防重复推送。"
+    plugin_icon = "rss.png"
+    plugin_version = "2.0.0"
+    plugin_author = "Raymond38324"
+    author_url = "https://github.com/Raymond38324"
+    plugin_config_prefix = "tvfirstwatch_"
+    plugin_order = 25
+    auth_level = 2
+
+    _scheduler: Optional[BackgroundScheduler] = None
+    _downloadchain: Optional[DownloadChain] = None
+    _history_path: Optional[Path] = None
+
+    _enabled: bool = False
+    _onlyonce: bool = False
+    _cron: str = "*/30 * * * *"
+    _rss_urls: str = ""
+    _max_episode: int = 2
+    _whitelist: str = "1080p,2160p,4K,HEVC,H.265"
+    _blacklist: str = "720p,CAM,HDTS"
+    _save_path: str = ""
+    _max_storage_gb: int = 0
+    _default_size_gb: float = 2.0
+    _max_single_size_gb: float = 10.0
+
+    def init_plugin(self, config: dict = None) -> None:
+        self._downloadchain = DownloadChain()
+        self.stop_service()
+
+        if config:
+            self._enabled = _to_bool(config.get("enabled", False), False)
+            self._onlyonce = _to_bool(config.get("onlyonce", False), False)
+            self._cron = config.get("cron", "*/30 * * * *") or "*/30 * * * *"
+            self._rss_urls = config.get("rss_urls", "")
+            self._max_episode = _to_int(config.get("max_episode", 2), 2)
+            self._whitelist = config.get("whitelist", "")
+            self._blacklist = config.get("blacklist", "")
+            self._save_path = config.get("save_path", "")
+            self._max_storage_gb = _to_int(config.get("max_storage_gb", 0), 0)
+            self._default_size_gb = _to_float(config.get("default_size_gb", 2.0), 2.0)
+            self._max_single_size_gb = _to_float(
+                config.get("max_single_size_gb", 10.0), 10.0
+            )
+
+        self._history_path = self.get_data_path() / "history.json"
+
+        if self._onlyonce:
+            self._scheduler = BackgroundScheduler(timezone=settings.TZ)
+            logger.info("[首播试看] 立即运行一次")
+            self._scheduler.add_job(
+                func=self._check_all_feeds,
+                trigger="date",
+                run_date=datetime.datetime.now(tz=pytz.timezone(settings.TZ))
+                + datetime.timedelta(seconds=3),
+            )
+            if self._scheduler.get_jobs():
+                self._scheduler.start()
+
+            self._onlyonce = False
+            self.__update_config()
+
+    def get_state(self) -> bool:
+        return self._enabled
+
+    def get_command(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "cmd": "/tvfirst_check",
+                "event": EventType.PluginAction,
+                "desc": "首播试看立即检查",
+                "category": "订阅",
+                "data": {"action": "check_feeds"},
+            }
+        ]
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "path": "/clear_history",
+                "endpoint": self._clear_history,
+                "methods": ["GET"],
+                "summary": "清空首播试看下载历史",
+            },
+            {
+                "path": "/storage_status",
+                "endpoint": self._storage_status,
+                "methods": ["GET"],
+                "summary": "获取存储空间使用情况",
+            },
+        ]
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        if self._enabled and self._cron:
+            return [
+                {
+                    "id": "TvFirstWatch",
+                    "name": "首播试看轮询",
+                    "trigger": CronTrigger.from_crontab(self._cron),
+                    "func": self._check_all_feeds,
+                    "kwargs": {},
+                }
+            ]
+        return []
+
+    @eventmanager.register(EventType.PluginAction)
+    def _plugin_action(self, event):
+        if not self._enabled:
+            return
+        event_data = event.event_data
+        if not event_data or event_data.get("action") != "check_feeds":
+            return
+        logger.info("[首播试看] 收到远程命令，立即执行检查")
+        self._check_all_feeds()
+
+    def stop_service(self) -> None:
+        if self._scheduler:
+            self._scheduler.remove_all_jobs()
+            if self._scheduler.running:
+                self._scheduler.shutdown()
+            self._scheduler = None
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            _col(4, _switch("enabled", "启用插件")),
+                            _col(4, _switch("onlyonce", "立即运行一次")),
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            _col(
+                                4,
+                                _textfield(
+                                    "cron",
+                                    "执行周期（Cron）",
+                                    placeholder="*/30 * * * *",
+                                ),
+                            ),
+                            _col(
+                                2,
+                                _textfield(
+                                    "max_episode",
+                                    "最大集号",
+                                    placeholder="默认 2",
+                                ),
+                            ),
+                            _col(
+                                3,
+                                _textfield(
+                                    "max_storage_gb",
+                                    "空间上限(GB)",
+                                    placeholder="0=不限制",
+                                ),
+                            ),
+                            _col(
+                                3,
+                                _textfield(
+                                    "max_single_size_gb",
+                                    "单集上限(GB)",
+                                    placeholder="超过跳过",
+                                ),
+                            ),
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            _col(
+                                6,
+                                _textfield(
+                                    "default_size_gb",
+                                    "预估大小(GB)",
+                                    placeholder="RSS无大小默认值",
+                                ),
+                            ),
+                            _col(
+                                6,
+                                _textfield(
+                                    "save_path",
+                                    "下载保存路径",
+                                    placeholder="留空使用MP默认",
+                                ),
+                            ),
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            _col(
+                                12,
+                                {
+                                    "component": "VTextarea",
+                                    "props": {
+                                        "model": "rss_urls",
+                                        "label": "RSS 地址",
+                                        "rows": 4,
+                                        "placeholder": (
+                                            "每行一个地址，格式：\n"
+                                            "https://site/rss?passkey=xxx\n"
+                                            "# 需要Cookie：https://site/rss|Cookie: uid=1; pass=abc"
+                                        ),
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            _col(
+                                6,
+                                _textfield(
+                                    "whitelist",
+                                    "白名单关键字（逗号分隔）",
+                                    placeholder="1080p,4K,HEVC",
+                                ),
+                            ),
+                            _col(
+                                6,
+                                _textfield(
+                                    "blacklist",
+                                    "黑名单关键字（逗号分隔）",
+                                    placeholder="720p,CAM",
+                                ),
+                            ),
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            _col(
+                                12,
+                                {
+                                    "component": "VAlert",
+                                    "props": {
+                                        "type": "info",
+                                        "variant": "tonal",
+                                        "text": (
+                                            "仅下载集号≤最大集号的电视剧，自动跳过Complete/全集。"
+                                            "单集上限：超过此大小的种子将跳过(防合集)。"
+                                            "空间上限：超出将停止下载，0表示不限制。"
+                                        ),
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "onlyonce": False,
+            "cron": "*/30 * * * *",
+            "rss_urls": "",
+            "max_episode": 2,
+            "whitelist": "1080p,2160p,4K,HEVC,H.265",
+            "blacklist": "720p,CAM,HDTS",
+            "save_path": "",
+            "max_storage_gb": 0,
+            "default_size_gb": 2.0,
+            "max_single_size_gb": 10.0,
+        }
+
+    def get_page(self) -> List[dict]:
+        history = self._load_history()
+        total_bytes = self._calculate_total_size(history)
+        total_gb = total_bytes / (1024**3)
+        max_gb = self._max_storage_gb
+        usage_percent = (total_gb / max_gb * 100) if max_gb > 0 else 0
+        count = len(history)
+
+        header_content = [
+            {
+                "component": "div",
+                "props": {"class": "d-flex justify-space-between align-center"},
+                "content": [
+                    {
+                        "component": "p",
+                        "props": {"class": "text-h6 mb-0"},
+                        "text": f"已用空间: {total_gb:.2f} GB"
+                        + (
+                            f" / {max_gb} GB ({usage_percent:.1f}%)"
+                            if max_gb > 0
+                            else f" | 共 {count} 条记录"
+                        ),
+                    },
+                    {
+                        "component": "VBtn",
+                        "props": {
+                            "color": "error",
+                            "variant": "outlined",
+                            "size": "small",
+                        },
+                        "text": "清空历史",
+                        "events": {
+                            "click": {
+                                "api": "plugin/TvFirstWatch/clear_history",
+                                "method": "get",
+                                "params": {"token": settings.API_TOKEN},
+                            }
+                        },
+                    },
+                ],
+            }
+        ]
+
+        if not history:
+            return [
+                {
+                    "component": "div",
+                    "props": {"class": "pa-4"},
+                    "content": header_content
+                    + [
+                        {
+                            "component": "p",
+                            "text": "暂无下载记录",
+                            "props": {"class": "text-center mt-4"},
+                        },
+                    ],
+                }
+            ]
+
+        rows = []
+        for key, meta in sorted(
+            history.items(), key=lambda x: x[1].get("added_at", ""), reverse=True
+        ):
+            size_str = meta.get("size_str", "-")
+            rows.append(
+                {
+                    "component": "tr",
+                    "content": [
+                        {"component": "td", "text": meta.get("series_name", key)},
+                        {"component": "td", "text": str(meta.get("episode", ""))},
+                        {"component": "td", "text": size_str},
+                        {"component": "td", "text": meta.get("source", "")},
+                        {"component": "td", "text": meta.get("added_at", "")},
+                    ],
+                }
+            )
+
+        return [
+            {
+                "component": "div",
+                "props": {"class": "pa-2"},
+                "content": header_content,
+            },
+            {
+                "component": "VTable",
+                "props": {"hover": True},
+                "content": [
+                    {
+                        "component": "thead",
+                        "content": [
+                            {
+                                "component": "tr",
+                                "content": [
+                                    {"component": "th", "text": "剧名"},
+                                    {"component": "th", "text": "集号"},
+                                    {"component": "th", "text": "大小"},
+                                    {"component": "th", "text": "来源"},
+                                    {"component": "th", "text": "下载时间"},
+                                ],
+                            }
+                        ],
+                    },
+                    {"component": "tbody", "content": rows},
+                ],
+            },
+        ]
+
+    def _check_all_feeds(self) -> None:
+        if not self._rss_urls:
+            logger.warning("[首播试看] 未配置任何 RSS 地址，跳过。")
+            return
+
+        lines = [l.strip() for l in self._rss_urls.splitlines() if l.strip()]
+        for line in lines:
+            try:
+                self._process_feed(line)
+            except Exception as exc:
+                logger.error("[首播试看] 处理 RSS 源出错: %s — %s", line, exc)
+
+    def _parse_feed_line(self, line: str) -> Tuple[str, dict]:
+        parts = line.split("|", 1)
+        url = parts[0].strip()
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/123.0.0.0 Safari/537.36"
+            )
+        }
+        if len(parts) == 2:
+            cookie_part = parts[1].strip()
+            if cookie_part.lower().startswith("cookie:"):
+                headers["Cookie"] = cookie_part[7:].strip()
+            else:
+                headers["Cookie"] = cookie_part
+        return url, headers
+
+    def _process_feed(self, line: str) -> None:
+        url, headers = self._parse_feed_line(line)
+        source = urlparse(url).netloc
+        logger.info("[首播试看] 抓取 RSS: %s", url)
+
+        try:
+            resp = requests.get(url, headers=headers, timeout=30)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            logger.error("[首播试看] RSS 请求失败 [%s]: %s", source, exc)
+            return
+
+        parsed = feedparser.parse(resp.text)
+        if not parsed.entries:
+            logger.warning("[首播试看] RSS 无条目 [%s]", source)
+            return
+
+        logger.info("[首播试看] [%s] 解析到 %d 个条目", source, len(parsed.entries))
+        for entry in parsed.entries:
+            try:
+                self._process_entry(entry, source)
+            except Exception as exc:
+                logger.error(
+                    "[首播试看] 处理条目异常 [%s]: %s", entry.get("title") or "", exc
+                )
+
+    def _process_entry(self, entry, source: str) -> None:
+        title = entry.get("title") or ""
+        if not title:
+            return
+
+        if not self._is_tv(entry):
+            logger.debug("[首播试看][跳过-非TV] %s", title)
+            return
+
+        if COMPLETE_HINTS.search(title):
+            logger.info("[首播试看][跳过-合集] %s | 检测到Complete/全集关键词", title)
+            return
+
+        episodes = _extract_episodes(title)
+        if not episodes:
+            logger.debug("[首播试看][跳过-无集数] %s", title)
+            return
+
+        eps_in_range = [ep for ep in episodes if ep <= self._max_episode]
+        if not eps_in_range:
+            logger.info(
+                "[首播试看][跳过-超限] %s | 识别集号=%s 限制≤%d",
+                title,
+                episodes,
+                self._max_episode,
+            )
+            return
+
+        ok, reason = self._keyword_filter(title)
+        if not ok:
+            logger.info("[首播试看][跳过-关键字] %s | %s", title, reason)
+            return
+
+        series_name = _guess_series_name(title)
+
+        torrent_size, is_estimated = self._get_torrent_size(entry)
+        size_label = "预估" if is_estimated else "实际"
+        size_gb = torrent_size / (1024**3)
+
+        if self._max_single_size_gb > 0 and size_gb > self._max_single_size_gb:
+            logger.info(
+                "[首播试看][跳过-过大] %s | 大小 %.2f GB > 上限 %.1f GB (可能是合集)",
+                title,
+                size_gb,
+                self._max_single_size_gb,
+            )
+            return
+
+        with lock:
+            history = self._load_history()
+            new_eps = [
+                ep
+                for ep in eps_in_range
+                if not self._is_downloaded(history, series_name, ep)
+            ]
+            if not new_eps:
+                logger.info(
+                    "[首播试看][跳过-已下载] %s | 剧名=%s | 集号=%s",
+                    title,
+                    series_name,
+                    eps_in_range,
+                )
+                return
+
+            if self._max_storage_gb > 0:
+                current_total = self._calculate_total_size(history)
+                max_bytes = self._max_storage_gb * (1024**3)
+                if current_total + torrent_size > max_bytes:
+                    logger.warning(
+                        "[首播试看][跳过-空间不足] 已用 %.2f GB + 新增 %.2f GB(%s) > 上限 %d GB",
+                        current_total / (1024**3),
+                        size_gb,
+                        size_label,
+                        self._max_storage_gb,
+                    )
+                    return
+
+            logger.info(
+                "[首播试看][下载] %s | 剧名=%s | 集号=%s | 大小=%.2f GB(%s) | 来源=%s",
+                title,
+                series_name,
+                new_eps,
+                size_gb,
+                size_label,
+                source,
+            )
+            success = self._do_download(entry, title, series_name)
+
+            if success:
+                now = datetime.datetime.now().isoformat(timespec="seconds")
+                size_str = self._format_size(torrent_size, is_estimated)
+                for ep in new_eps:
+                    key = _make_key(series_name, ep)
+                    history[key] = {
+                        "series_name": series_name,
+                        "episode": ep,
+                        "title": title,
+                        "source": source,
+                        "added_at": now,
+                        "size": torrent_size,
+                        "size_str": size_str,
+                        "is_estimated": is_estimated,
+                    }
+                self._save_history(history)
+
+    def _get_torrent_size(self, entry) -> Tuple[int, bool]:
+        """
+        获取种子大小。
+        返回: (大小字节数, 是否为预估大小)
+        """
+        try:
+            if hasattr(entry, "enclosures") and entry.enclosures:
+                for enc in entry.enclosures:
+                    length = enc.get("length")
+                    if length:
+                        return int(length), False
+            if hasattr(entry, "content_length"):
+                return int(entry.content_length), False
+        except Exception:
+            pass
+        default_bytes = int(self._default_size_gb * (1024**3))
+        return default_bytes, True
+
+    @staticmethod
+    def _format_size(size_bytes: int, is_estimated: bool = False) -> str:
+        label = "(预估)" if is_estimated else ""
+        if size_bytes == 0:
+            return "未知" + label
+        elif size_bytes < 1024:
+            return f"{size_bytes} B{label}"
+        elif size_bytes < 1024**2:
+            return f"{size_bytes / 1024:.1f} KB{label}"
+        elif size_bytes < 1024**3:
+            return f"{size_bytes / (1024**2):.1f} MB{label}"
+        else:
+            return f"{size_bytes / (1024**3):.2f} GB{label}"
+
+    @staticmethod
+    def _calculate_total_size(history: dict) -> int:
+        total = 0
+        for meta in history.values():
+            total += meta.get("size", 0)
+        return total
+
+    def _do_download(self, entry, title: str, series_name: str) -> bool:
+        torrent_url = ""
+        for enc in getattr(entry, "enclosures", []):
+            enc_type = enc.get("type") or ""
+            if enc_type.startswith("application/"):
+                torrent_url = enc.get("href") or ""
+                break
+        if not torrent_url:
+            torrent_url = entry.get("link") or ""
+
+        if not torrent_url:
+            logger.error("[首播试看] 条目缺少种子 URL: %s", title)
+            return False
+
+        meta = MetaInfo(title=title)
+        if not meta.name:
+            meta.name = series_name
+
+        mediainfo = self.chain.recognize_media(meta=meta)
+        if not mediainfo:
+            logger.warning("[首播试看] 未识别到媒体信息，使用基本信息: %s", title)
+            mediainfo = MediaInfo()
+            mediainfo.type = MediaType.TV
+            mediainfo.title = series_name
+
+        torrent = TorrentInfo(
+            title=title,
+            enclosure=torrent_url,
+            page_url=entry.get("link", ""),
+        )
+
+        context = Context(
+            meta_info=meta,
+            media_info=mediainfo,
+            torrent_info=torrent,
+        )
+
+        try:
+            did = self._downloadchain.download_single(
+                context=context,
+                torrent_file=None,
+                save_path=self._save_path or None,
+            )
+            if did:
+                logger.info("[首播试看] ✅ DownloadChain 推送成功: %s", title)
+                return True
+            else:
+                logger.error("[首播试看] ❌ DownloadChain 推送失败 [%s]", title)
+                return False
+        except Exception as exc:
+            logger.error("[首播试看] ❌ 下载异常 [%s]: %s", title, exc)
+            return False
+
+    def _keyword_filter(self, title: str) -> Tuple[bool, str]:
+        title_lower = title.lower()
+        for kw in [k.strip() for k in self._blacklist.split(",") if k.strip()]:
+            if kw.lower() in title_lower:
+                return False, f"命中黑名单「{kw}」"
+        wl = [k.strip() for k in self._whitelist.split(",") if k.strip()]
+        if wl and not any(k.lower() in title_lower for k in wl):
+            return False, f"未命中白名单 {wl}"
+        return True, ""
+
+    @staticmethod
+    def _is_tv(entry) -> bool:
+        cat = ""
+        try:
+            if hasattr(entry, "tags") and entry.tags:
+                term = entry.tags[0].get("term") or ""
+                cat = term.lower()
+            elif hasattr(entry, "category"):
+                cat = (entry.category or "").lower()
+        except Exception:
+            pass
+
+        tv_cats = ("tv", "series", "drama", "television", "综艺", "剧集", "连续剧")
+        movie_kw = ("movie", "film", "电影", "纪录片")
+        if any(k in cat for k in tv_cats):
+            return True
+        if any(k in cat for k in movie_kw):
+            return False
+        return bool(TV_HINTS.search(entry.get("title") or ""))
+
+    def _load_history(self) -> dict:
+        if self._history_path and self._history_path.exists():
+            try:
+                return json.loads(self._history_path.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+        return {}
+
+    def _save_history(self, history: dict) -> None:
+        if self._history_path:
+            self._history_path.write_text(
+                json.dumps(history, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+
+    @staticmethod
+    def _is_downloaded(history: dict, series_name: str, episode: int) -> bool:
+        return _make_key(series_name, episode) in history
+
+    def _clear_history(self, token: str = "") -> dict:
+        if token != settings.API_TOKEN:
+            return {"success": False, "message": "认证失败"}
+        self._save_history({})
+        logger.info("[首播试看] 下载历史已清空。")
+        return {"success": True, "message": "历史已清空"}
+
+    def _storage_status(self, token: str = "") -> dict:
+        if token != settings.API_TOKEN:
+            return {"success": False, "message": "认证失败"}
+        history = self._load_history()
+        total_bytes = self._calculate_total_size(history)
+        total_gb = total_bytes / (1024**3)
+        count = len(history)
+        return {
+            "success": True,
+            "total_bytes": total_bytes,
+            "total_gb": round(total_gb, 2),
+            "max_gb": self._max_storage_gb,
+            "count": count,
+        }
+
+    def __update_config(self) -> None:
+        self.update_config(
+            {
+                "enabled": self._enabled,
+                "onlyonce": self._onlyonce,
+                "cron": self._cron,
+                "rss_urls": self._rss_urls,
+                "max_episode": self._max_episode,
+                "whitelist": self._whitelist,
+                "blacklist": self._blacklist,
+                "save_path": self._save_path,
+                "max_storage_gb": self._max_storage_gb,
+                "default_size_gb": self._default_size_gb,
+                "max_single_size_gb": self._max_single_size_gb,
+            }
+        )
+
+
+def _extract_episodes(title: str) -> List[int]:
+    found: set[int] = set()
+    for pat in EPISODE_PATTERNS:
+        for m in pat.finditer(title):
+            try:
+                ep = int(m.group(1))
+                if 0 < ep < 1000:
+                    found.add(ep)
+            except (IndexError, ValueError):
+                pass
+    return sorted(found)
+
+
+def _guess_series_name(title: str) -> str:
+    name = re.split(
+        r"[\s._\-]*(?:[Ss]\d{1,2}[Ee]\d{1,3}|[Ee][Pp]?\d{1,3}|第\d+集|\d+of\d+|[\[(【]\d+[】\])])",
+        title,
+        maxsplit=1,
+    )[0]
+    name = re.sub(r"^\s*\[.*?\]\s*", "", name)
+    name = re.sub(r"\b(19|20)\d{2}\b", "", name)
+    name = re.sub(r"[\s._\-]+", " ", name).strip(" .-_")
+    return name or title
+
+
+def _make_key(series_name: str, episode: int) -> str:
+    norm = re.sub(r"\W+", "", series_name.lower())
+    return f"{norm}__ep{episode:03d}"
+
+
+def _to_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v in ("1", "true", "yes", "y", "on"):
+            return True
+        if v in ("0", "false", "no", "n", "off", ""):
+            return False
+    return default
+
+
+def _to_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _col(md: int, *children) -> dict:
+    return {
+        "component": "VCol",
+        "props": {"cols": 12, "md": md},
+        "content": list(children),
+    }
+
+
+def _switch(model: str, label: str) -> dict:
+    return {
+        "component": "VSwitch",
+        "props": {"model": model, "label": label},
+    }
+
+
+def _textfield(model: str, label: str, placeholder: str = "") -> dict:
+    props: dict = {"model": model, "label": label}
+    if placeholder:
+        props["placeholder"] = placeholder
+    return {"component": "VTextField", "props": props}

--- a/plugins.v3/tvfirstwatch/__init__.py
+++ b/plugins.v3/tvfirstwatch/__init__.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 import pytz
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
+from pydantic import BaseModel
 
 import feedparser
 import requests
@@ -22,6 +23,23 @@ from app.sdk.events import eventmanager
 from app.schemas.types import MediaType, EventType
 
 lock = Lock()
+
+
+class ClearHistoryResponse(BaseModel):
+    """清空下载历史接口的稳定响应结构。"""
+
+    success: bool
+    message: str
+
+
+class StorageStatusResponse(BaseModel):
+    """下载历史占用空间接口的稳定响应结构。"""
+
+    success: bool
+    total_bytes: int
+    total_gb: float
+    max_gb: int
+    count: int
 
 EPISODE_PATTERNS = [
     re.compile(r"[Ss]\d{1,2}[Ee](\d{1,3})", re.IGNORECASE),
@@ -125,13 +143,17 @@ class TvFirstWatch(_PluginBase):
                 "path": "/clear_history",
                 "endpoint": self._clear_history,
                 "methods": ["GET"],
+                "auth": "bear",
                 "summary": "清空首播试看下载历史",
+                "response_model": ClearHistoryResponse,
             },
             {
                 "path": "/storage_status",
                 "endpoint": self._storage_status,
                 "methods": ["GET"],
+                "auth": "bear",
                 "summary": "获取存储空间使用情况",
+                "response_model": StorageStatusResponse,
             },
         ]
 
@@ -348,7 +370,6 @@ class TvFirstWatch(_PluginBase):
                             "click": {
                                 "api": "plugin/TvFirstWatch/clear_history",
                                 "method": "get",
-                                "params": {"token": settings.API_TOKEN},
                             }
                         },
                     },
@@ -430,7 +451,12 @@ class TvFirstWatch(_PluginBase):
             try:
                 self._process_feed(line)
             except Exception as exc:
-                logger.error("[首播试看] 处理 RSS 源出错: %s — %s", line, exc)
+                source = urlparse(line.split("|", 1)[0].strip()).hostname or "unknown"
+                logger.error(
+                    "[首播试看] 处理 RSS 源出错 [%s]: %s",
+                    source,
+                    type(exc).__name__,
+                )
 
     def _parse_feed_line(self, line: str) -> Tuple[str, dict]:
         parts = line.split("|", 1)
@@ -452,14 +478,18 @@ class TvFirstWatch(_PluginBase):
 
     def _process_feed(self, line: str) -> None:
         url, headers = self._parse_feed_line(line)
-        source = urlparse(url).netloc
-        logger.info("[首播试看] 抓取 RSS: %s", url)
+        source = urlparse(url).hostname or "unknown"
+        logger.info("[首播试看] 抓取 RSS: %s", source)
 
         try:
             resp = requests.get(url, headers=headers, timeout=30)
             resp.raise_for_status()
         except requests.RequestException as exc:
-            logger.error("[首播试看] RSS 请求失败 [%s]: %s", source, exc)
+            logger.error(
+                "[首播试看] RSS 请求失败 [%s]: %s",
+                source,
+                type(exc).__name__,
+            )
             return
 
         parsed = feedparser.parse(resp.text)
@@ -721,16 +751,12 @@ class TvFirstWatch(_PluginBase):
     def _is_downloaded(history: dict, series_name: str, episode: int) -> bool:
         return _make_key(series_name, episode) in history
 
-    def _clear_history(self, token: str = "") -> dict:
-        if token != settings.API_TOKEN:
-            return {"success": False, "message": "认证失败"}
+    def _clear_history(self) -> dict:
         self._save_history({})
         logger.info("[首播试看] 下载历史已清空。")
         return {"success": True, "message": "历史已清空"}
 
-    def _storage_status(self, token: str = "") -> dict:
-        if token != settings.API_TOKEN:
-            return {"success": False, "message": "认证失败"}
+    def _storage_status(self) -> dict:
         history = self._load_history()
         total_bytes = self._calculate_total_size(history)
         total_gb = total_bytes / (1024**3)

--- a/plugins.v3/tvfirstwatch/pyproject.toml
+++ b/plugins.v3/tvfirstwatch/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "moviepilot-plugin-tvfirstwatch"
+dynamic = ["version"]
+requires-python = ">=3.12"
+dependencies = [
+    "feedparser>=6.0.0",
+]

--- a/tests/v3/moviepilotupdatenotify/test_plugin.py
+++ b/tests/v3/moviepilotupdatenotify/test_plugin.py
@@ -71,3 +71,19 @@ def test_stop_service_is_idempotent() -> None:
 
     assert calls == ["remove", "shutdown"]
     assert plugin._scheduler is None
+
+
+def test_notification_converts_github_utc_timestamp_to_configured_timezone(monkeypatch) -> None:
+    """GitHub 的 UTC 发布时间应按宿主时区显示，避免通知时间偏移。"""
+    module = importlib.import_module("app.plugins.moviepilotupdatenotify")
+    plugin = object.__new__(module.MoviePilotUpdateNotify)
+    plugin._notify = True
+    messages = []
+    plugin.post_message = lambda **kwargs: messages.append(kwargs)
+    monkeypatch.setattr(module.settings, "TZ", "Asia/Shanghai")
+
+    plugin._MoviePilotUpdateNotify__notify_update(
+        "2026-08-31T10:00:00Z", "v3.10.0", "修复更新检查", "后端"
+    )
+
+    assert messages[0]["text"].endswith("2026-08-31 18:00:00")

--- a/tests/v3/moviepilotupdatenotify/test_plugin.py
+++ b/tests/v3/moviepilotupdatenotify/test_plugin.py
@@ -1,0 +1,73 @@
+"""MoviePilotUpdateNotify V3 导入、版本线和生命周期合同测试。"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SOURCE = ROOT / "plugins.v3/moviepilotupdatenotify/__init__.py"
+
+
+def test_manifest_and_plugin_are_v3_aligned() -> None:
+    """V3 索引、实现版本和稳定宿主入口必须保持一致。"""
+    manifest = json.loads((ROOT / "package.v3.json").read_text(encoding="utf-8"))["MoviePilotUpdateNotify"]
+    source = SOURCE.read_text(encoding="utf-8")
+    modules = {
+        node.module or ""
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom)
+    }
+
+    assert manifest["version"] == "3.0.0"
+    assert manifest["system_version"] == ">=3.0.0"
+    assert "plugin_version = \"3.0.0\"" in source
+    assert {"app.sdk.config", "app.sdk.logging", "app.sdk.network", "app.sdk.services"} <= modules
+    assert not any(module.startswith(("app.core.", "app.helper.", "app.utils.", "app.log")) for module in modules)
+
+
+def test_latest_version_uses_v3_release_line(monkeypatch) -> None:
+    """更新检查不能把 V2 发布误报为当前 V3 更新。"""
+    module = importlib.import_module("app.plugins.moviepilotupdatenotify")
+
+    class Response:
+        def json(self):
+            return [
+                {"tag_name": "v2.99.0"},
+                {"tag_name": "v3.9.0"},
+                {"tag_name": "v3.10.0"},
+            ]
+
+    class Request:
+        def __init__(self, **_kwargs):
+            pass
+
+        def get_res(self, _url):
+            return Response()
+
+    monkeypatch.setattr(module, "RequestUtils", Request)
+    latest = module.MoviePilotUpdateNotify._MoviePilotUpdateNotify__get_latest_version("https://example.test/releases")
+
+    assert latest["tag_name"] == "v3.10.0"
+
+
+def test_stop_service_is_idempotent() -> None:
+    """热重载和卸载重复触发时必须释放调度器且不抛错。"""
+    module = importlib.import_module("app.plugins.moviepilotupdatenotify")
+    plugin = object.__new__(module.MoviePilotUpdateNotify)
+    calls: list[str] = []
+    plugin._scheduler = SimpleNamespace(
+        running=True,
+        remove_all_jobs=lambda: calls.append("remove"),
+        shutdown=lambda: calls.append("shutdown"),
+    )
+
+    plugin.stop_service()
+    plugin.stop_service()
+
+    assert calls == ["remove", "shutdown"]
+    assert plugin._scheduler is None

--- a/tests/v3/tvfirstwatch/test_plugin.py
+++ b/tests/v3/tvfirstwatch/test_plugin.py
@@ -1,0 +1,133 @@
+"""TvFirstWatch V3 导入、RSS 解析和生命周期合同测试。"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SOURCE = ROOT / "plugins.v3/tvfirstwatch/__init__.py"
+
+
+def _load_plugin(monkeypatch):
+    """在未安装插件可选依赖的后端测试环境中，仅为导入探针提供最小模块垫片。"""
+    try:
+        import feedparser  # noqa: F401
+    except ModuleNotFoundError:
+        fake_feedparser = types.ModuleType("feedparser")
+        fake_feedparser.parse = lambda _text: SimpleNamespace(entries=[])
+        monkeypatch.setitem(sys.modules, "feedparser", fake_feedparser)
+    return importlib.import_module("app.plugins.tvfirstwatch")
+
+
+def test_manifest_and_plugin_are_v3_aligned() -> None:
+    """V3 副本使用现代依赖清单并从公开 SDK 读取媒体上下文。"""
+    manifest = json.loads((ROOT / "package.v3.json").read_text(encoding="utf-8"))["TvFirstWatch"]
+    source = SOURCE.read_text(encoding="utf-8")
+    modules = {
+        node.module or ""
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom)
+    }
+
+    assert manifest["version"] == "2.0.0"
+    assert manifest["system_version"] == ">=3.0.0"
+    assert "plugin_version = \"2.0.0\"" in source
+    assert "app.sdk.media" in modules
+    assert "app.sdk.config" in modules
+    assert "app.sdk.logging" in modules
+    assert "app.sdk.events" in modules
+    assert not any(module.startswith(("app.core.", "app.helper.", "app.utils.", "app.log")) for module in modules)
+    assert (ROOT / "plugins.v3/tvfirstwatch/pyproject.toml").is_file()
+    assert not (ROOT / "plugins.v3/tvfirstwatch/requirements.txt").exists()
+
+
+def test_feed_line_and_episode_helpers_preserve_business_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RSS 行、集号和去重键应保持可重复且无网络副作用。"""
+    module = _load_plugin(monkeypatch)
+    plugin = object.__new__(module.TvFirstWatch)
+
+    url, headers = plugin._parse_feed_line("https://rss.example/feed | cookie: sid=abc")
+
+    assert url == "https://rss.example/feed"
+    assert headers["Cookie"] == "sid=abc"
+    assert module._extract_episodes("Example S01E02 1080p") == [2]
+    assert module._guess_series_name("Example S01E02 1080p") == "Example"
+    assert module._make_key("Example", 2) == "example__ep002"
+
+
+def test_stop_service_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """调度器停止必须清理任务并允许重复调用。"""
+    module = _load_plugin(monkeypatch)
+    plugin = object.__new__(module.TvFirstWatch)
+    calls: list[str] = []
+    plugin._scheduler = SimpleNamespace(
+        running=True,
+        remove_all_jobs=lambda: calls.append("remove"),
+        shutdown=lambda: calls.append("shutdown"),
+    )
+
+    plugin.stop_service()
+    plugin.stop_service()
+
+    assert calls == ["remove", "shutdown"]
+    assert plugin._scheduler is None
+
+
+def test_download_builds_public_context_and_forwards_save_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """下载路径应通过公开 Context/媒体/种子对象传给 DownloadChain。"""
+    module = _load_plugin(monkeypatch)
+
+    class FakeMeta:
+        def __init__(self, **kwargs):
+            self.name = ""
+            self.title = kwargs["title"]
+
+    class FakeMedia:
+        def __init__(self):
+            self.type = None
+            self.title = None
+
+    class FakeTorrent:
+        def __init__(self, **kwargs):
+            self.values = kwargs
+
+    class FakeContext:
+        def __init__(self, **kwargs):
+            self.values = kwargs
+
+    monkeypatch.setattr(module, "MetaInfo", FakeMeta)
+    monkeypatch.setattr(module, "MediaInfo", FakeMedia)
+    monkeypatch.setattr(module, "TorrentInfo", FakeTorrent)
+    monkeypatch.setattr(module, "Context", FakeContext)
+
+    class Chain:
+        def recognize_media(self, **_kwargs):
+            return None
+
+    class Download:
+        def __init__(self):
+            self.kwargs = None
+
+        def download_single(self, **kwargs):
+            self.kwargs = kwargs
+            return "download-id"
+
+    downloader = Download()
+    plugin = object.__new__(module.TvFirstWatch)
+    plugin.chain = Chain()
+    plugin._downloadchain = downloader
+    plugin._save_path = "/downloads"
+    entry = {"link": "https://rss.example/item.torrent"}
+
+    assert plugin._do_download(entry, "Example S01E01", "Example") is True
+    assert downloader.kwargs["save_path"] == "/downloads"
+    assert downloader.kwargs["context"].values["torrent_info"].values["enclosure"] == entry["link"]

--- a/tests/v3/tvfirstwatch/test_plugin.py
+++ b/tests/v3/tvfirstwatch/test_plugin.py
@@ -50,6 +50,81 @@ def test_manifest_and_plugin_are_v3_aligned() -> None:
     assert not (ROOT / "plugins.v3/tvfirstwatch/requirements.txt").exists()
 
 
+def test_api_uses_host_bearer_authentication(monkeypatch: pytest.MonkeyPatch) -> None:
+    """页面 API 使用宿主登录态认证，避免把 API token 拼进页面请求。"""
+    module = _load_plugin(monkeypatch)
+    plugin = object.__new__(module.TvFirstWatch)
+    plugin._history_path = None
+
+    apis = plugin.get_api()
+
+    assert [api["auth"] for api in apis] == ["bear", "bear"]
+    assert all("token" not in api for api in apis)
+
+
+def test_api_declares_exact_response_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    """动态路由应声明与实际 JSON 字段一致的输出模型。"""
+    module = _load_plugin(monkeypatch)
+    plugin = object.__new__(module.TvFirstWatch)
+    plugin._history_path = None
+
+    apis = {api["path"]: api for api in plugin.get_api()}
+
+    assert apis["/clear_history"]["response_model"] is module.ClearHistoryResponse
+    assert apis["/storage_status"]["response_model"] is module.StorageStatusResponse
+
+    assert module.ClearHistoryResponse.model_validate(
+        plugin._clear_history()
+    ).model_dump() == {"success": True, "message": "历史已清空"}
+
+
+def test_storage_status_response_model_matches_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """存储状态接口返回值应可被声明模型完整校验。"""
+    module = _load_plugin(monkeypatch)
+    plugin = object.__new__(module.TvFirstWatch)
+    plugin._history_path = None
+    plugin._max_storage_gb = 12
+
+    response = plugin._storage_status()
+
+    assert module.StorageStatusResponse.model_validate(response).model_dump() == {
+        "success": True,
+        "total_bytes": 0,
+        "total_gb": 0.0,
+        "max_gb": 12,
+        "count": 0,
+    }
+
+
+def test_rss_logs_never_include_passkey_or_cookie(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RSS 凭据只能用于请求，日志只允许出现来源 host 和异常类型。"""
+    module = _load_plugin(monkeypatch)
+    records: list[str] = []
+
+    class Logger:
+        def info(self, message, *args):
+            records.append(str(message) % args if args else str(message))
+
+        def error(self, message, *args):
+            records.append(str(message) % args if args else str(message))
+
+        def warning(self, message, *args):
+            records.append(str(message) % args if args else str(message))
+
+    monkeypatch.setattr(module, "logger", Logger())
+    plugin = object.__new__(module.TvFirstWatch)
+    plugin._rss_urls = "https://alice:secret@rss.example/feed?passkey=secret|Cookie: sid=private"
+    plugin._process_feed = lambda _line: (_ for _ in ()).throw(RuntimeError("sid=private"))
+
+    plugin._check_all_feeds()
+
+    output = "\n".join(records)
+    assert "rss.example" in output
+    assert "alice" not in output
+    assert "secret" not in output
+    assert "private" not in output
+
+
 def test_feed_line_and_episode_helpers_preserve_business_rules(monkeypatch: pytest.MonkeyPatch) -> None:
     """RSS 行、集号和去重键应保持可重复且无网络副作用。"""
     module = _load_plugin(monkeypatch)


### PR DESCRIPTION
## 变更
- 将 `MoviePilotUpdateNotify` 从 V2 迁移为 V3 `3.0.0`，使用当前 SDK 配置、日志、网络和服务入口。
- 将 `TvFirstWatch` 从 V2 迁移为 V3 `2.0.0`，迁移 `feedparser` 依赖并保留下载链路。
- 动态 API 使用宿主 bearer 认证，声明精确 Pydantic 响应模型，页面不再拼接 API token。
- RSS 日志仅记录 hostname 和异常类型，避免 query passkey、Cookie 与 URL userinfo 泄露。
- GitHub UTC 发布时间按宿主时区转换。

## 验证
- focused pytest：12 passed
- `tests/run.py`：CI 55 passed、V3 544 passed、V2 fallback 35 passed
- `py_compile`、JSON 校验、`git diff --check` 通过
- 独立 Review：pass

`ChatGPT` 依赖尚未公开的宿主 LLM 合同，本 PR 不包含该插件。