### PR TITLE
Update IqiyiDiscover V3 to v2.1.2

### DIFF
--- a/package.v3.json
+++ b/package.v3.json
@@ -715,12 +715,13 @@
     "name": "爱奇艺探索",
     "description": "让探索支持爱奇艺的数据浏览。",
     "labels": "探索",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "icon": "https://raw.githubusercontent.com/jxxghp/MoviePilot-Plugins/main/icons/iqiyi_A.png",
     "author": "LLL001a",
     "level": 1,
     "system_version": ">=3.0.0",
     "history": {
+      "v2.1.2": "优化首次加载速度，Cookie持久化与后台预获取，修复重复刷新和配置覆盖问题",
       "v2.1.1": "修复Cookie获取失败和默认分类404问题，优化首次加载速度",
       "v2.1.0": "新增媒体识别能力，支持点击海报识别媒体",
       "v2.0.0": "V3 独立大版本：适配 V3 SDK 导入规范，使用 MediaSource 枚举和统一响应格式"

--- a/plugins.v3/iqiyidiscover/__init__.py
+++ b/plugins.v3/iqiyidiscover/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import threading
 import time
 from typing import Any, List, Dict, Tuple, Optional
 
@@ -167,7 +168,7 @@ class IqiyiDiscover(_PluginBase):
     # 插件图标
     plugin_icon = "https://raw.githubusercontent.com/jxxghp/MoviePilot-Plugins/main/icons/iqiyi_A.png"
     # 插件版本
-    plugin_version = "2.1.1"
+    plugin_version = "2.1.2"
     # 插件作者
     plugin_author = "LLL001a"
     # 作者主页
@@ -205,13 +206,8 @@ class IqiyiDiscover(_PluginBase):
                 self._cookie = self.get_data("iqiyi_cookie") or ""
             # 无有效 Cookie 时后台预获取，不阻塞插件加载
             if not self._cookie:
-                try:
-                    import asyncio
-                    self._cookie_task = asyncio.create_task(self._async_auto_refresh_cookie())
-                except RuntimeError:
-                    # 无事件循环时（如同步初始化），退化为线程预获取
-                    import threading
-                    threading.Thread(target=self._auto_refresh_cookie, daemon=True).start()
+                self._cookie_task = threading.Thread(target=self._auto_refresh_cookie, daemon=True)
+                self._cookie_task.start()
 
     def get_state(self) -> bool:
         """
@@ -460,8 +456,11 @@ class IqiyiDiscover(_PluginBase):
                 return False
             self._cookie = cookie_str
             self._cookie_refresh_time = time.time()
-            # 持久化 Cookie，避免重启后重新获取
-            self.save_data("iqiyi_cookie", cookie_str)
+            # 持久化 Cookie 到插件数据存储，避免覆盖插件配置（enabled 等）
+            try:
+                self.save_data("iqiyi_cookie", cookie_str)
+            except Exception as err:
+                logger.warning(f"保存爱奇艺 Cookie 到数据存储失败: {str(err)}")
             logger.info(f"成功获取爱奇艺 Cookie（{len(cookies)} 项）")
             return True
         except Exception as err:
@@ -623,12 +622,13 @@ class IqiyiDiscover(_PluginBase):
         params["page_id"] = str(page)
         params["filter"] = filter_params or '{"mode":"11"}'
         headers = dict(HEADERS)
-        # 若 Cookie 为空且后台预获取任务存在，等待预获取完成，避免首次请求失败
-        if not self._cookie and self._cookie_task:
-            try:
-                await self._cookie_task
-            except Exception:
-                pass
+        # 若 Cookie 为空，等待后台预获取完成（共享同一个刷新任务，避免重复抓取）
+        if not self._cookie:
+            if self._cookie_task and self._cookie_task.is_alive():
+                await asyncio.to_thread(self._cookie_task.join)
+            else:
+                # 无进行中的刷新任务时，同步获取（用 asyncio.to_thread 避免阻塞事件循环）
+                await asyncio.to_thread(self._auto_refresh_cookie)
             self._cookie_task = None
         # 携带 Cookie 绕过爱奇艺风控，并从 Cookie 中提取设备ID（QC005）
         if self._cookie:
@@ -643,17 +643,11 @@ class IqiyiDiscover(_PluginBase):
             if not res.ok:
                 raise ValueError(f"请求爱奇艺 API失败：{res.text}")
             data = res.json()
-            # 风控拦截时返回空数据，自动刷新 Cookie 后重试一次
+            # 风控拦截时返回空数据，后台预刷新 Cookie（不阻塞当前请求），下次请求复用
             if data.get("code") == 0 and not data.get("data"):
-                logger.warning("爱奇艺接口返回空数据，可能被风控拦截，尝试自动刷新 Cookie")
-                if await self._async_auto_refresh_cookie():
-                    headers["Cookie"] = self._cookie
-                    device_id = self.__extract_device_id(self._cookie)
-                    if device_id:
-                        params["device_id"] = device_id
-                    res = RequestUtils(headers=headers).get_res(VIDEOLIB_DATA_URL, params=params)
-                    if res is not None and res.ok:
-                        data = res.json()
+                logger.warning("爱奇艺接口返回空数据，可能被风控拦截，后台预刷新 Cookie")
+                # 后台预刷新 Cookie，避免阻塞当前请求
+                threading.Thread(target=self._auto_refresh_cookie, daemon=True).start()
             return data.get("data") or []
         except Exception as err:
             logger.error(f"获取爱奇艺数据失败: {str(err)}")

--- a/tests/v3/iqiyidiscover/test_response.py
+++ b/tests/v3/iqiyidiscover/test_response.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import List
 
 from app import schemas
@@ -19,7 +20,7 @@ def test_discover_rejects_invalid_token_with_empty_response() -> None:
     plugin = object.__new__(IqiyiDiscover)
 
     endpoint = plugin.get_api()[0]["endpoint"]
-    response = endpoint(apikey=f"{settings.API_TOKEN}-invalid")
+    response = asyncio.run(endpoint(apikey=f"{settings.API_TOKEN}-invalid"))
 
     assert response.success is True
     assert response.data == []


### PR DESCRIPTION
## 爱奇艺探索插件 V3 版本更新

### 版本：2.1.1 → 2.1.2

优化首次加载速度，Cookie 持久化与后台预获取，修复重复刷新和配置覆盖问题。

### 变更内容
- Cookie 持久化（save_data，不覆盖插件配置）
- 后台预获取（threading.Thread，共享同一个刷新任务）
- 修复重复刷新（__request 与 init_plugin 共享 _cookie_task）
- 修复配置覆盖（改用 save_data 持久化 Cookie）
- 修复测试文件（asyncio.run 调用异步端点）

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at b092fb41e5d28b2c1283a05e445a8988ba15de1c

- 优化 Cookie 后台预获取与复用
- 首次请求等待线程刷新结果
- 风控空响应改为异步预刷新
- 修正异步接口测试调用方式
- 发布 `IqiyiDiscover` v2.1.2
<!-- pr-agent-summary:end -->
